### PR TITLE
Added compatibility with a few more addons

### DIFF
--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1460,6 +1460,9 @@ local function ForceRoundRestart(ply, command, args)
 
         StopRoundTimers()
 
+        -- Let addons know that a round ended
+        hook.Call("TTTEndRound", GAMEMODE, WIN_NONE)
+
         -- do prep
         PrepareRound()
     else

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -446,6 +446,14 @@ local function WinChecker()
     end
 end
 
+local function GetPlayerName(ply)
+    local name = ply:GetNWString("PlayerName", nil)
+    if name ~= nil then
+        name = ply:Nick()
+    end
+    return name
+end
+
 local function NameChangeKick()
     if not GetConVar("ttt_namechange_kick"):GetBool() then
         timer.Remove("namecheck")
@@ -455,7 +463,7 @@ local function NameChangeKick()
     if GetRoundState() == ROUND_ACTIVE then
         for _, ply in ipairs(player.GetHumans()) do
             if ply.spawn_nick then
-                if ply.has_spawned and ply.spawn_nick ~= ply:Nick() and not hook.Call("TTTNameChangeKick", GAMEMODE, ply) then
+                if ply.has_spawned and ply.spawn_nick ~= GetPlayerName(ply) and not hook.Call("TTTNameChangeKick", GAMEMODE, ply) then
                     local t = GetConVar("ttt_namechange_bantime"):GetInt()
                     local msg = "Changed name during a round"
                     if t > 0 then
@@ -465,7 +473,7 @@ local function NameChangeKick()
                     end
                 end
             else
-                ply.spawn_nick = ply:Nick()
+                ply.spawn_nick = GetPlayerName(ply)
             end
         end
     end
@@ -475,8 +483,8 @@ function StartNameChangeChecks()
     if not GetConVar("ttt_namechange_kick"):GetBool() then return end
 
     -- bring nicks up to date, may have been changed during prep/post
-    for _, ply in ipairs(player.GetAll()) do
-        ply.spawn_nick = ply:Nick()
+    for _, ply in pairs(player.GetAll()) do
+        ply.spawn_nick = GetPlayerName(ply)
     end
 
     if not timer.Exists("namecheck") then

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -92,7 +92,6 @@ function GM:PlayerSpawn(ply)
         SendRoundState(GetRoundState(), ply)
     end
 
-    ply.spawn_nick = ply:Nick()
     ply.has_spawned = true
 
     -- let the client do things on spawn

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -316,6 +316,19 @@ function plymeta:SpawnForRound(dead_only)
     self:SetTeam(TEAM_TERROR)
     self:Spawn()
 
+    -- Make sure players who are respawning get their default weapons
+    timer.Simple(1, function()
+        if not self:HasWeapon("weapon_ttt_unarmed") then
+            self:Give("weapon_ttt_unarmed")
+        end
+        if not self:HasWeapon("weapon_zm_carry") then
+            self:Give("weapon_zm_carry")
+        end
+        if not self:HasWeapon("weapon_zm_improvised") then
+            self:Give("weapon_zm_improvised")
+        end
+    end)
+
     -- tell caller that we spawned
     return true
 end
@@ -375,6 +388,18 @@ local oldUnSpectate = plymeta.UnSpectate
 function plymeta:UnSpectate()
     oldUnSpectate(self)
     self:SetNoTarget(false)
+end
+
+local oldSetTeam = plymeta.SetTeam
+function plymeta:SetTeam(team)
+    oldSetTeam(self, team)
+
+    -- If this player is a Spectator then strip all the weapons after a delay to work around some addons that force spectator but leave the magneto stick somehow
+    if team == TEAM_SPEC then
+        timer.Simple(0.5, function()
+            self:StripAll()
+        end)
+    end
 end
 
 function plymeta:GetAvoidDetective()


### PR DESCRIPTION
- Fixed compatibility with TTT Max Players to get rid of random floating magneto sticks from players who were forced to spectator
- Fixed restarting a round not notifying other addons that the round ended
- Added chat support for name overrides via the ULX SetName addon