### PR TITLE
Monster tweaks and bug fixes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -104,7 +104,8 @@ ttt_asn_credits_starting                    1       // The number of credits an 
 // Vampire
 ttt_vampires_are_monsters                   0       // Whether Vampires should be treated as members of the Monster team.
 ttt_vampire_vision_enable                   0       // Whether Vampires have their special vision highlights enabled
-ttt_vampire_convert_enable                  1       // Whether Vampires have the ability to drain other players' blood using their fangs
+ttt_vampire_drain_enable                    1       // Whether Vampires have the ability to drain other players' blood using their fangs
+ttt_vampire_convert_enable                  0       // Whether Vampires have the ability to convert other players to vampire thrals using their fangs
 ttt_vampire_show_target_icon                0       // Whether Vampires have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
 ttt_vampire_damage_reduction                0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a Vampire.
 ttt_vampire_fang_timer                      5       // The amount of time fangs must be used to fully drain a target's blood

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -106,7 +106,7 @@ ttt_vampires_are_monsters                   0       // Whether Vampires should b
 ttt_vampire_vision_enable                   0       // Whether Vampires have their special vision highlights enabled
 ttt_vampire_convert_enable                  1       // Whether Vampires have the ability to drain other players' blood using their fangs
 ttt_vampire_show_target_icon                0       // Whether Vampires have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
-ttt_vampire_damage_reduction                0     // The fraction an attacker's bullet damage will be reduced by when they are shooting a Vampire.
+ttt_vampire_damage_reduction                0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a Vampire.
 ttt_vampire_fang_timer                      5       // The amount of time fangs must be used to fully drain a target's blood
 ttt_vampire_fang_heal                       50      // The amount of health a Vampire will heal by when they fully drain a target's blood
 ttt_vampire_fang_overheal                   25      // The amount over the Vampire's normal maximum health (e.g. 100 + this ConVar) that the Vampire can heal to by drinking blood.
@@ -209,12 +209,14 @@ ttt_kil_credits_starting                    2       // The number of credits a K
 
 // Zombie
 ttt_zombies_are_monsters                    0       // Whether Zombies should be treated as members of the Monster team.
+ttt_zombies_are_traitors                    0       // Whether Zombies should be treated as members of the Traitors team.
+ttt_zombie_round_chance                     0.1     // The chance that a "Zombie Round" will occur where all players who would have been Traitors are made Zombies instead. Only usable when "ttt_zombies_are_traitors" is set to "1"
 ttt_zombie_vision_enable                    0       // Whether Zombies have their special vision highlights enabled
 ttt_zombie_spit_enable                      1       // Whether Zombies have their spit attack enabled
 ttt_zombie_leap_enable                      1       // Whether Zombies have their leap attack enabled
 ttt_zombie_show_target_icon                 0       // Whether Zombies have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
 ttt_zombie_damage_penalty                   0.5     // The fraction a Zombie's damage will be scaled by when they are attacking without using their claws.
-ttt_zombie_damage_reduction                 0     // The fraction an attacker's bullet damage will be reduced by when they are shooting a Zombie.
+ttt_zombie_damage_reduction                 0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a Zombie.
 ttt_zombie_prime_only_weapons               1       // Whether only Prime Zombies (e.g. players who spawn as Zombies originally) are allowed to pick up weapons.
 
 // ----------------------------------------
@@ -253,7 +255,8 @@ ttt_shop_random_vam_enabled                 0       // Whether role shop randomi
 ttt_shop_hyp_sync                           0       // Whether Hypnotists should have all weapons that vanilla Traitors have in their weapon shop
 ttt_shop_imp_sync                           0       // Whether Impersonators should have all weapons that vanilla Traitors have in their weapon shop
 ttt_shop_asn_sync                           0       // Whether Assassins should have all weapons that vanilla Traitors have in their weapon shop
-ttt_shop_vam_sync                           0       // Whether Vampires should have all weapons that vanilla Traitors have in their weapon shop (if they are not a Monster)
+ttt_shop_vam_sync                           0       // Whether Vampires should have all weapons that vanilla Traitors have in their weapon shop (if they are a Traitor)
+ttt_shop_zom_sync                           0       // Whether Zombies should have all weapons that vanilla Traitors have in their weapon shop (if they are a Traitor)
 
 // ----------------------------------------
 

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -257,6 +257,8 @@ function SWEP:Think()
                 if not ply:HasWeapon("weapon_zm_improvised") then
                     ply:Give("weapon_zm_improvised")
                 end
+                -- Disable Killer smoke if they have it
+                ply:SetNWBool("KillerSmoke", false)
                 ply:SetVampirePreviousRole(ply:GetRole())
                 ply:SetRole(ROLE_VAMPIRE)
                 ply:SetVampirePrime(false)

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -46,12 +46,13 @@ local STATE_CONVERT = 3
 
 local beep = Sound("npc/fast_zombie/fz_alert_close1.wav")
 
-local vampire_convert = CreateConVar("ttt_vampire_convert_enable", "1", FCVAR_ARCHIVE + FCVAR_REPLICATED)
-local vampire_fang_timer = CreateConVar("ttt_vampire_fang_timer", "5", FCVAR_ARCHIVE + FCVAR_REPLICATED)
-local vampire_fang_heal = CreateConVar("ttt_vampire_fang_heal", "50", FCVAR_ARCHIVE + FCVAR_REPLICATED)
-local vampire_fang_overheal = CreateConVar("ttt_vampire_fang_overheal", "25", FCVAR_ARCHIVE + FCVAR_REPLICATED)
-local vampire_fang_unfreeze_delay = CreateConVar("ttt_vampire_fang_unfreeze_delay", "1", FCVAR_ARCHIVE + FCVAR_REPLICATED)
-local vampire_prime_convert = CreateConVar("ttt_vampire_prime_only_convert", "1", FCVAR_ARCHIVE + FCVAR_REPLICATED)
+local vampire_convert = CreateConVar("ttt_vampire_convert_enable", "0")
+local vampire_drain = CreateConVar("ttt_vampire_drain_enable", "1")
+local vampire_fang_timer = CreateConVar("ttt_vampire_fang_timer", "5")
+local vampire_fang_heal = CreateConVar("ttt_vampire_fang_heal", "50")
+local vampire_fang_overheal = CreateConVar("ttt_vampire_fang_overheal", "25")
+local vampire_fang_unfreeze_delay = CreateConVar("ttt_vampire_fang_unfreeze_delay", "1")
+local vampire_prime_convert = CreateConVar("ttt_vampire_prime_only_convert", "1")
 
 function SWEP:SetupDataTables()
     self:NetworkVar("Int", 0, "State")
