### PR TITLE
Bug fixes

### DIFF
--- a/gamemodes/terrortown/gamemode/cl_awards.lua
+++ b/gamemodes/terrortown/gamemode/cl_awards.lua
@@ -21,6 +21,11 @@ local function GetRoleName(s)
     return T(ROLE_STRINGS[s.role])
 end
 
+local function GetRole(players, id)
+    local player = players[id]
+    return player and player.role or ROLE_NONE
+end
+
 -- a common pattern
 local function FindHighest(tbl)
     local m_num = 0
@@ -158,7 +163,7 @@ local function AllKills(events, scores, players)
     -- Someone killed all the traitors
     if #tr_killers == 1 then
         local id = tr_killers[1]
-        local role = players[id].role
+        local role = GetRole(players, id)
         -- Don't celebrate team killers
         if TRAITOR_ROLES[role] then
             local killer = players[id].nick
@@ -171,7 +176,7 @@ local function AllKills(events, scores, players)
     -- Someone killed all the innocents
     if #in_killers == 1 then
         local id = in_killers[1]
-        local role = players[id].role
+        local role = GetRole(players, id)
         -- Don't celebrate team killers
         if INNOCENT_ROLES[role] then
             local killer = players[id].nick
@@ -187,7 +192,7 @@ end
 local function NumKills_Traitor(events, scores, players)
     local trs = {}
     for id, s in pairs(scores) do
-        local role = players[id].role
+        local role = GetRole(players, id)
         if TRAITOR_ROLES[role] then
             if s.innos > 0 then
                 table.insert(trs, id)
@@ -224,7 +229,7 @@ end
 local function NumKills_Inno(events, scores, players)
     local ins = {}
     for id, s in pairs(scores) do
-        local role = players[id].role
+        local role = GetRole(players, id)
         if not TRAITOR_ROLES[role] then
             if s.traitors > 0 then
                 table.insert(ins, id)
@@ -499,6 +504,8 @@ local function KnifeUser(events, scores, players)
     if not most then return nil end
 
     local playerInfo = players[most.sid64]
+    if not playerInfo then return nil end
+
     local nick = playerInfo.nick
     if not nick then return nil end
 
@@ -610,7 +617,7 @@ local function TeamKiller(events, scores, players)
     local tker = nil
     local pct = 0
     for id, s in pairs(scores) do
-        local role = players[id].role
+        local role = GetRole(players, id)
         local kills = s.innos
         local team = num_inno - 1
         if TRAITOR_ROLES[role] then
@@ -628,6 +635,8 @@ local function TeamKiller(events, scores, players)
     if pct == 0 or tker == nil then return nil end
 
     local tkerInfo = players[tker]
+    if not tkerInfo then return nil end
+
     local nick = tkerInfo.nick
     if not nick then return nil end
 

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -154,9 +154,9 @@ function GetEquipmentForRole(role, promoted, block_randomization)
         if role == ROLE_MERCENARY and mercmode == MERC_SHOP_INTERSECT then
             for idx, i in pairs(traitor_equipment_ids) do
                 -- Traitor AND Detective mode, (Detective && Traitor) -> Mercenary
-                if not available[i.id] and table.HasValue(detective_equipment_ids, i) then
+                if not available[i] and table.HasValue(detective_equipment_ids, i) then
                     table.insert(tbl[role], traitor_equipment[idx])
-                    available[i.id] = true
+                    available[i] = true
                 end
             end
         else

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -675,7 +675,7 @@ end)
 net.Receive("TTT_ClientDeathNotify", function()
     -- Read the variables from the message
     local name = net.ReadString()
-    local role = net.ReadUInt(8)
+    local role = net.ReadInt(8)
     local reason = net.ReadString()
 
     -- Format the number role into a human readable role and identifying color

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -62,7 +62,7 @@ function CLSCORE:AddEvent(e, offset)
 end
 
 local function GetPlayerFromSteam64(id)
-    -- The first bot's ID is 90071996842377216 whhich translates to "STEAM_0:0:0", an 11-character string
+    -- The first bot's ID is 90071996842377216 which translates to "STEAM_0:0:0", an 11-character string
     -- A player's Steam ID cannot be that short, so if it is this must be a bot
     local isBot = string.len(util.SteamIDFrom64(id)) == 11
     -- Bots cannot be retrieved by SteamID on the client so search by name instead

--- a/gamemodes/terrortown/gamemode/cl_scoring_events.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring_events.lua
@@ -224,7 +224,7 @@ local function KillText(e)
 
    local txt = nil
 
-   if e.att.sid == e.vic.sid then
+   if e.att.sid64 == e.vic.sid64 then
       if is_dmg(dmg.t, DMG_BLAST) then
 
          txt = trap and "ev_blowup_trap" or "ev_blowup"
@@ -299,7 +299,7 @@ Event(EVENT_KILL,
 {
     text = KillText,
     icon = function(e)
-        if e.att.sid == e.vic.sid or e.att.sid == -1 then
+        if e.att.sid64 == e.vic.sid64 or e.att.sid64 == -1 then
             return wrong_icon, "Suicide"
         end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1754,7 +1754,7 @@ hook.Add("ScaleNPCDamage", "HitmarkerPlayerCritDetector", function(npc, hitgroup
 end)
 
 -- Death messages
-hook.Add("PlayerDeath", "Kill_Reveal_Notify", function(victim, entity, killer)
+hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, entity, killer)
     if gmod.GetGamemode().Name == "Trouble in Terrorist Town" then
         local reason = "nil"
         local killerName = "nil"

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -702,7 +702,6 @@ function PrepareRound()
         v:SetNWBool("WasHypnotised", false)
         v:SetNWBool("KillerClownActive", false)
         v:SetNWBool("HasPromotion", false)
-        v:GetNWBool("HadPromotion", false)
         v:SetNWBool("WasBeggar", false)
         v:SetNWBool("VeteranActive", false)
         -- Workaround to prevent GMod sprint from working

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1790,7 +1790,7 @@ hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, entity, killer
         -- Send the buffer message with the death information to the victim
         net.Start("TTT_ClientDeathNotify")
         net.WriteString(killerName)
-        net.WriteUInt(role, 8)
+        net.WriteInt(role, 8)
         net.WriteString(reason)
         net.Send(victim)
     end


### PR DESCRIPTION
- Fixed Mercenary shop error
- Fixed error displaying killer message when a Phantom is killed and haunting is enabled
- Fixed bot deaths being logged as suicides
- Added some sanity checks to the awards logic to prevent a weird error
- Change the death message hook name to be unique so it isn't overwritten by the original workshop addon