### PR TITLE
Added two hooks to the Sprint/Speed system to help external addons

### DIFF
--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -597,8 +597,8 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
     -- listen for activation
     hook.Add("Think", "TTTSprintThink", function()
         local client = LocalPlayer()
-
-        if client:KeyDown(IN_FORWARD) and client:KeyDown(IN_SPEED) then
+        local forward_key = hook.Call("TTTSprintKey", GAMEMODE, client) or IN_FORWARD
+        if client:KeyDown(forward_key) and client:KeyDown(IN_SPEED) then
             -- forward + selected key
             SprintFunction()
             recoveryTimer = CurTime()

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -554,8 +554,9 @@ ConVars()
 local function SpeedChange(bool)
     net.Start("TTT_SprintSpeedSet")
     if bool then
-        net.WriteFloat(math.min(math.max(speedMultiplier, 0.1), 2))
-        ply.mult = 1 + math.min(math.max(speedMultiplier, 0.1), 2)
+        local mul = math.min(math.max(speedMultiplier, 0.1), 2)
+        net.WriteFloat(mul)
+        ply.mult = 1 + mul
 
         local tmp = GetConVar("ttt_crosshair_size")
         crosshairSize = tmp and tmp:GetString() or 1
@@ -637,12 +638,9 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
 end)
 
 -- Set Sprint Speed
-hook.Add("TTTPlayerSpeedModifier", "TTTSprintPlayerSpeed", function(ply, _, _)
-    if sprinting then
-        return speedMultiplier + 1
-    else
-        return 1
-    end
+hook.Add("TTTPlayerSpeedModifier", "TTTSprintPlayerSpeed", function(sply, _, _)
+    if sply ~= ply then return end
+    return GetSprintMultiplier(sply, sprinting)
 end)
 
 -- Death messages

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1538,9 +1538,5 @@ end)
 
 -- return Speed
 hook.Add("TTTPlayerSpeedModifier", "TTTSprintPlayerSpeed", function(ply, _, _)
-    if ply.mult then
-        return ply.mult
-    else
-        return 1
-    end
+    return GetSprintMultiplier(ply, ply.mult ~= nil)
 end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -211,6 +211,22 @@ function GM:Move(ply, mv)
     end
 end
 
+function GetSprintMultiplier(ply, sprinting)
+    local mult = 1
+    if IsValid(ply) then
+        local mults = {}
+        hook.Run("TTTSpeedMultiplier", ply, mults)
+        for _, m in pairs(mults) do
+            mult = mult * m
+        end
+
+        if sprinting and ply.mult then
+            mult = mult * ply.mult
+        end
+    end
+    return mult
+end
+
 
 -- Weapons and items that come with TTT. Weapons that are not in this list will
 -- get a little marker on their icon if they're buyable, showing they are custom


### PR DESCRIPTION
- Added TTTSpeedMultiplier hook to allow multiple addons to cumulatively set the speed multiplier
- Added TTTSprintKey hook to change which is the "forward" key (used for the "Opposite Day" Randomat event)