@@ -86,7 +87,7 @@ function SWEP:OnDrop()
 end
 
 local function CanConvert(ply)
-    return not vampire_prime_convert:GetBool() or ply:IsVampirePrime()
+    return vampire_convert:GetBool() and (not vampire_prime_convert:GetBool() or ply:IsVampirePrime())
 end
 
 local function GetPlayerFromBody(body)
@@ -109,7 +110,7 @@ function SWEP:PrimaryAttack()
             end
 
             self:Eat(tr.Entity)
-        elseif ent:IsPlayer() and vampire_convert:GetBool() then
+        elseif ent:IsPlayer() and vampire_drain:GetBool() then
             if ent:IsJesterTeam() and not ent:GetNWBool("KillerClownActive", false) then
                 self:Error("TARGET IS A JESTER")
             elseif ent:IsVampireAlly() then

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -55,8 +55,8 @@ SWEP.NextReload = CurTime()
 SWEP.DeploySpeed = 2
 local sound_single = Sound("Weapon_Crowbar.Single")
 
-local zombie_leap = CreateConVar("ttt_zombie_leap_enable", "1", FCVAR_ARCHIVE)
-local zombie_spit = CreateConVar("ttt_zombie_spit_enable", "1", FCVAR_ARCHIVE)
+local zombie_leap = CreateConVar("ttt_zombie_leap_enable", "1")
+local zombie_spit = CreateConVar("ttt_zombie_spit_enable", "1")
 
 function SWEP:Initialize()
     self:SetHoldType(self.HoldType)

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -70,7 +70,8 @@ function GetEquipmentForRole(role, promoted, block_randomization)
     local sync_impersonator = GetGlobalBool("ttt_shop_imp_sync") and role == ROLE_IMPERSONATOR
     local sync_assassin = GetGlobalBool("ttt_shop_asn_sync") and role == ROLE_ASSASSIN
     local sync_vampire = GetGlobalBool("ttt_shop_vam_sync") and role == ROLE_VAMPIRE and TRAITOR_ROLES[ROLE_VAMPIRE]
-    local sync_traitor_weapons = sync_hypnotist or sync_impersonator or sync_assassin or sync_vampire or
+    local sync_zombie = GetGlobalBool("ttt_shop_zom_sync") and role == ROLE_ZOMBIE and TRAITOR_ROLES[ROLE_ZOMBIE]
+    local sync_traitor_weapons = sync_hypnotist or sync_impersonator or sync_assassin or sync_vampire or sync_zombie or
                                     (mercmode > MERC_SHOP_NONE and role == ROLE_MERCENARY)
     if sync_traitor_weapons and not Equipment[ROLE_TRAITOR] then
         GetEquipmentForRole(ROLE_TRAITOR, false, true)

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -749,10 +749,9 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
     stamina = 100
     ConVars()
 
-    local client = LocalPlayer()
-
     -- listen for activation
     hook.Add("Think", "TTTSprintThink", function()
+        local client = LocalPlayer()
         local forward_key = hook.Call("TTTSprintKey", GAMEMODE, client) or IN_FORWARD
         if client:KeyDown(forward_key) and client:KeyDown(IN_SPEED) then
             -- forward + selected key

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -829,14 +829,14 @@ end)
 
 -- Player highlights
 
-local function OnPlayerHighlightEnabled(client, alliedRoles, jesterRoles, hideEnemies, traitorAllies)
+local function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies, traitorAllies)
     if GetRoundState() ~= ROUND_ACTIVE then return end
     local enemies = {}
     local friends = {}
     local jesters = {}
     for _, v in pairs(player.GetAll()) do
         if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= client then
-            if table.HasValue(jesterRoles, v:GetRole()) then
+            if showJesters and v:IsJesterTeam() and not v:GetNWBool("KillerClownActive", false) then
                 table.insert(jesters, v)
             elseif table.HasValue(alliedRoles, v:GetRole()) then
                 table.insert(friends, v)
@@ -870,8 +870,7 @@ end
 
 local function EnableKillerHighlights(client)
     hook.Add("PreDrawHalos", "AddPlayerHighlights", function()
-        local jesters = table.GetKeys(JESTER_ROLES)
-        OnPlayerHighlightEnabled(client, {ROLE_KILLER}, jesters, false, false)
+        OnPlayerHighlightEnabled(client, {ROLE_KILLER}, true, false, false)
     end)
 end
 local function EnableTraitorHighlights(client)
@@ -881,8 +880,7 @@ local function EnableTraitorHighlights(client)
         -- And add the glitch
         table.insert(allies, ROLE_GLITCH)
 
-        local jesters = table.GetKeys(JESTER_ROLES)
-        OnPlayerHighlightEnabled(client, allies, jesters, true, true)
+        OnPlayerHighlightEnabled(client, allies, true, true, true)
     end)
 end
 local function EnableZombieHighlights(client)
@@ -907,8 +905,7 @@ local function EnableZombieHighlights(client)
             end
         end
 
-        local jesters = table.GetKeys(JESTER_ROLES)
-        OnPlayerHighlightEnabled(client, allies, jesters, hideEnemies, traitorAllies)
+        OnPlayerHighlightEnabled(client, allies, true, hideEnemies, traitorAllies)
     end)
 end
 local function EnableVampireHighlights(client)
@@ -928,8 +925,7 @@ local function EnableVampireHighlights(client)
             end
         end
 
-        local jesters = table.GetKeys(JESTER_ROLES)
-        OnPlayerHighlightEnabled(client, allies, jesters, hideEnemies, traitorAllies)
+        OnPlayerHighlightEnabled(client, allies, true, hideEnemies, traitorAllies)
     end)
 end
 

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -80,6 +80,9 @@ local function GetTextForLocalPlayer()
         end
 
         return text
