### PR TITLE
Fixed some weapons showing the wrong name in the scoring events 

### DIFF
--- a/gamemodes/terrortown/gamemode/scoring.lua
+++ b/gamemodes/terrortown/gamemode/scoring.lua
@@ -30,15 +30,7 @@ local function CopyDmg(dmg)
     local g, n
 
     if wep then
-        local id = WepToEnum(wep)
-        if id then
-            g = id
-        else
-            -- we can convert each standard TTT weapon name to a preset ID, but
-            -- that's not workable with custom SWEPs from people, so we'll just
-            -- have to pay the byte tax there
-            g = wep:GetClass()
-        end
+        g = wep:GetClass()
     else
         local infl = dmg:GetInflictor()
         if IsValid(infl) and infl.ScoreName then


### PR DESCRIPTION
This is due to custom weapons reusing stock enum values
Also this might not affect this version of CR as much but when I (hopefully) merge in the end-of-round summary improvements from my version it will be used again