### PR TITLE
Option to target shop roles just before Detectives

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -109,7 +109,7 @@ ttt_assassin_target_damage_bonus            1       // Damage bonus that the ass
 ttt_assassin_wrong_damage_penalty           0.5     // Damage penalty that the assassin has when attacking someone who is not their target (e.g. 0.5 = 50% less damage)
 ttt_assassin_failed_damage_penalty          0.5     // Damage penalty that the assassin has after they have failed their contract by killing the wrong person (e.g. 0.5 = 50% less damage)
 ttt_assassin_credits_starting               1       // The number of credits an assassin should start with
-ttt_assassin_shop_roles_last                0       // Whether the assasin should target the shop roles right before Detective or not
+ttt_assassin_shop_roles_last                0       // Whether the assassin should target the shop roles right before Detective or not
 
 // Vampire
 ttt_vampires_are_monsters                   0       // Whether vampires should be treated as members of the Monster team.

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -109,6 +109,7 @@ ttt_assassin_target_damage_bonus            1       // Damage bonus that the ass
 ttt_assassin_wrong_damage_penalty           0.5     // Damage penalty that the assassin has when attacking someone who is not their target (e.g. 0.5 = 50% less damage)
 ttt_assassin_failed_damage_penalty          0.5     // Damage penalty that the assassin has after they have failed their contract by killing the wrong person (e.g. 0.5 = 50% less damage)
 ttt_assassin_credits_starting               1       // The number of credits an assassin should start with
+ttt_assassin_shop_roles_last                0       // Whether the assasin should target the shop roles right before Detective or not
 
 // Vampire
 ttt_vampires_are_monsters                   0       // Whether vampires should be treated as members of the Monster team.

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,5 +1,11 @@
 # Beta Release Notes
 
+## 1.0.5
+**Released:**
+
+### Additions
+- Added new Assassin target priority CVar
+
 ## 1.0.4
 **Released:**
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -112,6 +112,7 @@ CreateConVar("ttt_assassin_next_target_delay", "5")
 CreateConVar("ttt_assassin_target_damage_bonus", "1")
 CreateConVar("ttt_assassin_wrong_damage_penalty", "0.5")
 CreateConVar("ttt_assassin_failed_damage_penalty", "0.5")
+CreateConVar("ttt_assassin_shop_roles_last", "0")
 
 CreateConVar("ttt_vampires_are_monsters", "0")
 CreateConVar("ttt_vampire_show_target_icon", "0")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -700,6 +700,7 @@ if SERVER then
         ply:SetNWString("AssassinTarget", "")
 
         local enemies = {}
+        local shops = {}
         local detectives = {}
         local independents = {}
         for _, p in pairs(player.GetAll()) do
@@ -710,7 +711,12 @@ if SERVER then
                 elseif (INNOCENT_ROLES[p:GetRole()] or MONSTER_ROLES[p:GetRole()]) and not p:IsGlitch() then
                     -- Don't add the former beggar to the list of enemies unless the "reveal" setting is enabled
                     if GetConVar("ttt_beggar_reveal_change"):GetBool() or not p:GetNWBool("WasBeggar", false) then
-                        table.insert(enemies, p:Nick())
+                        -- Put shop roles into a list if they should be targeted last
+                        if GetConVar("ttt_assassin_shop_roles_last").GetBool() and SHOP_ROLES[p:GetRole()] then
+                            table.insert(shops, p:Nick())
+                        else
+                            table.insert(enemies, p:Nick())
+                        end
                     end
                 -- Exclude the Old Man because they just want to survive
                 elseif INDEPENDENT_ROLES[p:GetRole()] and not p:IsOldMan() then
@@ -722,6 +728,8 @@ if SERVER then
         local target = nil
         if #enemies > 0 then
             target = enemies[math.random(#enemies)]
+        elseif #shops > 0 then
+            target = enemies[math.random(#shops)]
         elseif #detectives > 0 then
             target = detectives[math.random(#detectives)]
         elseif #independents > 0 then

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.0.4"
+CR_VERSION = "1.0.5"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")


### PR DESCRIPTION
Added the option for shop roles to be targeted right before Detectives by the Assassin