+    -- Zombies not on Traitor or Monster teams have a different message
+    elseif client:IsZombie() then
+        return GetPTranslation("info_popup_zombie_indep", { menukey = menukey })
     else
         return GetPTranslation("info_popup_" .. client:GetRoleStringRaw(), { menukey = menukey })
     end

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -682,8 +682,8 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     bg.PaintOver = function()
         draw.RoundedBox(8, 8, ywin - 5, w - 14, winlbl:GetTall() + 10, title.c)
         if old_man_won_last_round then draw.RoundedBoxEx(8, 8, 65, w - 14, 28, ROLE_COLORS[ROLE_OLDMAN], false, false, true, true) end
-        draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 14, 341, 330 + height_extra, Color(164, 164, 164, 255))
-        draw.RoundedBox(0, 357, ywin + winlbl:GetTall() + 14, 341, 330 + height_extra, Color(164, 164, 164, 255))
+        draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 15, 341, 329 + height_extra, Color(164, 164, 164, 255))
+        draw.RoundedBox(0, 357, ywin + winlbl:GetTall() + 15, 341, 329 + height_extra, Color(164, 164, 164, 255))
         local loc = ywin + winlbl:GetTall() + 47
         for _ = 1, player_rows do
             draw.RoundedBox(0, 8, loc, 341, 1, Color(97, 100, 102, 255))

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -319,15 +319,36 @@ local function ValidAward(a)
     return a and a.nick and a.text and a.title and a.priority
 end
 
-local wintitle = {
-    [WIN_INNOCENT] = { txt = "hilite_win_innocent", c = ROLE_COLORS[ROLE_INNOCENT] },
-    [WIN_TRAITOR] = { txt = "hilite_win_traitors", c = ROLE_COLORS[ROLE_TRAITOR] },
-    [WIN_JESTER] = { txt = "hilite_win_jester", c = ROLE_COLORS[ROLE_JESTER] },
-    [WIN_CLOWN] = { txt = "hilite_win_clown", c = ROLE_COLORS[ROLE_JESTER] },
-    [WIN_KILLER] = { txt = "hilite_win_killer", c = ROLE_COLORS[ROLE_KILLER] },
-    [WIN_ZOMBIE] = { txt = "hilite_win_zombies", c = ROLE_COLORS[ROLE_ZOMBIE] },
-    [WIN_MONSTER] = { txt = "hilite_win_monster", c = ROLE_COLORS[ROLE_ZOMBIE] }
-}
+local function GetWinTitle(wintype)
+    local wintitle = {
+        [WIN_INNOCENT] = { txt = "hilite_win_innocent", c = ROLE_COLORS[ROLE_INNOCENT] },
+        [WIN_TRAITOR] = { txt = "hilite_win_traitors", c = ROLE_COLORS[ROLE_TRAITOR] },
+        [WIN_JESTER] = { txt = "hilite_win_jester", c = ROLE_COLORS[ROLE_JESTER] },
+        [WIN_CLOWN] = { txt = "hilite_win_clown", c = ROLE_COLORS[ROLE_JESTER] },
+        [WIN_KILLER] = { txt = "hilite_win_killer", c = ROLE_COLORS[ROLE_KILLER] },
+        [WIN_ZOMBIE] = { txt = "hilite_win_zombies", c = ROLE_COLORS[ROLE_ZOMBIE] },
+        [WIN_MONSTER] = { txt = "hilite_win_monster", c = ROLE_COLORS[ROLE_ZOMBIE] }
+    }
+    local title = wintitle[wintype]
+
+    -- If this was a monster win, check that both roles are part of the monsters team still
+    if wintype == WIN_MONSTER then
+        -- If Zombies are not monsters then Vampires win
+        if not MONSTER_ROLES[ROLE_ZOMBIE] then
+            title.txt = "hilite_win_vampires"
+            -- Also make sure to override the color because they will be different
+            title.c = ROLE_COLORS[ROLE_VAMPIRE]
+        -- And vice versa
+        elseif not MONSTER_ROLES[ROLE_VAMPIRE] then
+            title.txt = "hilite_win_zombies"
+        -- Otherwise the monsters legit win
+        else
+            title.txt = "hilite_win_monster"
+        end
+    end
+
+    return title
+end
 
 function CLSCORE:BuildEventLogPanel(dpanel)
     local margin = 10
@@ -624,29 +645,13 @@ function CLSCORE:BuildSummaryPanel(dpanel)
         dpanel:SetSize(w, h)
     end
 
-    local title = wintitle[WIN_INNOCENT]
+    local title = GetWinTitle(WIN_INNOCENT)
     for i = #self.Events, 1, -1 do
         local e = self.Events[i]
         if e.id == EVENT_FINISH then
             local wintype = e.win
             if wintype == WIN_TIMELIMIT then wintype = WIN_INNOCENT end
-            title = wintitle[wintype]
-
-            -- If this was a monster win, check that both roles are part of the monsters team still
-            if wintype == WIN_MONSTER then
-                -- If Zombies are not monsters then Vampires win
-                if not MONSTER_ROLES[ROLE_ZOMBIE] then
-                    title.txt = "hilite_win_vampires"
-                    -- Also make sure to override the color because they will be different
-                    title.c = ROLE_COLORS[ROLE_VAMPIRE]
-                -- And vice versa
-                elseif not MONSTER_ROLES[ROLE_VAMPIRE] then
-                    title.txt = "hilite_win_zombies"
-                -- Otherwise the monsters legit win
-                else
-                    title.txt = "hilite_win_monster"
-                end
-            end
+            title = GetWinTitle(wintype)
             break
         end
     end
@@ -879,7 +884,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
     local w, h = dpanel:GetSize()
 
     local endtime = self.StartTime
-    local title = wintitle[WIN_INNOCENT]
+    local title = GetWinTitle(WIN_INNOCENT)
     for i=#self.Events, 1, -1 do
         local e = self.Events[i]
         if e.id == EVENT_FINISH then
@@ -887,7 +892,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
            -- when win is due to timeout, innocents win
            local wintype = e.win
            if wintype == WIN_TIMELIMIT then wintype = WIN_INNOCENT end
-           title = wintitle[wintype]
+           title = GetWinTitle(wintype)
            break
         end
     end

