### PR TITLE
Equipment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /shelf/
 /.idea/workspace.xml
 /.idea/
+/.vscode/
 # Datasource local storage ignored files
 /../../../../../:\Development\gmod\TTT-Custom-Roles-2.0\.idea/dataSources/
 /dataSources.local.xml

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -382,6 +382,13 @@ local function TraitorMenuPopup()
                 slot:SetIconSize(16)
 
                 slot:SetIconText(item.slot)
+                ic.slot = item.slot
+
+                -- Credit to @Angela and @Technofrood on the Lonely Yogs Discord for the fix!
+                -- Clamp the item slot within the correct limits
+                if ic.slot ~= nil then
+                    ic.slot = math.Clamp(ic.slot, 1, #paneltable)
+                end
 
                 slot:SetIconProperties(COLOR_WHITE,
                         "DefaultBold",

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -196,7 +196,7 @@ local function PreqLabels(parent, x, y)
     return function(selected)
         local allow = true
         for k, pnl in pairs(tbl) do
-            local result, text = pnl:Check(selected)
+            local result, text, tooltip = pnl:Check(selected)
             pnl:SetTextColor(result and color_good or color_bad)
             pnl:SetText(text)
             pnl:SizeToContents()

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -11,43 +11,6 @@ local showCustomVar = CreateClientConVar("ttt_bem_marker_custom", 1, true, false
 local showFavoriteVar = CreateClientConVar("ttt_bem_marker_fav", 1, true, false, "Should favorite items get a marker?")
 local showSlotVar = CreateClientConVar("ttt_bem_marker_slot", 1, true, false, "Should items get a slot-marker?")
 
--- add favorites DB functions
-function CreateFavTable()
-    if not (sql.TableExists("ttt_bem_fav")) then
-        query = "CREATE TABLE ttt_bem_fav (guid TEXT, role TEXT, weapon_id TEXT)"
-        result = sql.Query(query)
-    else
-        print("ALREADY EXISTS")
-    end
-end
-
-function AddFavorite(guid, role, weapon_id)
-    query = "INSERT INTO ttt_bem_fav VALUES('" .. guid .. "','" .. role .. "','" .. weapon_id .. "')"
-    result = sql.Query(query)
-end
-
-function RemoveFavorite(guid, role, weapon_id)
-    query = "DELETE FROM ttt_bem_fav WHERE guid = '" .. guid .. "' AND role = '" .. role .. "' AND weapon_id = '" .. weapon_id .. "'"
-    result = sql.Query(query)
-end
-
-function GetFavorites(guid, role)
-    query = "SELECT weapon_id FROM ttt_bem_fav WHERE guid = '" .. guid .. "' AND role = '" .. role .. "'"
-    result = sql.Query(query)
-    return result
-end
-
--- looks for weapon id in favorites table (result of GetFavorites)
-function IsFavorite(favorites, weapon_id)
-    for _, value in pairs(favorites) do
-        local dbid = value["weapon_id"]
-        if (dbid == tostring(weapon_id)) then
-            return true
-        end
-    end
-    return false
-end
-
 -- Buyable weapons are loaded automatically. Buyable items are defined in
 -- equip_items_shd.lua
 

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -618,7 +618,7 @@ local function ReceiveEquipment()
     local ply = LocalPlayer()
     if not IsValid(ply) then return end
 
-    ply.equipment_items = net.ReadUInt(16)
+    ply.equipment_items = net.ReadUInt(32)
 end
 net.Receive("TTT_Equipment", ReceiveEquipment)
 
@@ -660,7 +660,7 @@ net.Receive("TTT_Bought", ReceiveBought)
 -- Player received the item he has just bought, so run clientside init
 local function ReceiveBoughtItem()
     local is_item = net.ReadBit() == 1
-    local id = is_item and net.ReadUInt(16) or net.ReadString()
+    local id = is_item and net.ReadUInt(32) or net.ReadString()
 
     -- I can imagine custom equipment wanting this, so making a hook
     hook.Run("TTTBoughtItem", is_item, id)

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -199,32 +199,30 @@ local color_slot = {
     [ROLE_IMPERSONATOR] = COLOR_SPECIAL_TRAITOR
 }
 
-local fieldstbl = { "name", "type", "desc" }
-
 -- BEM helper functions
 
 function CreateFavTable()
     if not sql.TableExists("ttt_bem_fav") then
-    query = "CREATE TABLE ttt_bem_fav (guid TEXT, role TEXT, weapon_id TEXT)"
-    result = sql.Query(query)
-        else
+        local query = "CREATE TABLE ttt_bem_fav (guid TEXT, role TEXT, weapon_id TEXT)"
+        sql.Query(query)
+    else
         print("ALREADY EXISTS")
     end
 end
 
 function AddFavorite(guid, role, weapon_id)
-    query = "INSERT INTO ttt_bem_fav VALUES('" .. guid .. "','" .. role .. "','" .. weapon_id .. "')"
-    result = sql.Query(query)
+    local query = "INSERT INTO ttt_bem_fav VALUES('" .. guid .. "','" .. role .. "','" .. weapon_id .. "')"
+    sql.Query(query)
 end
 
 function RemoveFavorite(guid, role, weapon_id)
-    query = "DELETE FROM ttt_bem_fav WHERE guid = '" .. guid .. "' AND role = '" .. role .. "' AND weapon_id = '" .. weapon_id .. "'"
-    result = sql.Query(query)
+    local query = "DELETE FROM ttt_bem_fav WHERE guid = '" .. guid .. "' AND role = '" .. role .. "' AND weapon_id = '" .. weapon_id .. "'"
+    sql.Query(query)
 end
 
 function GetFavorites(guid, role)
-    query = "SELECT weapon_id FROM ttt_bem_fav WHERE guid = '" .. guid .. "' AND role = '" .. role .. "'"
-    result = sql.Query(query)
+    local query = "SELECT weapon_id FROM ttt_bem_fav WHERE guid = '" .. guid .. "' AND role = '" .. role .. "'"
+    local result = sql.Query(query)
     return result
 end
 
@@ -242,10 +240,9 @@ end
 
 local eqframe = nil
 local function TraitorMenuPopup()
-
-    numCols = numColsVar:GetInt()
-    numRows = numRowsVar:GetInt()
-    itemSize = itemSizeVar:GetInt()
+    local numCols = numColsVar:GetInt()
+    local numRows = numRowsVar:GetInt()
+    local itemSize = itemSizeVar:GetInt()
 
     -- margin
     local m = 5
@@ -472,8 +469,6 @@ local function TraitorMenuPopup()
     dfields.desc:SetContentAlignment(7)
     dfields.desc:MoveBelow(dfields.type, 1)
 
-    local iw, ih = dinfo:GetSize()
-
     local dhelp = vgui.Create("DPanel", dinfobg)
     dhelp:SetPaintBackground(false)
     dhelp:SetSize(diw, 64)
@@ -515,7 +510,6 @@ local function TraitorMenuPopup()
     end
 
     hook.Run("TTTEquipmentTabs", dsheet)
-
 
     -- couple panelselect with info
     dlist.OnActivePanelChanged = function(self, _, new)

--- a/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/cl_search.lua
@@ -483,7 +483,7 @@ local function ReceiveRagdollSearch()
     search.nick = net.ReadString()
 
     -- Equipment
-    local eq = net.ReadUInt(16)
+    local eq = net.ReadUInt(32)
 
     -- All equipment pieces get their own icon
     search.eq_armor = util.BitSet(eq, EQUIP_ARMOR)

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -303,7 +303,7 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
     net.WriteUInt(rag:EntIndex(), 16) -- 16 bits
     net.WriteUInt(owner, 8) -- 128 max players. ( 8 bits )
     net.WriteString(nick)
-    net.WriteUInt(eq, 16) -- Equipment ( 16 = max. )
+    net.WriteUInt(eq, 32) -- Equipment ( 32 = max. )
     net.WriteUInt(role, 8) -- ( 8 bits )
     net.WriteInt(c4, bitsRequired(C4_WIRE_COUNT) + 1) -- -1 -> 2^bits ( default c4: 4 bits )
     net.WriteUInt(dmg, 30) -- DMG_BUCKSHOT is the highest. ( 30 bits )

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -89,7 +89,7 @@ end
 -- We do this instead of an NW var in order to limit the info to just this ply
 function plymeta:SendEquipment()
     net.Start("TTT_Equipment")
-    net.WriteUInt(self.equipment_items, 16)
+    net.WriteUInt(self.equipment_items, 32)
     net.Send(self)
 end
 

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -424,7 +424,7 @@ local function OrderEquipment(ply, cmd, args)
                     net.Start("TTT_BoughtItem")
                     net.WriteBit(is_item)
                     if is_item then
-                        net.WriteUInt(id, 16)
+                        net.WriteUInt(id, 32)
                     else
                         net.WriteString(id)
                     end


### PR DESCRIPTION
- Fixed equipment requirement tooltip not working
- Fixed error when a workshop weapon used an invalid (e.g. too large) item slot
- Updated to support a maximum of 32 equipment items
- Removed duplicate BEM functions
- Removed unused variables
- Changed some variables to local to reduce global variable pollution