### PR TITLE
Fixes and cleanup

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_doc_defib.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_doc_defib.lua
@@ -74,7 +74,7 @@ SWEP.WorldModel = "models/weapons/w_c4.mdl"
 SWEP.AutoSpawnable = false
 SWEP.NoSights = true
 
-local oldScoreGroup = oldScoreGroup or ScoreGroup
+local oldScoreGroup
 local DEFIB_IDLE = 0
 local DEFIB_BUSY = 1
 local DEFIB_ERROR = 2
@@ -117,11 +117,9 @@ if SERVER then
             local t = {
                 start = v,
                 endpos = v,
-                filter = target,
                 mins = midsize / -2,
                 maxs = midsize / 2
             }
-
             local tr = util.TraceHull(t)
 
             if not tr.Hit then return (v - Vector(0, 0, midsize.z / 2)) end
@@ -295,8 +293,7 @@ if CLIENT then
         for _, v in pairs(player.GetAll()) do v.DefibHide = nil end
     end)
 
-
-
+    oldScoreGroup = oldScoreGroup or ScoreGroup
     function ScoreGroup(ply)
         if ply.DefibHide then return GROUP_FOUND end
         return oldScoreGroup(ply)

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -63,12 +63,7 @@ function GetEquipmentForRole(role, promoted, block_randomization)
     WEPS.PrepWeaponsLists(role)
 
     -- Determine which role sync variable to use, if any
-    local rolemode = SHOP_SYNC_MODE_NONE
-    if role == ROLE_MERCENARY then
-        rolemode = GetGlobalInt("ttt_shop_mer_mode")
-    elseif role == ROLE_CLOWN then
-        rolemode = GetGlobalInt("ttt_shop_clo_mode")
-    end
+    local rolemode = GetGlobalInt("ttt_shop_" .. ROLE_STRINGS_SHORT[role] .. "_mode", SHOP_SYNC_MODE_NONE)
 
     -- Pre-load the Traitor weapons so that any that have their CanBuy modified will also apply to the enabled allied role(s)
     local sync_hypnotist = GetGlobalBool("ttt_shop_hyp_sync") and role == ROLE_HYPNOTIST
@@ -78,7 +73,7 @@ function GetEquipmentForRole(role, promoted, block_randomization)
     local sync_zombie = GetGlobalBool("ttt_shop_zom_sync") and role == ROLE_ZOMBIE and TRAITOR_ROLES[ROLE_ZOMBIE]
     local sync_traitor_weapons = sync_hypnotist or sync_impersonator or sync_assassin or sync_vampire or sync_zombie or
                                     (rolemode > SHOP_SYNC_MODE_NONE)
-  
+
     if sync_traitor_weapons and not Equipment[ROLE_TRAITOR] then
         GetEquipmentForRole(ROLE_TRAITOR, false, true)
     end
@@ -87,7 +82,7 @@ function GetEquipmentForRole(role, promoted, block_randomization)
     local sync_detective_like = (promoted and (role == ROLE_DEPUTY or role == ROLE_IMPERSONATOR))
     local sync_detective_weapons = sync_detective_like or
                                     (rolemode > SHOP_SYNC_MODE_NONE)
-  
+
     if sync_detective_weapons and not Equipment[ROLE_DETECTIVE] then
         GetEquipmentForRole(ROLE_DETECTIVE, false, true)
     end

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -64,8 +64,9 @@ end
 
 local function GetPlayerFromSteam64(id)
     -- The first bot's ID is 90071996842377216 which translates to "STEAM_0:0:0", an 11-character string
+    -- At some point it becomes double digits at the end (e.g. "STEAM_0:0:10") so we check for 12 or fewer characters
     -- A player's Steam ID cannot be that short, so if it is this must be a bot
-    local isBot = string.len(util.SteamIDFrom64(id)) == 11
+    local isBot = string.len(util.SteamIDFrom64(id)) <= 12
     -- Bots cannot be retrieved by SteamID on the client so search by name instead
     if isBot then
         for _, p in pairs(player.GetAll()) do

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -573,8 +573,8 @@ function CLSCORE:BuildSummaryPanel(dpanel)
                 if IsValid(ply) then
                     alive = ply:Alive()
                     finalRole = ply:GetRole()
-                    -- Keep the original role icon for people converted to Zombie and Vampire
-                    if finalRole ~= ROLE_ZOMBIE and finalRole ~= ROLE_VAMPIRE then
+                    -- Keep the original role icon for people converted to Zombie and Vampire or the Bodysnatcher
+                    if finalRole ~= ROLE_ZOMBIE and finalRole ~= ROLE_VAMPIRE and startingRole ~= ROLE_BODYSNATCHER then
                         roleFileName = ROLE_STRINGS_SHORT[finalRole]
                     end
                     roleColor = ROLE_COLORS[finalRole]

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1608,16 +1608,18 @@ function SelectRoles()
     local plys = player.GetAll()
 
     for _, v in ipairs(plys) do