--- a/gamemodes/terrortown/gamemode/cl_scoring_events.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring_events.lua
@@ -84,6 +84,8 @@ Event(EVENT_FINISH,
                         return T("ev_win_zombie")
                      end
                      return T("ev_win_monster")
+                  elseif e.win == WIN_ZOMBIE then
+                     return T("ev_win_zombie")
                   elseif e.win == WIN_TIMELIMIT then
                      return T("ev_win_time")
                   end
@@ -109,6 +111,8 @@ Event(EVENT_FINISH,
                         text = "Zombies won"
                      end
                      return star_icon, text
+                  elseif e.win == WIN_ZOMBIE then
+                     return star_icon, "Zombies won"
                   else
                      return star_icon, "Timelimit"
                   end

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -331,7 +331,12 @@ function GM:HUDDrawTargetID()
                 end
                 target_vampire = ent:IsVampire() and ent:IsMonsterTeam()
                 target_jester = showJester
-            elseif client:IsKiller() then
+            elseif client:IsIndependentTeam() then
+                if client:IsZombie() then
+                    target_fellow_zombie = ent:IsZombie()
+                else
+                    target_zombie = ent:IsZombie() and ent:IsIndependentTeam()
+                end
                 target_jester = showJester
             end
         end

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -124,9 +124,9 @@ function GM:PostDrawTranslucentRenderables()
                         elseif showJester then
                             DrawRoleIcon(ROLE_JESTER, false, pos, dir)
                         end
-                    elseif client:IsZombie() then
-                        if v:IsZombie() then
-                            DrawRoleIcon(ROLE_ZOMBIE, true, pos, dir)
+                    elseif client:IsIndependentTeam() then
+                        if v:IsIndependentTeam() then
+                            DrawRoleIcon(v:GetRole(), true, pos, dir)
                         elseif showJester then
                             DrawRoleIcon(ROLE_JESTER, false, pos, dir)
                         end

--- a/gamemodes/terrortown/gamemode/equip_items_shd.lua
+++ b/gamemodes/terrortown/gamemode/equip_items_shd.lua
@@ -323,41 +323,42 @@ function GenerateNewEquipmentID()
 end
 
 local function LoadMonsterRoleEquipment(role, radar)
-  if not table.HasValue(DefaultEquipment[role], EQUIP_RADAR) then
-      table.insert(DefaultEquipment[role], EQUIP_RADAR)
-  end
+    if not table.HasValue(DefaultEquipment[role], EQUIP_RADAR) then
+        table.insert(DefaultEquipment[role], EQUIP_RADAR)
+    end
 
-  if GetEquipmentItem(role, EQUIP_RADAR) == nil then
-      table.insert(EquipmentItems[role], radar)
-  end
+    if GetEquipmentItem(role, EQUIP_RADAR) == nil then
+        table.insert(EquipmentItems[role], radar)
+    end
 end
 
 local function RemoveMonsterRoleEquipment(role)
-  for i, v in ipairs(DefaultEquipment[role]) do
-      if v == EQUIP_RADAR then
-          table.remove(DefaultEquipment[role], i)
-      end
-  end
+    for i, v in ipairs(DefaultEquipment[role]) do
+        if v == EQUIP_RADAR then
+            table.remove(DefaultEquipment[role], i)
+        end
+    end
 
-  for i, v in ipairs(EquipmentItems[role]) do
-      if v.id == EQUIP_RADAR then
-          table.remove(EquipmentItems[role], i)
-      end
-  end
+    for i, v in ipairs(EquipmentItems[role]) do
+        if v.id == EQUIP_RADAR then
+            table.remove(EquipmentItems[role], i)
+        end
+    end
 end
 
 function LoadMonsterEquipment(zombies_are_monsters, vampires_are_monsters)
-  local radar = GetEquipmentItem(ROLE_TRAITOR, EQUIP_RADAR)
+    local radar = GetEquipmentItem(ROLE_TRAITOR, EQUIP_RADAR)
 
-  -- Allow Monsters to buy Radar if they aren't members of the Monster team
-  if zombies_are_monsters then
-      RemoveMonsterRoleEquipment(ROLE_ZOMBIE)
-  else
-      LoadMonsterRoleEquipment(ROLE_ZOMBIE, radar)
-  end
-  if vampires_are_monsters then
-      RemoveMonsterRoleEquipment(ROLE_VAMPIRE)
-  else
-      LoadMonsterRoleEquipment(ROLE_VAMPIRE, radar)
-  end
+    -- Allow Monsters to buy Radar if they aren't members of the Monster team
+    if zombies_are_monsters then
+        RemoveMonsterRoleEquipment(ROLE_ZOMBIE)
+    else
+        LoadMonsterRoleEquipment(ROLE_ZOMBIE, radar)
+    end
+
+    if vampires_are_monsters then
+        RemoveMonsterRoleEquipment(ROLE_VAMPIRE)
+    else
+        LoadMonsterRoleEquipment(ROLE_VAMPIRE, radar)
+    end
 end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -103,6 +103,7 @@ CreateConVar("ttt_veteran_min_players", "0")
 -- Special traitor spawn probabilities
 CreateConVar("ttt_special_traitor_pct", 0.33)
 CreateConVar("ttt_special_traitor_chance", 0.5)
+CreateConVar("ttt_zombie_round_chance", 0.1)
 CreateConVar("ttt_hypnotist_enabled", 0)
 CreateConVar("ttt_hypnotist_spawn_weight", "1")
 CreateConVar("ttt_hypnotist_min_players", "0")
@@ -234,6 +235,7 @@ CreateConVar("ttt_killer_warn_all", "0")
 CreateConVar("ttt_killer_vision_enable", "1")
 
 CreateConVar("ttt_zombies_are_monsters", "0")
+CreateConVar("ttt_zombies_are_traitors", "0")
 CreateConVar("ttt_zombie_show_target_icon", "0")
 CreateConVar("ttt_zombie_damage_penalty", "0.5")
 CreateConVar("ttt_zombie_damage_reduction", "0")
@@ -296,6 +298,7 @@ CreateConVar("ttt_shop_hyp_sync", "0")
 CreateConVar("ttt_shop_imp_sync", "0")
 CreateConVar("ttt_shop_asn_sync", "0")
 CreateConVar("ttt_shop_vam_sync", "0")
+CreateConVar("ttt_shop_zom_sync", "0")
 CreateConVar("ttt_shop_mer_mode", "2")
 
 -- bem server convars
@@ -510,6 +513,7 @@ function GM:SyncGlobals()
     SetGlobalBool("ttt_shop_imp_sync", GetConVar("ttt_shop_imp_sync"):GetBool())
     SetGlobalBool("ttt_shop_asn_sync", GetConVar("ttt_shop_asn_sync"):GetBool())
     SetGlobalBool("ttt_shop_vam_sync", GetConVar("ttt_shop_vam_sync"):GetBool())
+    SetGlobalBool("ttt_shop_zom_sync", GetConVar("ttt_shop_zom_sync"):GetBool())
     SetGlobalInt("ttt_shop_mer_mode", GetConVar("ttt_shop_mer_mode"):GetInt())
 
     SetGlobalBool("ttt_phantom_killer_smoke", GetConVar("ttt_phantom_killer_smoke"):GetBool())
@@ -526,6 +530,7 @@ function GM:SyncGlobals()
     SetGlobalBool("ttt_killer_vision_enable", GetConVar("ttt_killer_vision_enable"):GetBool())
 
     SetGlobalBool("ttt_zombies_are_monsters", GetConVar("ttt_zombies_are_monsters"):GetBool())
+    SetGlobalBool("ttt_zombies_are_traitors", GetConVar("ttt_zombies_are_traitors"):GetBool())
     SetGlobalBool("ttt_zombie_show_target_icon", GetConVar("ttt_zombie_show_target_icon"):GetBool())
     SetGlobalBool("ttt_zombie_vision_enable", GetConVar("ttt_zombie_vision_enable"):GetBool())
 
@@ -1418,7 +1423,7 @@ function GM:TTTCheckForWin()
     for _, v in ipairs(player.GetAll()) do
         local zombifying = v:GetNWBool("IsZombifying", false)
         if (v:Alive() and v:IsTerror()) or zombifying then
-            if v:IsTraitorTeam() then
+            if v:IsTraitorTeam() or (TRAITOR_ROLES[ROLE_ZOMBIE] and zombifying) then
                 traitor_alive = true
             elseif v:IsMonsterTeam() or (MONSTER_ROLES[ROLE_ZOMBIE] and zombifying) then
                 monster_alive = true
@@ -1661,7 +1666,6 @@ function SelectRoles()
                     else
                         forcedMonsterCount = forcedMonsterCount + 1
                     end
-                    v:SetVampirePrime(true)
 
                 -- INNOCENT ROLES
                 elseif role == ROLE_DETECTIVE then
@@ -1718,10 +1722,11 @@ function SelectRoles()
                     if INDEPENDENT_ROLES[role] then
                         hasIndependent = true
                         forcedIndependentCount = forcedIndependentCount + 1
+                    elseif TRAITOR_ROLES[role] then
+                        forcedSpecialTraitorCount = forcedSpecialTraitorCount + 1
                     else
                         forcedMonsterCount = forcedMonsterCount + 1
                     end
-                    v:SetZombiePrime(true)
                 end
 
                 if role > ROLE_NONE and role < ROLE_MAX then
@@ -1773,50 +1778,58 @@ function SelectRoles()
         end
     end
 
-    -- pick special traitors
-    if max_special_traitor_count > 0 then
-        local specialTraitorRoles = {}
-        if not hasHypnotist and GetConVar("ttt_hypnotist_enabled"):GetBool() and choice_count >= GetConVar("ttt_hypnotist_min_players"):GetInt() then
-            for _ = 1, GetConVar("ttt_hypnotist_spawn_weight"):GetInt() do
-                table.insert(specialTraitorRoles, ROLE_HYPNOTIST)
-            end
+    if ((GetConVar("ttt_zombie_enabled"):GetBool() and math.random() <= GetConVar("ttt_zombie_round_chance"):GetFloat() and (forcedTraitorCount <= 0) and (forcedSpecialTraitorCount <= 0)) or hasZombie) and TRAITOR_ROLES[ROLE_ZOMBIE] then
+        -- This is a zombie round so all traitors become zombies
+        for _, v in pairs(traitors) do
+            v:SetRole(ROLE_ZOMBIE)
+            PrintRole(v, "zombie")
         end
-        if not hasImpersonator and GetConVar("ttt_impersonator_enabled"):GetBool() and choice_count >= GetConVar("ttt_impersonator_min_players"):GetInt() and detective_count > 0 and not deputy_only then
-            for _ = 1, GetConVar("ttt_impersonator_spawn_weight"):GetInt() do
-                table.insert(specialTraitorRoles, ROLE_IMPERSONATOR)
+    else
+        -- pick special traitors
+        if max_special_traitor_count > 0 then
+            local specialTraitorRoles = {}
+            if not hasHypnotist and GetConVar("ttt_hypnotist_enabled"):GetBool() and choice_count >= GetConVar("ttt_hypnotist_min_players"):GetInt() then
+                for _ = 1, GetConVar("ttt_hypnotist_spawn_weight"):GetInt() do
+                    table.insert(specialTraitorRoles, ROLE_HYPNOTIST)
+                end
             end
-        end
-        if not hasAssassin and GetConVar("ttt_assassin_enabled"):GetBool() and choice_count >= GetConVar("ttt_assassin_min_players"):GetInt() then
-            for _ = 1, GetConVar("ttt_assassin_spawn_weight"):GetInt() do
-                table.insert(specialTraitorRoles, ROLE_ASSASSIN)
+            if not hasImpersonator and GetConVar("ttt_impersonator_enabled"):GetBool() and choice_count >= GetConVar("ttt_impersonator_min_players"):GetInt() and detective_count > 0 and not deputy_only then
+                for _ = 1, GetConVar("ttt_impersonator_spawn_weight"):GetInt() do
+                    table.insert(specialTraitorRoles, ROLE_IMPERSONATOR)
+                end
             end
-        end
-        if not hasVampire and GetConVar("ttt_vampire_enabled"):GetBool() and choice_count >= GetConVar("ttt_vampire_min_players"):GetInt() and TRAITOR_ROLES[ROLE_VAMPIRE] then
-            for _ = 1, GetConVar("ttt_vampire_spawn_weight"):GetInt() do
-                table.insert(specialTraitorRoles, ROLE_VAMPIRE)
+            if not hasAssassin and GetConVar("ttt_assassin_enabled"):GetBool() and choice_count >= GetConVar("ttt_assassin_min_players"):GetInt() then
+                for _ = 1, GetConVar("ttt_assassin_spawn_weight"):GetInt() do
+                    table.insert(specialTraitorRoles, ROLE_ASSASSIN)
+                end
             end
-        end
-        for _ = 1, max_special_traitor_count do
-            if #specialTraitorRoles ~= 0 and math.random() <= GetConVar("ttt_special_traitor_chance"):GetFloat() and #traitors > 0 then
-                local plyPick = math.random(1, #traitors)
-                local ply = traitors[plyPick]
-                local rolePick = math.random(1, #specialTraitorRoles)
-                local role = specialTraitorRoles[rolePick]
-                ply:SetRole(role)
-                PrintRole(ply, ply:GetRoleString())
-                table.remove(traitors, plyPick)
-                for i = #specialTraitorRoles, 1, -1 do
-                    if specialTraitorRoles[i] == role then
-                        table.remove(specialTraitorRoles, i)
+            if not hasVampire and GetConVar("ttt_vampire_enabled"):GetBool() and choice_count >= GetConVar("ttt_vampire_min_players"):GetInt() and TRAITOR_ROLES[ROLE_VAMPIRE] then
+                for _ = 1, GetConVar("ttt_vampire_spawn_weight"):GetInt() do
+                    table.insert(specialTraitorRoles, ROLE_VAMPIRE)
+                end
+            end
+            for _ = 1, max_special_traitor_count do
+                if #specialTraitorRoles ~= 0 and math.random() <= GetConVar("ttt_special_traitor_chance"):GetFloat() and #traitors > 0 then
+                    local plyPick = math.random(1, #traitors)
+                    local ply = traitors[plyPick]
+                    local rolePick = math.random(1, #specialTraitorRoles)
+                    local role = specialTraitorRoles[rolePick]
+                    ply:SetRole(role)
+                    PrintRole(ply, ply:GetRoleString())
+                    table.remove(traitors, plyPick)
+                    for i = #specialTraitorRoles, 1, -1 do
+                        if specialTraitorRoles[i] == role then
+                            table.remove(specialTraitorRoles, i)
+                        end
                     end
                 end
             end
         end
-    end
 
-    -- Any of these left is a vanilla traitor
-    for _, v in pairs(traitors) do
-        PrintRole(v, "traitor")
+        -- Any of these left is a vanilla traitor
+        for _, v in pairs(traitors) do
+            PrintRole(v, "traitor")
+        end
     end
 
     -- pick independent

--- a/gamemodes/terrortown/gamemode/karma.lua
+++ b/gamemodes/terrortown/gamemode/karma.lua
@@ -157,7 +157,7 @@ function KARMA.Hurt(attacker, victim, dmginfo)
         if IsDebug() then
             print(Format("%s (%f) attacked %s (%f) for %d and got penalised for %f", attacker:Nick(), attacker:GetLiveKarma(), victim:Nick(), victim:GetLiveKarma(), hurt_amount, penalty))
         end
-    elseif victim:IsJesterTeam() then
+    elseif victim:IsJesterTeam() and not victim:GetNWBool("KillerClownActive", false) then
         -- Don't hurt a traitor's karma if killing a Jester doesn't end the round for them
         if GetConVar("ttt_jester_win_by_traitors"):GetBool() or not attacker:IsTraitorTeam() then
             local penalty = hurt_amount * config.jratio:GetFloat()
@@ -208,7 +208,7 @@ function KARMA.Killed(attacker, victim, dmginfo)
         if IsDebug() then
             print(Format("%s (%f) killed %s (%f) and gets penalised for %f", attacker:Nick(), attacker:GetLiveKarma(), victim:Nick(), victim:GetLiveKarma(), penalty))
         end
-    elseif victim:IsJesterTeam() then
+    elseif victim:IsJesterTeam() and not victim:GetNWBool("KillerClownActive", false) then
         -- Don't hurt a traitor's karma if killing a Jester doesn't end the round for them
         if GetConVar("ttt_jester_win_by_traitors"):GetBool() or not attacker:IsTraitorTeam() then
             local penalty = config.jpenalty:GetFloat()

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -977,7 +977,7 @@ L.info_popup_vampire = [[You are a Vampire! Work with your allies to kill all ot
 These are your comrades:
 {allylist}
 
-You can use your fangs (left-click) to drink blood from the living and the dead to refill your health or to fade from view (right-click).
+You can use your fangs (left-click) to drink blood and refill your health or to fade from view (right-click).
 
 Press {menukey} to receive your special equipment!]]
 
@@ -988,7 +988,7 @@ you does not seek the same goal.
 These are your comrades:
 {allylist}
 
-You can use your fangs (left-click) to drink blood from the living and the dead to refill your health or to fade from view (right-click).
+You can use your fangs (left-click) to drink blood and refill your health or to fade from view (right-click).
 
 Press {menukey} to receive your special equipment!]]
 
@@ -996,7 +996,7 @@ L.info_popup_vampire_alone = [[You are a Vampire! You have no allies this round.
 
 Kill all others to win!
 
-You can use your fangs (left-click) to drink blood from the living and the dead to refill your health or to fade from view (right-click).
+You can use your fangs (left-click) to drink blood and refill your health or to fade from view (right-click).
 
 Press {menukey} to receive your special equipment!]]
 

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -937,7 +937,7 @@ L.info_popup_zombie = [[You are a Zombie! Work with your allies to kill all othe
 These are your comrades:
 {allylist}
 
-All damage you deal with guns is reduced by one half.
+All damage you deal with guns is reduced.
 Killing someone with your claws will turn them into a zombie.
 
 Press {menukey} to receive your special equipment!]]
@@ -949,7 +949,7 @@ you does not seek the same goal.
 These are your comrades:
 {allylist}
 
-All damage you deal with guns is reduced by one half.
+All damage you deal with guns is reduced.
 Killing someone with your claws will turn them into a zombie.
 
 Press {menukey} to receive your special equipment!]]
@@ -958,7 +958,16 @@ L.info_popup_zombie_alone = [[You are a Zombie! You have no allies this round.
 
 Kill all others to win!
 
-All damage you deal with guns is reduced by one half.
+All damage you deal with guns is reduced.
+Killing someone with your claws will turn them into a zombie.
+
+Press {menukey} to receive your special equipment!]]
+
+L.info_popup_zombie_indep = [[You are a Zombie!
+
+Kill all others to win!
+
+All damage you deal with guns is reduced.
 Killing someone with your claws will turn them into a zombie.
 
 Press {menukey} to receive your special equipment!]]

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -616,7 +616,7 @@ local function CheckCreditAward(victim, attacker)
     local valid_attacker = IsValid(attacker) and attacker:IsPlayer()
 
     -- DETECTIVE AWARD
-    if valid_attacker and (victim:IsTraitorTeam() or victim:IsKiller()) then
+    if valid_attacker and (victim:IsTraitorTeam() or victim:IsMonsterTeam() or victim:IsKiller() or victim:IsZombie()) then
         local amt = GetConVarNumber("ttt_det_credits_traitordead") or 1
         for _, ply in ipairs(player.GetAll()) do
             if ply:IsActiveDetective() or (ply:IsActiveDeputy() and ply:GetNWBool("HasPromotion", false)) then
@@ -627,9 +627,8 @@ local function CheckCreditAward(victim, attacker)
         LANG.Msg(GetDetectiveFilter(true), "credit_det_all", { num = amt })
     end
 
-
     -- TRAITOR AWARD
-    if (not victim:IsTraitorTeam()) and (not GAMEMODE.AwardedCredits or GetConVar("ttt_credits_award_repeat"):GetBool()) then
+    if valid_attacker and not (victim:IsTraitorTeam() or victim:IsJesterTeam()) and (not GAMEMODE.AwardedCredits or GetConVar("ttt_credits_award_repeat"):GetBool()) then
         local inno_alive = 0
         local inno_dead = 0
         local inno_total = 0

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -939,8 +939,8 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
             local delay = GetConVar("ttt_assassin_next_target_delay"):GetFloat()
             -- Delay giving the next target if we're configured to do so
             if delay > 0 then
-                attacker:PrintMessage(HUD_PRINTCENTER, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.")
-                attacker:PrintMessage(HUD_PRINTTALK, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.")
+                v:PrintMessage(HUD_PRINTCENTER, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.")
+                v:PrintMessage(HUD_PRINTTALK, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.")
                 timer.Simple(delay, function()
                     AssignAssassinTarget(v, false, true)
                 end)

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -108,9 +108,10 @@ function GM:PlayerSpawn(ply)
 
     ply.has_spawned = true
 
-    -- Reset player color and transparency
+    -- Reset player color, transparency, and render mode
     ply:SetColor(Color(255, 255, 255, 255))
     ply:SetMaterial("models/glass")
+    ply:SetRenderMode(RENDERMODE_TRANSALPHA)
 
     -- let the client do things on spawn
     net.Start("TTT_PlayerSpawned")
@@ -1791,7 +1792,7 @@ local function HandleRoleForcedWeapons(ply)
         if ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_zom_claws" then
             ply:SetColor(Color(70, 100, 25, 255))
             ply:SetRenderMode(RENDERMODE_NORMAL)
-        else
+        elseif ply:GetRenderMode() ~= RENDERMODE_TRANSALPHA then
             ply:SetColor(Color(255, 255, 255, 255))
             ply:SetRenderMode(RENDERMODE_TRANSALPHA)
         end
@@ -1816,7 +1817,7 @@ local function HandleRoleForcedWeapons(ply)
         if not ply:HasWeapon("weapon_vam_fangs") then
             ply:Give("weapon_vam_fangs")
         end
-    else
+    elseif ply:GetRenderMode() ~= RENDERMODE_TRANSALPHA then
         ply:SetColor(Color(255, 255, 255, 255))
         ply:SetRenderMode(RENDERMODE_TRANSALPHA)
     end

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -108,6 +108,10 @@ function GM:PlayerSpawn(ply)
 
     ply.has_spawned = true
 
+    -- Reset player color and transparency
+    ply:SetColor(Color(255, 255, 255, 255))
+    ply:SetMaterial("models/glass")
+
     -- let the client do things on spawn
     net.Start("TTT_PlayerSpawned")
     net.WriteBit(ply:IsSpec())

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -330,6 +330,8 @@ function plymeta:SpawnForRound(dead_only)
     self:SetNWBool("Haunting", false)
     self:SetNWString("HauntingTarget", nil)
     self:SetNWInt("HauntingPower", 0)
+    -- Disable Killer smoke
+    self:SetNWBool("KillerSmoke", false)
     timer.Remove(self:Nick() .. "HauntingPower")
     timer.Remove(self:Nick() .. "HauntingSpectate")
     self:Spawn()

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -43,8 +43,10 @@ function plymeta:GetZombieAlly()
     local role = self:GetRole()
     if MONSTER_ROLES[ROLE_ZOMBIE] then
         return MONSTER_ROLES[role]
+    elseif TRAITOR_ROLES[ROLE_ZOMBIE] then
+        return TRAITOR_ROLES[role]
     end
-    return role == ROLE_ZOMBIE
+    return INDEPENDENT_ROLES[role]
 end
 function plymeta:GetVampireAlly()
     local role = self:GetRole()

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -574,8 +574,11 @@ end
 
 function UpdateDynamicTeams()
     local zombies_are_monsters = GetGlobalBool("ttt_zombies_are_monsters")
+    -- Zombies cannot be both Monsters and Traitors so don't make them Traitors if they are already Monsters
+    local zombies_are_traitors = not zombies_are_monsters and GetGlobalBool("ttt_zombies_are_traitors")
     MONSTER_ROLES[ROLE_ZOMBIE] = zombies_are_monsters
-    INDEPENDENT_ROLES[ROLE_ZOMBIE] = not zombies_are_monsters
+    TRAITOR_ROLES[ROLE_VAMPIRE] = zombies_are_traitors
+    INDEPENDENT_ROLES[ROLE_ZOMBIE] = not zombies_are_monsters and not zombies_are_traitors
 
     local vampires_are_monsters = GetGlobalBool("ttt_vampires_are_monsters")
     MONSTER_ROLES[ROLE_VAMPIRE] = vampires_are_monsters

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -573,14 +573,14 @@ function GetSprintMultiplier(ply, sprinting)
 end
 
 function UpdateDynamicTeams()
-    local zombies_are_monsters = GetGlobalBool("ttt_zombies_are_monsters")
+    local zombies_are_monsters = GetGlobalBool("ttt_zombies_are_monsters", false)
     -- Zombies cannot be both Monsters and Traitors so don't make them Traitors if they are already Monsters
-    local zombies_are_traitors = not zombies_are_monsters and GetGlobalBool("ttt_zombies_are_traitors")
+    local zombies_are_traitors = not zombies_are_monsters and GetGlobalBool("ttt_zombies_are_traitors", false)
     MONSTER_ROLES[ROLE_ZOMBIE] = zombies_are_monsters
-    TRAITOR_ROLES[ROLE_VAMPIRE] = zombies_are_traitors
+    TRAITOR_ROLES[ROLE_ZOMBIE] = zombies_are_traitors
     INDEPENDENT_ROLES[ROLE_ZOMBIE] = not zombies_are_monsters and not zombies_are_traitors
 
-    local vampires_are_monsters = GetGlobalBool("ttt_vampires_are_monsters")
+    local vampires_are_monsters = GetGlobalBool("ttt_vampires_are_monsters", false)
     MONSTER_ROLES[ROLE_VAMPIRE] = vampires_are_monsters
     TRAITOR_ROLES[ROLE_VAMPIRE] = not vampires_are_monsters
 

--- a/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -186,6 +186,7 @@ local function clear_role_effects(ply)
     if ply:HasWeapon("weapon_zom_claws") then
         ply:StripWeapon("weapon_zom_claws")
     end
+    ply:Give("weapon_zm_improvised")
     ply:SetDefaultCredits()
     ply:SetMaxHealth(100)
     ply:SetHealth(100)

--- a/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -174,6 +174,18 @@ local function clear_role_effects(ply)
     if ply:HasWeapon("weapon_ttt_bodysnatch") then
         ply:StripWeapon("weapon_ttt_bodysnatch")
     end
+    if ply:HasWeapon("weapon_kil_knife") then
+        ply:StripWeapon("weapon_kil_knife")
+    end
+    if ply:HasWeapon("weapon_kil_crowbar") then
+        ply:StripWeapon("weapon_kil_crowbar")
+    end
+    if ply:HasWeapon("weapon_vam_fangs") then
+        ply:StripWeapon("weapon_vam_fangs")
+    end
+    if ply:HasWeapon("weapon_zom_claws") then
+        ply:StripWeapon("weapon_zom_claws")
+    end
     ply:SetDefaultCredits()
     ply:SetMaxHealth(100)
     ply:SetHealth(100)
@@ -326,6 +338,9 @@ local function force_killer(ply)
     local max = GetConVar("ttt_killer_max_health"):GetInt()
     ply:SetMaxHealth(max)
     ply:SetHealth(max)
+    ply:StripWeapon("weapon_zm_improvised")
+    ply:Give("weapon_kil_crowbar")
+    ply:Give("weapon_kil_knife")
     SendFullStateUpdate()
 end
 concommand.Add("ttt_force_killer", force_killer, nil, nil, FCVAR_CHEAT)
@@ -333,6 +348,7 @@ concommand.Add("ttt_force_killer", force_killer, nil, nil, FCVAR_CHEAT)
 local function force_zombie(ply)
     ply:SetRoleAndBroadcast(ROLE_ZOMBIE)
     clear_role_effects(ply)
+    ply:Give("weapon_zom_claws")
     SendFullStateUpdate()
 end
 concommand.Add("ttt_force_zombie", force_zombie, nil, nil, FCVAR_CHEAT)
@@ -340,6 +356,7 @@ concommand.Add("ttt_force_zombie", force_zombie, nil, nil, FCVAR_CHEAT)
 local function force_vampire(ply)
     ply:SetRoleAndBroadcast(ROLE_VAMPIRE)
     clear_role_effects(ply)
+    ply:Give("weapon_vam_fangs")
     SendFullStateUpdate()
 end
 concommand.Add("ttt_force_vampire", force_vampire, nil, nil, FCVAR_CHEAT)

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -125,12 +125,10 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
         elseif showJester then
             return ROLE_JESTER
         end
-    elseif client:IsZombie() then
-        if ply:IsZombie() then
-            return ROLE_ZOMBIE
-        end
     elseif client:IsIndependentTeam() then
-        if showJester then
+        if ply:IsIndependentTeam() then
+            return ply:GetRole()
+        elseif showJester then
             return ROLE_JESTER
         end
     elseif client:IsMonsterTeam() then

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -368,7 +368,8 @@ local function OrderEquipment(ply, cmd, args)
     local sync_impersonator = GetGlobalBool("ttt_shop_imp_sync") and ply:IsImpersonator()
     local sync_assassin = GetGlobalBool("ttt_shop_asn_sync") and ply:IsAssassin()
     local sync_vampire = GetGlobalBool("ttt_shop_vam_sync") and ply:IsVampire() and TRAITOR_ROLES[ROLE_VAMPIRE]
-    local sync_traitor_weapons = sync_hypnotist or sync_impersonator or sync_assassin or sync_vampire
+    local sync_zombie = GetGlobalBool("ttt_shop_zom_sync") and ply:IsZombie() and TRAITOR_ROLES[ROLE_ZOMBIE]
+    local sync_traitor_weapons = sync_hypnotist or sync_impersonator or sync_assassin or sync_vampire or sync_zombie
     local promoted = ply:IsDetectiveLike() and role ~= ROLE_DETECTIVE
 
     -- If this role has a table of additional weapons and that table includes this weapon


### PR DESCRIPTION
- Updated Vampire round popup to remove "from the living and the dead" to cover the case where fang draining of the living is not enabled
- Renamed ttt_vampire_convert_enable to ttt_vampire_drain_enable to reflect it's actual functionality
- Added new ttt_vampire_convert_enable (disabled by default) to control whether converting is allowed
- Added missing WIN_ZOMBIE handling for EVENT_FINISH
- Added back ability for Zombies to be Traitors
- Added missing target labels for Independent Zombies
- Fixed Independent Zombie round start popup
- Fixed round summary colors not being updated if colors or roles change team
- Fixed Vampires getting stuck invisible if they are killed while invisible
- Fixed some role weapons not being removed when the force_* commands are used
- Fixed Killer smoke not being removed when a player is converted to Zombie or Vampire
- Fixed Detectives not getting credit rewards when Monsters or Independent Zombies are killed
- Optimized Zombie color handling for majority case

Changes unrelated to Monsters
- Fixed 1 extra pixel above role list in round summary
- Fixed players who killed Assassin targets getting the "Target eliminated" message instead of the Assassin themselves
- Fixed error that can happen when sprinting if a local player is initialized too slowly
- Fixed activated Killer Clown still being highlighted when traitor vision was enabled
- Fixed Traitors getting credit rewards for killing Jesters
- Fixed losing karma when killing the activated Killer Clown
- Changed ttt_force_* commands to give the player the default crowbar to handle classes that don't have it