### PR TITLE
Added workaround to prevent GMod infinite sprint from working in some circumstances

### DIFF
--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -553,7 +553,7 @@ function GM:TTTDelayRoundStartForVote()
 end
 
 function PrepareRound()
-    for k, v in pairs(player.GetAll()) do
+    for _, v in pairs(player.GetAll()) do
         v:SetNWBool("HauntedSmoke", false)
         v:SetNWString("RevengerLover", "")
         v:SetNWString("JesterKiller", "")
@@ -562,7 +562,8 @@ function PrepareRound()
         v:SetNWString("WasHypnotised", "")
         v:SetNWBool("KillerClownActive", false)
         v:SetNWBool("HasPromotion", false)
-        v:SetNWBool("WasBeggar", false)
+        -- Workaround to prevent GMod sprint from working
+        v:SetRunSpeed(v:GetWalkSpeed())
     end
 
     net.Start("TTT_UpdateOldManWins")

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -562,6 +562,7 @@ function PrepareRound()
         v:SetNWString("WasHypnotised", "")
         v:SetNWBool("KillerClownActive", false)
         v:SetNWBool("HasPromotion", false)
+        v:SetNWBool("WasBeggar", false)
         -- Workaround to prevent GMod sprint from working
         v:SetRunSpeed(v:GetWalkSpeed())
     end

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -278,6 +278,9 @@ function plymeta:SpawnForRound(dead_only)
     hook.Call("PlayerSetModel", GAMEMODE, self)
     hook.Call("TTTPlayerSetColor", GAMEMODE, self)
 
+    -- Workaround to prevent GMod sprint from working
+    self:SetRunSpeed(self:GetWalkSpeed())
+
     -- wrong alive status and not a willing spec who unforced after prep started
     -- (and will therefore be "alive")
     if dead_only and self:Alive() and (not self:IsSpec()) then


### PR DESCRIPTION
Late last year players started reporting that they could sprint forever and faster than normal. It turns out it was GMod's sprint system that starting working in TTT sometimes. This workaround prevents that from working by essentially limiting the player's run speed to their normal walk speed.