-        -- everyone on the spec team is in specmode
-        if IsValid(v) and not v:IsSpec() then
-            -- save previous role and sign up as possible traitor/detective
-            local r = GAMEMODE.LastRole[v:SteamID64()] or v:GetRole() or ROLE_NONE
+        if IsValid(v) then
+            -- everyone on the spec team is in specmode
+            if not v:IsSpec() then
+                -- save previous role and sign up as a possible role
+                local r = GAMEMODE.LastRole[v:SteamID64()] or v:GetRole() or ROLE_NONE
 
-            table.insert(prev_roles[r], v)
-            table.insert(choices, v)
+                table.insert(prev_roles[r], v)
+                table.insert(choices, v)
+            end
+
+            v:SetRole(ROLE_NONE)
         end
-
-        v:SetRole(ROLE_NONE)
     end
 
     local choice_count = #choices
@@ -1667,14 +1669,15 @@ function SelectRoles()
     PrintRoleText("-----CHECKING EXTERNALLY CHOSEN ROLES-----")
     for _, v in pairs(player.GetAll()) do
         if IsValid(v) and (not v:IsSpec()) then
-            local index = 0
-            for i, j in pairs(choices) do
-                if v == j then
-                    index = i
-                end
-            end
             local role = v:GetRole()
             if role > ROLE_NONE and role <= ROLE_MAX then
+                local index = 0
+                for i, j in pairs(choices) do
+                    if v == j then
+                        index = i
+                    end
+                end
+
                 table.remove(choices, index)
                 -- TRAITOR ROLES
                 if role == ROLE_TRAITOR then
@@ -2029,6 +2032,11 @@ function SelectRoles()
     for _, ply in ipairs(plys) do
         -- initialize credit count for everyone based on their role
         if IsValid(ply) and not ply:IsSpec() then
+            if ply:GetRole() == ROLE_NONE then
+                ErrorNoHalt("WARNING: " .. ply:Nick() .. " was not assigned a role! Forcing them to be Innocent...\n")
+                ply:SetRole(ROLE_INNOCENT)
+            end
+
             if ply:GetRole() == ROLE_ZOMBIE then
                 ply:SetZombiePrime(true)
             elseif ply:GetRole() == ROLE_VAMPIRE then

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1611,7 +1611,7 @@ function SelectRoles()
         -- everyone on the spec team is in specmode
         if IsValid(v) and not v:IsSpec() then
             -- save previous role and sign up as possible traitor/detective
-            local r = GAMEMODE.LastRole[v:SteamID64()] or v:GetRole() or ROLE_INNOCENT
+            local r = GAMEMODE.LastRole[v:SteamID64()] or v:GetRole() or ROLE_NONE
 
             table.insert(prev_roles[r], v)
             table.insert(choices, v)
@@ -1674,7 +1674,7 @@ function SelectRoles()
                 end
             end
             local role = v:GetRole()
-            if role ~= ROLE_NONE then
+            if role > ROLE_NONE and role <= ROLE_MAX then
                 table.remove(choices, index)
                 -- TRAITOR ROLES
                 if role == ROLE_TRAITOR then
@@ -1723,11 +1723,9 @@ function SelectRoles()
                 elseif role == ROLE_VETERAN then
                     hasVeteran = true
                     forcedSpecialInnocentCount = forcedSpecialInnocentCount + 1
-                    PrintRole(v, "veteran")
                 elseif role == ROLE_DOCTOR then
                     hasDoctor = true
                     forcedSpecialInnocentCount = forcedSpecialInnocentCount + 1
-                    PrintRole(v, "doctor")
 
                 -- JESTER/INDEPENDENT ROLES
                 elseif role == ROLE_JESTER then
@@ -1766,9 +1764,7 @@ function SelectRoles()
                     end
                 end
 
-                if role > ROLE_NONE and role < ROLE_MAX then
-                    PrintRole(v, ROLE_STRINGS[role])
-                end
+                PrintRole(v, ROLE_STRINGS[role])
             end
         end
     end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1783,15 +1783,11 @@ function SelectRoles()
     -- pick detectives
     if choice_count >= GetConVar("ttt_detective_min_players"):GetInt() then
         local min_karma = GetConVar("ttt_detective_karma_min"):GetInt()
-        local function HasGoodKarma(ply)
-            return not KARMA.IsEnabled() or ply:GetBaseKarma() >= min_karma
-        end
-
         local options = {}
         local secondary_options = {}
         local tertiary_options = {}
         for _, p in ipairs(choices) do
-            if HasGoodKarma(p) then
+            if not KARMA.IsEnabled() or p:GetBaseKarma() >= min_karma then
                 if not p:GetAvoidDetective() then
                     table.insert(options, p)
                 end

