### PR TITLE
Fixed entity ignition problems and Jester team being able to do fire damage

### DIFF
--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -6,6 +6,12 @@ if not plymeta then
     return
 end
 
+local entmeta = FindMetaTable("Entity")
+if not entmeta then
+    Error("FAILED TO FIND ENTITY TABLE")
+    return
+end
+
 function plymeta:SetRagdollSpec(s)
     if s then
         self.spec_ragdoll_start = CurTime()
@@ -363,4 +369,10 @@ end
 
 function plymeta:GetAvoidDetective()
     return self:GetInfoNum("ttt_avoid_detective", 0) > 0
+end
+
+function plymeta:Ignite(dur, radius)
+    -- Keep track of extended ignition information so when multiple things are causing burning the later ones don't lose their data. See PlayerTakeDamage in player.lua
+    self.ignite_info_ext = {dur = dur, end_time = CurTime() + dur}
+    entmeta.Ignite(self, dur, radius)
 end


### PR DESCRIPTION
Fixed entity ignition timers not extending themselves, breaking entity ignition checks in PlayerTakeDamage
Fixed Jester team doing fire damage from things that do burning damage over time like the Golden Dragon