### PR TITLE
Added traitor team features

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -24,15 +24,18 @@ ttt_shop_random_imp_enabled 0 // Whether role shop randomization is enabled for 
 ttt_phantom_respawn_health           50  // The amount of health a Phantom will respawn with
 ttt_phantom_weaker_each_respawn      0   // Whether a Phantom respawns weaker (1/2 as much HP) each time they respawn, down to a minimum of 1
 ttt_phantom_killer_smoke             1   // Whether to show smoke on the player who killed the Phantom
-ttt_phantom_killer_footstep_time     0  // The amount of time a Phantom's killer's footsteps should show before fading. 0 to disable
+ttt_phantom_killer_footstep_time     0   // The amount of time a Phantom's killer's footsteps should show before fading. 0 to disable
 ttt_phantom_announce_death           0   // Whether to announce to Detectives (and promoted Deputies and Imposters) that a Phantom has been killed or respawned
 ttt_phantom_killer_haunt             1   // Whether to have the Phantom haunt their killer
 ttt_phantom_killer_haunt_power_max   100 // The maximum amount of power a Phantom can have when haunting their killer
-ttt_phantom_killer_haunt_power_rate  10   // The amount of power to regain per second when a Phantom is haunting their killer
+ttt_phantom_killer_haunt_power_rate  10  // The amount of power to regain per second when a Phantom is haunting their killer
 ttt_phantom_killer_haunt_move_cost   25  // The amount of power to spend when a Phantom is moving their killer via a haunting. 0 to disable
 ttt_phantom_killer_haunt_jump_cost   50  // The amount of power to spend when a Phantom is making their killer jump via a haunting. 0 to disable
 ttt_phantom_killer_haunt_drop_cost   75  // The amount of power to spend when a Phantom is making their killer drop their weapon via a haunting. 0 to disable
-ttt_phantom_killer_haunt_attack_cost 100  // The amount of power to spend when a Phantom is making their killer attack via a haunting. 0 to disable
+ttt_phantom_killer_haunt_attack_cost 100 // The amount of power to spend when a Phantom is making their killer attack via a haunting. 0 to disable
+
+// Other
+ttt_traitor_vision_enable             0  // Whether members of the Traitor team can see other members of the Traitor team (including Glitches) through walls via a highlight effect.
 
 // Logging
 ttt_debug_logkills 1 // Whether to log when a player is killed in the console

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -8,17 +8,18 @@ Add the following to your server config:
 // ----------------------------------------
 
 // Weapon Shop
-ttt_shop_random_percent 50    // The percent chance that a weapon in the shop will be not be shown
-ttt_shop_random_tra_percent 0 // The percent chance that a weapon in the shop will be not be shown for the Traitors
-ttt_shop_random_det_percent 0 // The percent chance that a weapon in the shop will be not be shown for the Detectives
-ttt_shop_random_hyp_percent 0 // The percent chance that a weapon in the shop will be not be shown for the Hypnotists
-ttt_shop_random_dep_percent 0 // The percent chance that a weapon in the shop will be not be shown for the Deputies
-ttt_shop_random_imp_percent 0 // The percent chance that a weapon in the shop will be not be shown for the Impersonators
-ttt_shop_random_tra_enabled 0 // Whether role shop randomization is enabled for Traitors
-ttt_shop_random_det_enabled 0 // Whether role shop randomization is enabled for Detectives
-ttt_shop_random_hyp_enabled 0 // Whether role shop randomization is enabled for Hypnotists
-ttt_shop_random_dep_enabled 0 // Whether role shop randomization is enabled for Deputies
-ttt_shop_random_imp_enabled 0 // Whether role shop randomization is enabled for Impersonators
+ttt_shop_random_percent     50 // The percent chance that a weapon in the shop will be not be shown
+ttt_shop_random_tra_percent 0  // The percent chance that a weapon in the shop will be not be shown for the Traitors
+ttt_shop_random_det_percent 0  // The percent chance that a weapon in the shop will be not be shown for the Detectives
+ttt_shop_random_hyp_percent 0  // The percent chance that a weapon in the shop will be not be shown for the Hypnotists
+ttt_shop_random_dep_percent 0  // The percent chance that a weapon in the shop will be not be shown for the Deputies
+ttt_shop_random_imp_percent 0  // The percent chance that a weapon in the shop will be not be shown for the Impersonators
+ttt_shop_random_tra_enabled 0  // Whether role shop randomization is enabled for Traitors
+ttt_shop_random_det_enabled 0  // Whether role shop randomization is enabled for Detectives
+ttt_shop_random_hyp_enabled 0  // Whether role shop randomization is enabled for Hypnotists
+ttt_shop_random_dep_enabled 0  // Whether role shop randomization is enabled for Deputies
+ttt_shop_random_imp_enabled 0  // Whether role shop randomization is enabled for Impersonators
+ttt_shop_hypnotist_sync     0  // Whether Hypnotists should have all weapons that vanilla Traitors have in their weapon shop
 
 // Phantom
 ttt_phantom_respawn_health           50  // The amount of health a Phantom will respawn with

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -67,6 +67,12 @@ function GetEquipmentForRole(role, extra, block_randomization)
         GetEquipmentForRole(ROLE_DETECTIVE, false, true)
     end
 