--- a/gamemodes/terrortown/gamemode/scoring.lua
+++ b/gamemodes/terrortown/gamemode/scoring.lua
@@ -111,7 +111,7 @@ function SCORE:HandleSelection()
 end
 
 function SCORE:HandleBodyFound(finder, found)
-    self:AddEvent({ id = EVENT_BODYFOUND, ni = finder:Nick(), sid = finder:SteamID(), sid64 = finder:SteamID64(), b = found:Nick() })
+    self:AddEvent({ id = EVENT_BODYFOUND, ni = finder:Nick(), sid = finder:SteamID(), sid64 = finder:SteamID64(), b = found:Nick(), isd = finder:IsDetectiveLike() })
 end
 
 function SCORE:HandleC4Explosion(planter, arm_time, exp_time)

--- a/gamemodes/terrortown/gamemode/scoring_shd.lua
+++ b/gamemodes/terrortown/gamemode/scoring_shd.lua
@@ -59,10 +59,11 @@ function ScoreEvent(e, scores)
         end
     elseif e.id == EVENT_BODYFOUND then
         local sid = e.sid64
-        -- Unknown players and don't get points for finding bodies... because they probably created them
-        if scores[sid] == nil or TRAITOR_ROLES[scores[sid].role] then return end
+        -- Unknown players, traitors, and independents don't get points for finding bodies... because they probably created them
+        if scores[sid] == nil or TRAITOR_ROLES[scores[sid].role] or INDEPENDENT_ROLES[scores[sid].role] then return end
 
-        local find_bonus = scores[sid].role == ROLE_DETECTIVE and 3 or 1
+        -- Detective-like roles (who aren't traitors) get more of a bonus than innocents
+        local find_bonus = e.isd and 3 or 1
         scores[sid].bonus = scores[sid].bonus + find_bonus
     end
 end

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -395,12 +395,7 @@ local function OrderEquipment(ply, cmd, args)
         local allowed = GetEquipmentItem(role, id)
         -- Check for the syncing options
         if not allowed then
-            local rolemode = SHOP_SYNC_MODE_NONE
-            if ply:IsMercenary() then
-                rolemode = GetGlobalInt("ttt_shop_mer_mode")
-            elseif ply:IsClown() then
-                rolemode = GetGlobalInt("ttt_shop_clo_mode")
-            end
+            local rolemode = GetGlobalInt("ttt_shop_" .. ROLE_STRINGS_SHORT[role] .. "_mode", SHOP_SYNC_MODE_NONE)
             if rolemode > SHOP_SYNC_MODE_NONE then
                 -- Traitor OR Detective
                 if rolemode == SHOP_SYNC_MODE_UNION then

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -99,27 +99,16 @@ SHOP_SYNC_MODE_INTERSECT = 2
 SHOP_SYNC_MODE_DETECTIVE = 3
 SHOP_SYNC_MODE_TRAITOR = 4
 
-local mercmode = nil
-local clownmode = nil
+local rolemodes = {}
 function WEPS.HandleCanBuyOverrides(wep, role, block_randomization, sync_traitor_weapons, sync_detective_weapons)
     if wep == nil then return end
     local id = WEPS.GetClass(wep)
 
     -- Cache these the first time
-    if mercmode == nil then
-        mercmode = GetGlobalInt("ttt_shop_mer_mode")
+    if not rolemodes[role] then
+        rolemodes[role] = GetGlobalInt("ttt_shop_" .. ROLE_STRINGS_SHORT[role] .. "_mode", SHOP_SYNC_MODE_NONE)
     end
-    if clownmode == nil then
-        clownmode = GetGlobalInt("ttt_shop_clo_mode")
-    end
-
-    -- Determine which role sync variable to use, if any
-    local rolemode = SHOP_SYNC_MODE_NONE
-    if role == ROLE_MERCENARY then
-        rolemode = mercmode
-    elseif role == ROLE_CLOWN then
-        rolemode = clownmode
-    end
+    local rolemode = rolemodes[role]
 
     -- Handle the other overrides
     if wep.CanBuy then


### PR DESCRIPTION
Fixes
- Fixed some bots showing as disconnected in the round summary
- Fixed promoted Deputy not getting a score bonus matching the Detective when they identified a body
- Fixed Bodysnatcher not having their original role icon shown on the round summary
- Added ROLE_NONE sanity check to role selection
  - Forces role to ROLE_INNOCENT but logs a non-halting error in console to make it clear it's happening
- Fixed having multiple Detectives enabled causing some players to not get a role
- Fixed there not always being a Detective if players don't have good enough karma or they have "Avoid Detective" enabled

Cleanup
- Warning cleanup
- Cleanup role force messages
- Cleanup role selection logic to avoid errors
- Updated ttt_shop_*_mode to have dynamic usage