### PR TITLE
Bug fixes

### DIFF
--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -6,6 +6,9 @@
 ### Fixes
 - Fixed detective showing deputy icon when ttt_deputy_use_detective_icon is enabled
 - Fixed scoreboard icons not obeying ttt_deputy_use_detective_icon and ttt_impersonator_use_detective_icon
+- Fixed error trying to assign an assassin target preventing rounds from starting when there was an assassin
+- Fixed potential error picking an assassin target when ttt_assassin_shop_roles_last was enabled
+- Fixed "next"/"final" label sometimes being incorrect for an assassin getting their next target if ttt_assassin_shop_roles_last was enabled
 
 ## 1.0.5
 **Released: July 19th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,5 +1,11 @@
 # Beta Release Notes
 
+## 1.0.6
+**Released:**
+
+### Fixes
+- Fixed detective showing deputy icon when ttt_deputy_use_detective_icon is enabled
+
 ## 1.0.5
 **Released: July 19th, 2021**
 

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed detective showing deputy icon when ttt_deputy_use_detective_icon is enabled
+- Fixed scoreboard icons not obeying ttt_deputy_use_detective_icon and ttt_impersonator_use_detective_icon
 
 ## 1.0.5
 **Released: July 19th, 2021**

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -112,7 +112,9 @@ function GM:PostDrawTranslucentRenderables()
                 render.SetMaterial(indicator_mat_rolefront_noz)
                 render.DrawQuadEasy(pos, dir, 8, 8, COLOR_WHITE, 180)
             else
-                if v:GetDetectiveLike() and not (v:GetImpersonator() and client:IsTraitorTeam()) then
+                if v:GetDetective() then
+                    DrawRoleIcon(ROLE_DETECTIVE, false, pos, dir)
+                elseif v:GetDetectiveLike() and not (v:GetImpersonator() and client:IsTraitorTeam()) then
                     DrawRoleIcon(GetDetectiveIconRole(false), false, pos, dir)
                 elseif v:GetClown() and v:GetNWBool("KillerClownActive", false) and not GetGlobalBool("ttt_clown_hide_when_active", false) then
                     DrawRoleIcon(ROLE_CLOWN, false, pos, dir)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.0.5"
+CR_VERSION = "1.0.6"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -733,7 +733,7 @@ if SERVER then
                     -- Don't add the former beggar to the list of enemies unless the "reveal" setting is enabled
                     if GetConVar("ttt_beggar_reveal_change"):GetBool() or not p:GetNWBool("WasBeggar", false) then
                         -- Put shop roles into a list if they should be targeted last
-                        if GetConVar("ttt_assassin_shop_roles_last").GetBool() and SHOP_ROLES[p:GetRole()] then
+                        if GetConVar("ttt_assassin_shop_roles_last"):GetBool() and SHOP_ROLES[p:GetRole()] then
                             table.insert(shops, p:Nick())
                         else
                             table.insert(enemies, p:Nick())
@@ -750,7 +750,7 @@ if SERVER then
         if #enemies > 0 then
             target = enemies[math.random(#enemies)]
         elseif #shops > 0 then
-            target = enemies[math.random(#shops)]
+            target = shops[math.random(#shops)]
         elseif #detectives > 0 then
             target = detectives[math.random(#detectives)]
         elseif #independents > 0 then
@@ -761,7 +761,7 @@ if SERVER then
         if target ~= nil then
             ply:SetNWString("AssassinTarget", target)
 
-            local targets = #enemies + #detectives + #independents
+            local targets = #enemies + #shops + #detectives + #independents
             local targetCount
             if targets > 1 then
                 targetCount = start and "first" or "next"

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -182,15 +182,28 @@ function PANEL:Paint(width, height)
         c = defaultcolor
     end
 
+    local client = LocalPlayer()
     local roleStr = ""
     if c ~= defaultcolor then
-        -- If the impersonator is promoted, use the Detective's icon with the Impersonator's color
-        if ply:IsImpersonator() and ply:GetNWBool("HasPromotion", false) then
-            roleStr = ROLE_STRINGS_SHORT[ROLE_DETECTIVE]
-        else
-            roleStr = ROLE_STRINGS_SHORT[c]
-        end
+        local role = c
         c = ROLE_COLORS_SCOREBOARD[c]
+        -- Swap the icon depending on which settings are enabled
+        if ply:GetDetectiveLike() then
+            if client:IsTraitorTeam() and ply:IsImpersonator() then
+                if GetGlobalBool("ttt_impersonator_use_detective_icon", false) then
+                    role = ROLE_DETECTIVE
+                else
+                    role = ROLE_IMPERSONATOR
+                end
+            elseif GetGlobalBool("ttt_deputy_use_detective_icon", false) then
+                role = ROLE_DETECTIVE
+            else
+                role = ROLE_DEPUTY
+                c = ROLE_COLORS_SCOREBOARD[role]
+            end
+        end
+
+        roleStr = ROLE_STRINGS_SHORT[role]
     end
 
     surface.SetDrawColor(c)
@@ -203,7 +216,6 @@ function PANEL:Paint(width, height)
         self.sresult:SetVisible(false)
     end
 
-    local client = LocalPlayer()
     if GetRoundState() >= ROUND_ACTIVE then
         if client:IsRevenger() and ply:SteamID64() == client:GetNWString("RevengerLover", "") then
             DrawFlashingBorder(width, ROLE_REVENGER)


### PR DESCRIPTION
**Fixes**
- Fixed detective showing deputy icon when ttt_deputy_use_detective_icon is enabled
- Fixed scoreboard icons not obeying ttt_deputy_use_detective_icon and ttt_impersonator_use_detective_icon
- Fixed error trying to assign an assassin target preventing rounds from starting when there was an assassin
- Fixed potential error picking an assassin target when ttt_assassin_shop_roles_last was enabled
- Fixed "next"/"final" label sometimes being incorrect for an assassin getting their next target if ttt_assassin_shop_roles_last was enabled