+    -- Pre-load the Traitor weapons so that any that have their CanBuy modified will also apply to the enabled allied role(s)
+    local sync_traitor_weapons = GetGlobalBool("ttt_shop_hypnotist_sync") and role == ROLE_HYPNOTIST
+    if sync_traitor_weapons and not Equipment[ROLE_TRAITOR] then
+        GetEquipmentForRole(ROLE_TRAITOR, false, true)
+    end
+
     -- Cache the equipment
     if not Equipment[role] then
         -- start with all the non-weapon goodies
@@ -74,7 +80,7 @@ function GetEquipmentForRole(role, extra, block_randomization)
 
         -- find buyable weapons to load info from
         for _, v in pairs(weapons.GetList()) do
-            WEPS.HandleCanBuyOverrides(v, role, extra, block_randomization)
+            WEPS.HandleCanBuyOverrides(v, role, extra, block_randomization, sync_traitor_weapons)
             if v and v.CanBuy then
                 local data = v.EquipMenuData or {}
                 local base = {

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -179,6 +179,12 @@ local function ReceiveRole()
     -- Update the local state
     traitor_vision = GetGlobalBool("ttt_traitor_vision_enable")
 
+    -- Disable highlights on role change
+    if vision_enabled then
+        hook.Remove("PreDrawHalos", "AddPlayerHighlights")
+        vision_enabled = false
+    end
+
     Msg("You are: ")
     if client:IsTraitor() then MsgN("TRAITOR")
     elseif client:IsDetective() then MsgN("DETECTIVE")
@@ -803,6 +809,8 @@ function HandleRoleHighlights(client)
             EnableTraitorHighlights()
             vision_enabled = true
         end
+    else
+        vision_enabled = false
     end
 
     if not vision_enabled then

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -197,6 +197,7 @@ for _, role in ipairs(table.GetKeys(SHOP_ROLES)) do
     CreateConVar("ttt_shop_random_" .. shortstring .. "_percent", "0", FCVAR_REPLICATED, "The percent chance that a weapon in the shop will not be shown for the " .. rolestring, 0, 100)
     CreateConVar("ttt_shop_random_" .. shortstring .. "_enabled", "0", FCVAR_REPLICATED, "Whether shop randomization should run for the " .. rolestring)
 end
+CreateConVar("ttt_shop_hypnotist_sync", "0")
 
 -- bem server convars
 CreateConVar("ttt_bem_allow_change", 1, { FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE }, "Allow clients to change the look of the Traitor/Detective menu")
@@ -396,6 +397,7 @@ function GM:SyncGlobals()
         SetGlobalInt("ttt_shop_random_" .. shortstring .. "_percent", GetConVar("ttt_shop_random_" .. shortstring .. "_percent"):GetInt())
         SetGlobalBool("ttt_shop_random_" .. shortstring .. "_enabled", GetConVar("ttt_shop_random_" .. shortstring .. "_enabled"):GetBool())
     end
+    SetGlobalBool("ttt_shop_hypnotist_sync", GetConVar("ttt_shop_hypnotist_sync"):GetBool())
 
     SetGlobalBool("ttt_phantom_killer_smoke", GetConVar("ttt_phantom_killer_smoke"):GetBool())
     SetGlobalInt("ttt_phantom_killer_haunt_power_max", GetConVar("ttt_phantom_killer_haunt_power_max"):GetInt())

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -139,6 +139,8 @@ CreateConVar("ttt_old_man_starting_health", "1")
 CreateConVar("ttt_jesters_trigger_traitor_testers", "1")
 CreateConVar("ttt_independents_trigger_traitor_testers", "0")
 
+CreateConVar("ttt_traitor_vision_enable", "0")
+
 CreateConVar("ttt_phantom_respawn_health", "50")
 CreateConVar("ttt_phantom_weaker_each_respawn", "0")
 CreateConVar("ttt_phantom_killer_smoke", "1")
@@ -189,7 +191,7 @@ CreateConVar("ttt_namechange_bantime", "10")
 CreateConVar("ttt_detective_search_only", "1", FCVAR_REPLICATED)
 
 CreateConVar("ttt_shop_random_percent", "50", FCVAR_REPLICATED, "The percent chance that a weapon in the shop will not be shown by default", 0, 100)
-for _, role in pairs(SHOP_ROLES) do
+for _, role in ipairs(table.GetKeys(SHOP_ROLES)) do
     local shortstring = ROLE_STRINGS_SHORT[role]
     local rolestring = ROLE_STRINGS[role]
     CreateConVar("ttt_shop_random_" .. shortstring .. "_percent", "0", FCVAR_REPLICATED, "The percent chance that a weapon in the shop will not be shown for the " .. rolestring, 0, 100)
@@ -389,7 +391,7 @@ function GM:SyncGlobals()
     SetGlobalBool("ttt_reveal_beggar_change", GetConVar("ttt_reveal_beggar_change"):GetBool())
 
     SetGlobalInt("ttt_shop_random_percent", GetConVar("ttt_shop_random_percent"):GetInt())
-    for _, role in pairs(SHOP_ROLES) do
+    for _, role in ipairs(table.GetKeys(SHOP_ROLES)) do
         local shortstring = ROLE_STRINGS_SHORT[role]
         SetGlobalInt("ttt_shop_random_" .. shortstring .. "_percent", GetConVar("ttt_shop_random_" .. shortstring .. "_percent"):GetInt())
         SetGlobalBool("ttt_shop_random_" .. shortstring .. "_enabled", GetConVar("ttt_shop_random_" .. shortstring .. "_enabled"):GetBool())
@@ -401,6 +403,8 @@ function GM:SyncGlobals()
     SetGlobalInt("ttt_phantom_killer_haunt_attack_cost", GetConVar("ttt_phantom_killer_haunt_attack_cost"):GetInt())
     SetGlobalInt("ttt_phantom_killer_haunt_jump_cost", GetConVar("ttt_phantom_killer_haunt_jump_cost"):GetInt())
     SetGlobalInt("ttt_phantom_killer_haunt_drop_cost", GetConVar("ttt_phantom_killer_haunt_drop_cost"):GetInt())
+
+    SetGlobalBool("ttt_traitor_vision_enable", GetConVar("ttt_traitor_vision_enable"):GetBool())
 
     SetGlobalBool("sv_voiceenable", GetConVar("sv_voiceenable"):GetBool())
 end

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -62,16 +62,20 @@ end
 function plymeta:SubtractCredits(amt) self:AddCredits(-amt) end
 
 function plymeta:SetDefaultCredits()
-    if self:GetTraitor() then
-        local c = GetConVarNumber("ttt_credits_starting")
-        if CountTraitors() == 1 then
-            c = c + GetConVarNumber("ttt_credits_alonebonus")
+    if self:IsTraitorTeam() then
+        local c = 0
+        if self:IsTraitor() then
+            c = GetConVar("ttt_credits_starting"):GetInt()
+        elseif self:IsHypnotist() then
+            c = GetConVar("ttt_hyp_credits_starting"):GetInt()
+        end
+
+        if not self:IsImpersonator() and CountTraitors() == 1 then
+            c = c + GetConVar("ttt_credits_alonebonus"):GetInt()
         end
         self:SetCredits(math.ceil(c))
-    elseif self:GetDetective() then
-        self:SetCredits(math.ceil(GetConVarNumber("ttt_det_credits_starting")))
-    elseif self:GetHypnotist() then
-        self:SetCredits(math.ceil(GetConVarNumber("ttt_hyp_credits_starting")))
+    elseif self:IsDetective() then
+        self:SetCredits(math.ceil(GetConVar("ttt_det_credits_starting"):GetInt()))
     else
         self:SetCredits(0)
     end

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -53,7 +53,7 @@ function plymeta:IsCustom()
     return role ~= ROLE_INNOCENT and role ~= ROLE_TRAITOR and role ~= ROLE_DETECTIVE
 end
 function plymeta:IsShopRole()
-    return table.HasValue(SHOP_ROLES, self:GetRole())
+    return SHOP_ROLES[self:GetRole()]
 end
 
 function plymeta:SetRoleAndBroadcast(role)
@@ -96,22 +96,10 @@ function plymeta:IsActiveShopRole() return self:IsShopRole() and self:IsActive()
 function plymeta:IsActiveDetectiveLike() return self:IsActive() and self:IsDetectiveLike() end
 
 -- functions to group individual roles into teams
-function plymeta:IsTraitorTeam()
-    local role = self:GetRole()
-    return role == ROLE_TRAITOR or role == ROLE_HYPNOTIST or role == ROLE_IMPERSONATOR
-end
-function plymeta:IsInnocentTeam()
-    local role = self:GetRole()
-    return role == ROLE_INNOCENT or role == ROLE_DETECTIVE or role == ROLE_GLITCH or role == ROLE_PHANTOM or role == ROLE_REVENGER or role == ROLE_DEPUTY
-end
-function plymeta:IsJesterTeam()
-    local role = self:GetRole()
-    return role == ROLE_JESTER or role == ROLE_SWAPPER or role == ROLE_CLOWN or role == ROLE_BEGGAR
-end
-function plymeta:IsIndependentTeam()
-    local role = self:GetRole()
-    return role == ROLE_DRUNK or role == ROLE_OLDMAN
-end
+function plymeta:IsTraitorTeam() return TRAITOR_ROLES[self:GetRole()] end
+function plymeta:IsInnocentTeam() return INNOCENT_ROLES[self:GetRole()] end
+function plymeta:IsJesterTeam() return JESTER_ROLES[self:GetRole()] end
+function plymeta:IsIndependentTeam() return INDEPENDENT_ROLES[self:GetRole()] end
 function plymeta:IsActiveTraitorTeam() return self:IsTraitorTeam() and self:IsActive() end
 function plymeta:IsActiveInnocentTeam() return self:IsInnocentTeam() and self:IsActive() end
 function plymeta:IsActiveJesterTeam() return self:IsJesterTeam() and self:IsActive() end

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -53,7 +53,7 @@ function plymeta:IsCustom()
     return role ~= ROLE_INNOCENT and role ~= ROLE_TRAITOR and role ~= ROLE_DETECTIVE
 end
 function plymeta:IsShopRole()
-    return SHOP_ROLES[self:GetRole()]
+    return SHOP_ROLES[self:GetRole()] or false
 end
 
 function plymeta:SetRoleAndBroadcast(role)
@@ -96,10 +96,10 @@ function plymeta:IsActiveShopRole() return self:IsShopRole() and self:IsActive()
 function plymeta:IsActiveDetectiveLike() return self:IsActive() and self:IsDetectiveLike() end
 
 -- functions to group individual roles into teams
-function plymeta:IsTraitorTeam() return TRAITOR_ROLES[self:GetRole()] end
-function plymeta:IsInnocentTeam() return INNOCENT_ROLES[self:GetRole()] end
-function plymeta:IsJesterTeam() return JESTER_ROLES[self:GetRole()] end
-function plymeta:IsIndependentTeam() return INDEPENDENT_ROLES[self:GetRole()] end
+function plymeta:IsTraitorTeam() return TRAITOR_ROLES[self:GetRole()] or false end
+function plymeta:IsInnocentTeam() return INNOCENT_ROLES[self:GetRole()] or false end
+function plymeta:IsJesterTeam() return JESTER_ROLES[self:GetRole()] or false end
+function plymeta:IsIndependentTeam() return INDEPENDENT_ROLES[self:GetRole()] or false end
 function plymeta:IsActiveTraitorTeam() return self:IsTraitorTeam() and self:IsActive() end
 function plymeta:IsActiveInnocentTeam() return self:IsInnocentTeam() and self:IsActive() end
 function plymeta:IsActiveJesterTeam() return self:IsJesterTeam() and self:IsActive() end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -31,7 +31,28 @@ ROLE_OLDMAN = 14
 
 ROLE_MAX = 14
 
-SHOP_ROLES = {ROLE_TRAITOR, ROLE_DETECTIVE, ROLE_HYPNOTIST, ROLE_DEPUTY, ROLE_IMPERSONATOR}
+local function AddRoleAssociations(list, roles)
+    -- Use an associative array so we can do a O(1) lookup by role
+    -- See: https://wiki.facepunch.com/gmod/table.HasValue
+    for _, r in ipairs(roles) do
+        list[r] = true
+    end
+end
+
+SHOP_ROLES = {}
+AddRoleAssociations(SHOP_ROLES, {ROLE_TRAITOR, ROLE_DETECTIVE, ROLE_HYPNOTIST, ROLE_DEPUTY, ROLE_IMPERSONATOR})
+
+TRAITOR_ROLES = {}
+AddRoleAssociations(TRAITOR_ROLES, {ROLE_TRAITOR, ROLE_HYPNOTIST, ROLE_IMPERSONATOR})
+
+INNOCENT_ROLES = {}
+AddRoleAssociations(INNOCENT_ROLES, {ROLE_INNOCENT, ROLE_DETECTIVE, ROLE_GLITCH, ROLE_PHANTOM, ROLE_REVENGER, ROLE_DEPUTY})
+
+JESTER_ROLES = {}
+AddRoleAssociations(JESTER_ROLES, {ROLE_JESTER, ROLE_SWAPPER, ROLE_CLOWN, ROLE_BEGGAR})
+
+INDEPENDENT_ROLES = {}
+AddRoleAssociations(INDEPENDENT_ROLES, {ROLE_DRUNK, ROLE_OLDMAN})
 
 -- Role colours
 COLOR_INNOCENT = Color(25, 200, 25, 255)

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -377,7 +377,9 @@ local function OrderEquipment(ply, cmd, args)
         end
 
         -- Add the loaded weapons for this role
-        WEPS.HandleCanBuyOverrides(swep_table, role, role == ROLE_DEPUTY or role == ROLE_IMPERSONATOR)
+        local extra = role == ROLE_DEPUTY or role == ROLE_IMPERSONATOR
+        local sync_traitor_weapons = GetGlobalBool("ttt_shop_hypnotist_sync") and role == ROLE_HYPNOTIST
+        WEPS.HandleCanBuyOverrides(swep_table, role, extra, false, sync_traitor_weapons)
     end
 
     local received = false


### PR DESCRIPTION
- Traitor vision (disabled by default)
  - Highlights members of the traitor team and jester team
  - Created to be extensible for other roles (Killer, Vampire, Zombie)
- Ability to sync Traitor shop weapons to other Traitor roles (currently only Hypnotist but will be available for Assassin as well)