### PR TITLE
ConVar Additions and bug fixes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -8,6 +8,8 @@ Add the following to your server.cfg (for dedicated servers) or listenserver.cfg
 // ----------------------------------------
 
 // ROLE SPAWN REQUIREMENTS
+ttt_traitor_pct                             0.25    // Percentage of players, rounded up, that can spawn as a traitor or "special traitor"
+ttt_detective_pct                           0.13    // Percentage of players, rounded up, that can spawn as a detective
 ttt_special_traitor_pct                     0.33    // Percentage of traitors, rounded up, that can spawn as a "special traitor" (e.g. hypnotist, impersonator, etc.)
 ttt_special_traitor_chance                  0.5     // The chance that a "special traitor" will spawn in each available slot made by "ttt_special_traitor_pct"
 ttt_special_innocent_pct                    0.33    // Percentage of innocents, rounded up, that can spawn as a "special innocent" (e.g. glitch, phantom, etc.)

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -186,6 +186,9 @@ ttt_doctor_credits_starting                 0       // How many credits the doct
 
 // JESTER TEAM SETTINGS
 ttt_jesters_trigger_traitor_testers         1       // Whether jesters trigger traitor testers as if they were traitors
+ttt_jesters_visible_to_traitors             1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to members of the traitor team
+ttt_jesters_visible_to_monsters             1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to members of the monster team
+ttt_jesters_visible_to_independents         1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to independent players
 
 // Jester
 ttt_jester_win_by_traitors                  1       // Whether the jester will win the round if they are killed by a traitor

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -141,7 +141,7 @@ ttt_parasite_infection_time                 90      // The time it takes in seco
 ttt_parasite_respawn_mode                   0       // The way in which the parasite respawns. 0 - Take over host. 1 - Respawn at the parasite's body. 2 - Respawn at a random location.
 ttt_parasite_respawn_health                 100     // The health on which the parasite respawns
 ttt_parasite_announce_infection             0       // Whether players are notified when they are infected with the parasite
-ttt_parasite_cure_mode                      1       // How to handle using a parasite cure on someone who is not infected. 0 = Kill nobody (But use up the cure), 1 = Kill the person who uses the cure, 2 = Kill the person the cure is used on
+ttt_parasite_cure_mode                      2       // How to handle using a parasite cure on someone who is not infected. 0 = Kill nobody (But use up the cure), 1 = Kill the person who uses the cure, 2 = Kill the person the cure is used on
 ttt_parasite_credits_starting               1       // The number of credits a parasite should start with
 
 // ----------------------------------------

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -309,16 +309,34 @@ ttt_clown_shop_random_enabled               0       // Whether role shop randomi
 ttt_quack_shop_random_enabled               0       // Whether role shop randomization is enabled for quacks
 ttt_parasite_shop_random_enabled            0       // Whether role shop randomization is enabled for parasites
 
-// Role Sync (Server or round must be restarted for changes to take effect)
-ttt_mercenary_shop_mode                     2       // What items are available to the mercenary in the shop (0=None, 1=Either detective OR traitor (aka Union), 2=Both detective AND traitor (aka Intersect), 3=Just detective, 4=Just traitor)
-ttt_clown_shop_mode                         0       // What items are available to the clown in the shop (0=None, 1=Either detective OR traitor (aka Union), 2=Both detective AND traitor (aka Intersect), 3=Just detective, 4=Just traitor)
-ttt_hypnotist_shop_sync                     0       // Whether Hypnotists should have all weapons that vanilla Traitors have in their weapon shop
-ttt_impersonator_shop_sync                  0       // Whether Impersonators should have all weapons that vanilla Traitors have in their weapon shop
-ttt_assassin_shop_sync                      0       // Whether Assassins should have all weapons that vanilla Traitors have in their weapon shop
-ttt_vampire_shop_sync                       0       // Whether Vampires should have all weapons that vanilla Traitors have in their weapon shop (if they are a Traitor)
-ttt_zombie_shop_sync                        0       // Whether Zombies should have all weapons that vanilla Traitors have in their weapon shop (if they are a Traitor)
-ttt_quack_shop_sync                         0       // Whether Quacks should have all weapons that vanilla Traitors have in their weapon shop
-ttt_parasite_shop_sync                      0       // Whether Parasites should have all weapons that vanilla Traitors have in their weapon shop
+// Role Shop Mode (Server or round must be restarted for changes to take effect)
+// Mode explanation:
+// 0 (Disable) - No additional weapons
+// 1 (Union) - All weapons available to EITHER the traitor or the detective
+// 2 (Intersect) - Only weapons available to BOTH the traitor and the detective
+// 3 (Detective) - All weapons available to the detective
+// 4 (Traitor) - All weapons available to the traitor
+
+// Examples:
+// Assuming the detective can buy "radar" and the "juggernaut suit" and the traitor can buy "radar" and the "banana bomb"
+// Then the modes would produce the following results:
+// 0 (Disable) - No additional weapons
+// 1 (Union) - "radar", "juggernaut suit", and "banana bomb"
+// 2 (Intersect) - "radar"
+// 3 (Detective) - "radar" and "juggernaut suit"
+// 4 (Traitor) - "radar" and "banana bomb"
+
+ttt_mercenary_shop_mode                     2       // What additional items are available to the mercenary in the shop (See above for possible values)
+ttt_clown_shop_mode                         0       // What additional items are available to the clown in the shop (See above for possible values)
+
+// Traitor Role Shop Sync (Server or round must be restarted for changes to take effect)
+ttt_hypnotist_shop_sync                     0       // Whether Hypnotists should have all weapons that vanilla traitors have in their weapon shop
+ttt_impersonator_shop_sync                  0       // Whether Impersonators should have all weapons that vanilla traitors have in their weapon shop
+ttt_assassin_shop_sync                      0       // Whether Assassins should have all weapons that vanilla traitors have in their weapon shop
+ttt_vampire_shop_sync                       0       // Whether Vampires should have all weapons that vanilla traitors have in their weapon shop (if they are a Traitor)
+ttt_zombie_shop_sync                        0       // Whether Zombies should have all weapons that vanilla traitors have in their weapon shop (if they are a Traitor)
+ttt_quack_shop_sync                         0       // Whether Quacks should have all weapons that vanilla traitors have in their weapon shop
+ttt_parasite_shop_sync                      0       // Whether Parasites should have all weapons that vanilla traitors have in their weapon shop
 
 // ----------------------------------------
 

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -8,6 +8,8 @@ Add the following to your server.cfg (for dedicated servers) or listenserver.cfg
 // ----------------------------------------
 
 // ROLE SPAWN REQUIREMENTS
+ttt_traitor_pct                             0.25    // Percentage of players, rounded up, that can spawn as a traitor or "special traitor"
+ttt_detective_pct                           0.13    // Percentage of players, rounded up, that can spawn as a detective
 ttt_special_traitor_pct                     0.33    // Percentage of traitors, rounded up, that can spawn as a "special traitor" (e.g. hypnotist, impersonator, etc.)
 ttt_special_traitor_chance                  0.5     // The chance that a "special traitor" will spawn in each available slot made by "ttt_special_traitor_pct"
 ttt_special_innocent_pct                    0.33    // Percentage of innocents, rounded up, that can spawn as a "special innocent" (e.g. glitch, phantom, etc.)

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -179,6 +179,8 @@ ttt_mercenary_credits_starting              1       // The number of credits a m
 // Veteran
 ttt_veteran_damage_bonus                    0.5     // Damage bonus that the veteran has when they are the last innocent alive (e.g. 0.5 = 50% more damage)
 ttt_veteran_full_heal                       1       // Whether the veteran gets a full heal upon becoming the last remaining innocent or not
+ttt_veteran_heal_bonus                      0       // The amount of bonus health to give the veteran when they are healed as the last remaining innocent
+ttt_veteran_announce                        0       // Whether to announce to all other living players when the veteran is the last remaining innocent
 
 // Doctor
 ttt_doctor_mode                             0       // What tool the doctor starts with (0=Health Station, 1=Defib then Health Station)

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -182,7 +182,6 @@ ttt_veteran_full_heal                       1       // Whether the veteran gets 
 
 // Doctor
 ttt_doctor_mode                             0       // What tool the doctor starts with (0=Health Station, 1=Defib then Health Station)
-ttt_doctor_credits_starting                 0       // How many credits the doctor starts with
 
 // ----------------------------------------
 

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -216,6 +216,7 @@ ttt_clown_activation_credits                0       // The number of credits to 
 ttt_clown_hide_when_active                  0       // Whether the clown should be hidden from other players' Target ID (overhead icons) when they are activated. Server or round must be restarted for changes to take effect
 ttt_clown_show_target_icon                  0       // Whether the clown has an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect
 ttt_clown_heal_on_activate                  0       // Whether the clown should fully heal when they activate or not
+ttt_clown_shop_active_only                  1       // Whether the clown's shop should be available only after they activate
 ttt_clown_credits_starting                  0       // The number of credits a clown should start with
 
 // Beggar

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -141,6 +141,7 @@ ttt_parasite_infection_time                 90      // The time it takes in seco
 ttt_parasite_respawn_mode                   0       // The way in which the parasite respawns. 0 - Take over host. 1 - Respawn at the parasite's body. 2 - Respawn at a random location.
 ttt_parasite_respawn_health                 100     // The health on which the parasite respawns
 ttt_parasite_announce_infection             0       // Whether players are notified when they are infected with the parasite
+ttt_parasite_cure_mode                      1       // How to handle using a parasite cure on someone who is not infected. 0 = Kill nobody (But use up the cure), 1 = Kill the person who uses the cure, 2 = Kill the person the cure is used on
 ttt_parasite_credits_starting               1       // The number of credits a parasite should start with
 
 // ----------------------------------------

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -18,6 +18,8 @@
 - Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)
 - Added ability to give the veteran a health bonus (in addition to the heal) when they are activated
 - Added ability to notify other remaining players when a veteran is activated
+- Added convar to control what happens when a parasite cure is used on someone who is not infected
+  - NOTE: By default, parasite cure will now kill the owner if it is used on someone who is not infected. This was done to avoid the use of the parasite cure as a one-shot kill weapon.
 
 ## 1.0.6
 **Released: July 20th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -21,6 +21,7 @@
 - Added ability to give the veteran a health bonus (in addition to the heal) when they are activated
 - Added ability to notify other remaining players when a veteran is activated
 - Added convar to control what happens when a parasite cure is used on someone who is not infected
+- Added ability for the clown to always have access to their shop via a new convar
 
 ### Developer
 - Added the ability for SWEPs to not be randomized out of the shop by setting "SWEP.BlockShopRandomization = true"

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -15,6 +15,8 @@
 
 ### Additions
 - Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)
+- Added ability to give the veteran a health bonus (in addition to the heal) when they are activated
+- Added ability to notify other remaining players when a veteran is activated
 
 ## 1.0.6
 **Released: July 20th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -13,13 +13,13 @@
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
 - Changed end-of-round summary to automatically add a row if there are both independents and jesters in a round (via something like a Randomat event)
+- Changed parasite cure to have a 3-second charge time to prevent it from being used as an instant-kill weapon
 
 ### Additions
 - Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)
 - Added ability to give the veteran a health bonus (in addition to the heal) when they are activated
 - Added ability to notify other remaining players when a veteran is activated
 - Added convar to control what happens when a parasite cure is used on someone who is not infected
-  - NOTE: By default, parasite cure will now kill the owner if it is used on someone who is not infected. This was done to avoid the use of the parasite cure as a one-shot kill weapon.
 
 ## 1.0.6
 **Released: July 20th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed team player count calculations not always being accurate by truncating the "_pct" convars to 3 digits to work around floating point inaccuracy
+- Fixed assassin not getting a target because they were treated as having a failed contract by default
 
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -3,6 +3,9 @@
 ## 1.0.7
 **Released:**
 
+### Fixes
+- Fixed team player count calculations not always being accurate by truncating the "_pct" convars to 3 digits to work around floating point inaccuracy
+
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
 

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -14,12 +14,16 @@
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
 - Changed end-of-round summary to automatically add a row if there are both independents and jesters in a round (via something like a Randomat event)
 - Changed parasite cure to have a 3-second charge time to prevent it from being used as an instant-kill weapon
+- Changed parasite cure to never be removed if shop randomization is enabled
 
 ### Additions
 - Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)
 - Added ability to give the veteran a health bonus (in addition to the heal) when they are activated
 - Added ability to notify other remaining players when a veteran is activated
 - Added convar to control what happens when a parasite cure is used on someone who is not infected
+
+### Developer
+- Added the ability for SWEPs to not be randomized out of the shop by setting "SWEP.BlockShopRandomization = true"
 
 ## 1.0.6
 **Released: July 20th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -11,6 +11,7 @@
 
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
+- Changed end-of-round summary to automatically add a row if there are both independents and jesters in a round (via something like a Randomat event)
 
 ### Additions
 - Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -7,6 +7,7 @@
 - Fixed team player count calculations not always being accurate by truncating the "_pct" convars to 3 digits to work around floating point inaccuracy
 - Fixed assassin not getting a target because they were treated as having a failed contract by default
 - Fixed missing ttt_clown_shop_mode
+- Fixed weapons added to detective or traitor via the roleweapons system not being buyable by roles using the shop mode convars
 
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -6,6 +6,7 @@
 ### Fixes
 - Fixed team player count calculations not always being accurate by truncating the "_pct" convars to 3 digits to work around floating point inaccuracy
 - Fixed assassin not getting a target because they were treated as having a failed contract by default
+- Fixed missing ttt_clown_shop_mode
 
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -8,6 +8,7 @@
 - Fixed assassin not getting a target sometimes because they were treated as having a failed contract by default
 - Fixed missing ttt_clown_shop_mode
 - Fixed weapons added to detective or traitor via the roleweapons system not being buyable by roles using the shop mode convars
+- Fixed old man not also winning when a map declares a winning team
 
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -5,7 +5,7 @@
 
 ### Fixes
 - Fixed team player count calculations not always being accurate by truncating the "_pct" convars to 3 digits to work around floating point inaccuracy
-- Fixed assassin not getting a target because they were treated as having a failed contract by default
+- Fixed assassin not getting a target sometimes because they were treated as having a failed contract by default
 - Fixed missing ttt_clown_shop_mode
 - Fixed weapons added to detective or traitor via the roleweapons system not being buyable by roles using the shop mode convars
 

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -6,6 +6,9 @@
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
 
+### Additions
+- Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)
+
 ## 1.0.6
 **Released: July 20th, 2021**
 

--- a/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
@@ -42,6 +42,7 @@ SWEP.HoldType = "slam"
 
 SWEP.UseHands = true
 SWEP.ViewModelFlip = false
+SWEP.BlockShopRandomization = true
 
 PARASITE_CURE_KILL_NONE = 0
 PARASITE_CURE_KILL_OWNER = 1

--- a/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
@@ -38,6 +38,7 @@ SWEP.Kind = WEAPON_EQUIP
 SWEP.CanBuy = { ROLE_DETECTIVE }
 SWEP.CanBuyDefault = { ROLE_DETECTIVE }
 SWEP.NoSights = true
+SWEP.HoldType = "slam"
 
 SWEP.UseHands = true
 SWEP.ViewModelFlip = false
@@ -46,90 +47,200 @@ PARASITE_CURE_KILL_NONE = 0
 PARASITE_CURE_KILL_OWNER = 1
 PARASITE_CURE_KILL_TARGET = 2
 
-local CureMode = CreateConVar("ttt_parasite_cure_mode", "1")
-local CureSound = Sound("items/smallmedkit1.wav")
+local DEFIB_IDLE = 0
+local DEFIB_BUSY = 1
+local DEFIB_ERROR = 2
 
-function SWEP:Initialize()
-    self:SetWeaponHoldType("slam")
-end
+local CureMode = CreateConVar("ttt_parasite_cure_mode", "2")
 
-function SWEP:PrimaryAttack()
+local charge = 3
 
-    if not SERVER then return end
-
-    local owner = self:GetOwner()
-    local tr = util.TraceLine({
-        start = owner:GetShootPos(),
-        endpos = owner:GetShootPos() + owner:GetAimVector() * 64,
-        filter = owner
-    })
-
-    local ent = tr.Entity
-    if IsValid(ent) and ent:IsPlayer() then
-        ent:EmitSound(CureSound)
-
-        if ent:GetNWBool("Infected", false) then
-            for _, v in pairs(player.GetAll()) do
-                if v:GetNWString("InfectingTarget", "") == ent:SteamID64() then
-                    ent:SetNWBool("Infected", false)
-                    v:SetNWBool("Infecting", false)
-                    v:SetNWString("InfectingTarget", nil)
-                    v:SetNWInt("InfectionProgress", 0)
-                    timer.Remove(v:Nick() .. "InfectionProgress")
-                    timer.Remove(v:Nick() .. "InfectingSpectate")
-                    v:PrintMessage(HUD_PRINTCENTER, "Your host has been cured.")
-                end
-            end
-        else
-            local cureMode = CureMode:GetInt()
-            if cureMode == PARASITE_CURE_KILL_OWNER and IsValid(owner) then
-                owner:Kill()
-            elseif cureMode == PARASITE_CURE_KILL_TARGET then
-                ent:Kill()
-            end
-        end
-
-        self:Remove()
-    else
-        self:SetNextPrimaryFire(CurTime() + 1)
-    end
-end
-
-function SWEP:SecondaryAttack()
-
-    if not SERVER then return end
-
-    local owner = self:GetOwner()
-
-    if IsValid(owner) and owner:IsPlayer() then
-        owner:EmitSound(CureSound)
-
-        if owner:GetNWBool("Infected", false) then
-            for _, v in pairs(player.GetAll()) do
-                if v:GetNWString("InfectingTarget", "") == owner:SteamID64() then
-                    owner:SetNWBool("Infected", false)
-                    v:SetNWBool("Infecting", false)
-                    v:SetNWString("InfectingTarget", nil)
-                    v:SetNWInt("InfectionProgress", 0)
-                    timer.Remove(v:Nick() .. "InfectionProgress")
-                    timer.Remove(v:Nick() .. "InfectingSpectate")
-                    v:PrintMessage(HUD_PRINTCENTER, "Your host has been cured.")
-                end
-            end
-        else
-            owner:Kill()
-        end
-
-        self:Remove()
-    else
-        self:SetNextSecondaryFire(CurTime() + 1)
-    end
-end
+local beep = Sound("buttons/button17.wav")
+local hum = Sound("items/nvg_on.wav")
+local cured = Sound("items/smallmedkit1.wav")
 
 if CLIENT then
     function SWEP:Initialize()
         self:AddHUDHelp("cure_help_pri", "cure_help_sec", true)
-
+        self:SetHoldType(self.HoldType)
         return self.BaseClass.Initialize(self)
     end
 end
+
+function SWEP:SetupDataTables()
+    self:NetworkVar("Int", 0, "State")
+    self:NetworkVar("Float", 1, "Begin")
+    self:NetworkVar("String", 0, "Message")
+end
+
+if SERVER then
+    function SWEP:Reset()
+        self:SetState(DEFIB_IDLE)
+        self:SetBegin(-1)
+        self:SetMessage('')
+        self.Target = nil
+    end
+
+    function SWEP:Error(msg)
+        self:SetState(DEFIB_ERROR)
+        self:SetBegin(CurTime())
+        self:SetMessage(msg)
+
+        self:GetOwner():EmitSound(beep, 60, 50, 1)
+        self.Target = nil
+
+        timer.Simple(3 * 0.75, function()
+            if IsValid(self) then self:Reset() end
+        end)
+    end
+
+    function SWEP:DoCure(ply)
+        local owner = self:GetOwner()
+        if IsValid(ply) and ply:IsPlayer() then
+            ply:EmitSound(cured)
+
+            if ply:GetNWBool("Infected", false) then
+                for _, v in pairs(player.GetAll()) do
+                    if v:GetNWString("InfectingTarget", "") == ply:SteamID64() then
+                        ply:SetNWBool("Infected", false)
+                        v:SetNWBool("Infecting", false)
+                        v:SetNWString("InfectingTarget", nil)
+                        v:SetNWInt("InfectionProgress", 0)
+                        timer.Remove(v:Nick() .. "InfectionProgress")
+                        timer.Remove(v:Nick() .. "InfectingSpectate")
+                        v:PrintMessage(HUD_PRINTCENTER, "Your host has been cured.")
+                    end
+                end
+            else
+                local cureMode = CureMode:GetInt()
+                if cureMode == PARASITE_CURE_KILL_OWNER and IsValid(owner) then
+                    owner:Kill()
+                elseif cureMode == PARASITE_CURE_KILL_TARGET then
+                    ply:Kill()
+                end
+            end
+
+            self:Remove()
+        else
+            if ply == owner then
+                self:SetNextPrimaryFire(CurTime() + 1)
+            else
+                self:SetNextSecondaryFire(CurTime() + 1)
+            end
+        end
+    end
+
+    function SWEP:Begin(ply)
+        if not ply or not IsValid(ply) or not ply:IsPlayer() then
+            self:Error("INVALID TARGET")
+            return
+        end
+
+        self:SetState(DEFIB_BUSY)
+        self:SetBegin(CurTime())
+        if ply == self:GetOwner() then
+            self:SetMessage("CURING YOURSELF")
+        else
+            self:SetMessage("CURING " .. string.upper(ply:Nick()))
+        end
+
+        self:GetOwner():EmitSound(hum, 75, math.random(98, 102), 1)
+
+        self.Target = ply
+    end
+
+    function SWEP:Think()
+        if self:GetState() == DEFIB_BUSY then
+            local owner = self:GetOwner()
+            if self:GetBegin() + charge <= CurTime() then
+                self:DoCure(self.Target)
+                self:Reset()
+            elseif owner == self.Target then
+                if not owner:KeyDown(IN_ATTACK2) then
+                    self:Error("CURE ABORTED")
+                end
+            elseif not owner:KeyDown(IN_ATTACK) or owner:GetEyeTrace(MASK_SHOT_HULL).Entity ~= self.Target then
+                self:Error("CURE ABORTED")
+            end
+        end
+    end
+
+    function SWEP:PrimaryAttack()
+        if self:GetState() ~= DEFIB_IDLE then return end
+        if GetRoundState() ~= ROUND_ACTIVE then return end
+
+        local owner = self:GetOwner()
+        local tr = util.TraceLine({
+            start = owner:GetShootPos(),
+            endpos = owner:GetShootPos() + owner:GetAimVector() * 64,
+            filter = owner
+        })
+
+        local ent = tr.Entity
+        if ent and IsValid(ent) and ent:IsPlayer() then
+            self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
+            self:Begin(ent)
+        end
+    end
+
+    function SWEP:SecondaryAttack()
+        if self:GetState() ~= DEFIB_IDLE then return end
+        if GetRoundState() ~= ROUND_ACTIVE then return end
+
+        local owner = self:GetOwner()
+        if owner and IsValid(owner) and owner:IsPlayer() then
+            self:SetNextSecondaryFire(CurTime() + self.Primary.Delay)
+            self:Begin(owner)
+        end
+    end
+end
+
+if CLIENT then
+    function SWEP:DrawHUD()
+        local state = self:GetState()
+        self.BaseClass.DrawHUD(self)
+
+        if state == DEFIB_IDLE then return end
+
+        local timer = self:GetBegin() + charge
+
+        local x = ScrW() / 2.0
+        local y = ScrH() / 2.0
+
+        y = y + (y / 3)
+
+        local w, h = 255, 20
+
+        if state == DEFIB_BUSY then
+            if timer < 0 then return end
+
+            local cc = math.min(1, 1 - ((timer - CurTime()) / charge))
+
+            surface.SetDrawColor(0, 255, 0, 155)
+
+            surface.DrawOutlinedRect(x - w / 2, y - h, w, h)
+
+            surface.DrawRect(x - w / 2, y - h, w * cc, h)
+
+            surface.SetFont("TabLarge")
+            surface.SetTextColor(255, 255, 255, 180)
+            surface.SetTextPos((x - w / 2) + 3, y - h - 15)
+            surface.DrawText(self:GetMessage())
+        elseif state == DEFIB_ERROR then
+            surface.SetDrawColor(200 + math.sin(CurTime() * 32) * 50, 0, 0, 155)
+
+            surface.DrawOutlinedRect(x - w / 2, y - h, w, h)
+
+            surface.DrawRect(x - w / 2, y - h, w, h)
+
+            surface.SetFont("TabLarge")
+            surface.SetTextColor(255, 255, 255, 180)
+            surface.SetTextPos((x - w / 2) + 3, y - h - 15)
+            surface.DrawText(self:GetMessage())
+        end
+    end
+
+    function SWEP:PrimaryAttack() return false end
+end
+
+function SWEP:DryFire() return false end

--- a/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
@@ -42,7 +42,11 @@ SWEP.NoSights = true
 SWEP.UseHands = true
 SWEP.ViewModelFlip = false
 
+PARASITE_CURE_KILL_NONE = 0
+PARASITE_CURE_KILL_OWNER = 1
+PARASITE_CURE_KILL_TARGET = 2
 
+local CureMode = CreateConVar("ttt_parasite_cure_mode", "1")
 local CureSound = Sound("items/smallmedkit1.wav")
 
 function SWEP:Initialize()
@@ -53,14 +57,14 @@ function SWEP:PrimaryAttack()
 
     if not SERVER then return end
 
+    local owner = self:GetOwner()
     local tr = util.TraceLine({
-        start = self.Owner:GetShootPos(),
-        endpos = self.Owner:GetShootPos() + self.Owner:GetAimVector() * 64,
-        filter = self.Owner
+        start = owner:GetShootPos(),
+        endpos = owner:GetShootPos() + owner:GetAimVector() * 64,
+        filter = owner
     })
 
     local ent = tr.Entity
-
     if IsValid(ent) and ent:IsPlayer() then
         ent:EmitSound(CureSound)
 
@@ -77,7 +81,12 @@ function SWEP:PrimaryAttack()
                 end
             end
         else
-            ent:Kill()
+            local cureMode = CureMode:GetInt()
+            if cureMode == PARASITE_CURE_KILL_OWNER and IsValid(owner) then
+                owner:Kill()
+            elseif cureMode == PARASITE_CURE_KILL_TARGET then
+                ent:Kill()
+            end
         end
 
         self:Remove()

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -124,6 +124,7 @@ SWEP.ReloadAnim = ACT_VM_RELOAD
 
 SWEP.fingerprints = {}
 SWEP.BoughtBuy = nil
+SWEP.BlockShopRandomization = false
 
 local sparkle = CLIENT and CreateConVar("ttt_crazy_sparks", "0", FCVAR_ARCHIVE)
 

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -65,20 +65,18 @@ function GetEquipmentForRole(role, promoted, block_randomization)
 
     -- Determine which role sync variable to use, if any
     local rolemode = GetGlobalInt("ttt_" .. ROLE_STRINGS[role] .. "_shop_mode", SHOP_SYNC_MODE_NONE)
-
-    -- Pre-load the Traitor weapons so that any that have their CanBuy modified will also apply to the enabled allied role(s)
     local traitorsync = GetGlobalBool("ttt_" .. ROLE_STRINGS[role] .. "_shop_sync", false) and TRAITOR_ROLES[role]
-
     local sync_traitor_weapons = traitorsync or (rolemode > SHOP_SYNC_MODE_NONE)
 
+    -- Pre-load the Traitor weapons so that any that have their CanBuy modified will also apply to the enabled allied role(s)
     if sync_traitor_weapons and not Equipment[ROLE_TRAITOR] then
         GetEquipmentForRole(ROLE_TRAITOR, false, true)
     end
 
-    -- Pre-load the Detective weapons so that any that have their CanBuy modified will also apply to the enabled allied role(s)
     local sync_detective_like = (promoted and (role == ROLE_DEPUTY or role == ROLE_IMPERSONATOR))
     local sync_detective_weapons = sync_detective_like or (rolemode > SHOP_SYNC_MODE_NONE)
 
+    -- Pre-load the Detective weapons so that any that have their CanBuy modified will also apply to the enabled allied role(s)
     if sync_detective_weapons and not Equipment[ROLE_DETECTIVE] then
         GetEquipmentForRole(ROLE_DETECTIVE, false, true)
     end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -995,7 +995,7 @@ local function DrawFootprints()
 
                 local hitpos = footstep.pos
                 -- If this player is spectating through the target's eyes, move the prints down so they don't appear to float
-                if client:IsSpec() and client:GetNWInt("SpecMode", -1) == OBS_MODE_IN_EYE then
+                if client:IsSpec() and client:GetObserverMode() == OBS_MODE_IN_EYE then
                     hitpos = hitpos + Vector(0, 0, -50)
                 end
                 render.DrawQuadEasy(hitpos + footstep.normal * 0.01, footstep.normal, 10, 20, col, footstep.angle)

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -71,6 +71,12 @@ local function GetDetectiveIconRole(is_traitor)
     return ROLE_DEPUTY
 end
 
+local function ShouldHideJesters(p)
+    return (p:IsTraitorTeam() and not GetGlobalBool("ttt_jesters_visible_to_traitors", false)) or
+            (p:IsMonsterTeam() and not GetGlobalBool("ttt_jesters_visible_to_monsters", false)) or
+            (p:IsIndependentTeam() and not GetGlobalBool("ttt_jesters_visible_to_independents", false))
+end
+
 -- using this hook instead of pre/postplayerdraw because playerdraw seems to
 -- happen before certain entities are drawn, which then clip over the sprite
 function GM:PostDrawTranslucentRenderables()
@@ -92,7 +98,7 @@ function GM:PostDrawTranslucentRenderables()
             pos.z = pos.z + v:GetHeight() + 15
 
             local hideBeggar = v:GetNWBool("WasBeggar", false) and not GetGlobalBool("ttt_beggar_reveal_change", true)
-            local showJester = (v:IsJesterTeam() and not v:GetNWBool("KillerClownActive", false)) or ((v:GetTraitor() or v:GetInnocent()) and hideBeggar)
+            local showJester = ((v:IsJesterTeam() and not v:GetNWBool("KillerClownActive", false)) or ((v:GetTraitor() or v:GetInnocent()) and hideBeggar)) and not ShouldHideJesters(client)
 
             -- Only show the "KILL" target if the setting is enabled
             local showkillicon = ((client:IsAssassin() and GetGlobalBool("ttt_assassin_show_target_icon", false) and client:GetNWString("AssassinTarget") == v:Nick()) or
@@ -142,14 +148,14 @@ function GM:PostDrawTranslucentRenderables()
                         elseif showJester then
                             DrawRoleIcon(ROLE_JESTER, false, pos, dir)
                         end
+                    elseif client:IsKiller() then
+                        if showJester then
+                            DrawRoleIcon(ROLE_JESTER, false, pos, dir)
+                        end
                     elseif client:IsIndependentTeam() then
                         if v:IsIndependentTeam() then
                             DrawRoleIcon(v:GetRole(), true, pos, dir)
                         elseif showJester then
-                            DrawRoleIcon(ROLE_JESTER, false, pos, dir)
-                        end
-                    elseif client:IsKiller() then
-                        if showJester then
                             DrawRoleIcon(ROLE_JESTER, false, pos, dir)
                         end
                     end
@@ -333,7 +339,7 @@ function GM:HUDDrawTargetID()
         local hideBeggar = ent:GetNWBool("WasBeggar", false) and not GetGlobalBool("ttt_beggar_reveal_change", true)
 
         if not hide_roles and GetRoundState() == ROUND_ACTIVE then
-            local showJester = (ent:IsJesterTeam() and not ent:GetNWBool("KillerClownActive", false)) or ((ent:GetTraitor() or ent:GetInnocent()) and hideBeggar)
+            local showJester = ((ent:IsJesterTeam() and not ent:GetNWBool("KillerClownActive", false)) or ((ent:GetTraitor() or ent:GetInnocent()) and hideBeggar)) and not ShouldHideJesters(client)
             if client:IsTraitorTeam() then
                 target_traitor = (ent:IsTraitor() and not hideBeggar) or ent:IsGlitch()
                 target_hypnotist = ent:IsHypnotist()

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -179,6 +179,7 @@ CreateConVar("ttt_clown_activation_credits", "0")
 CreateConVar("ttt_clown_hide_when_active", "0")
 CreateConVar("ttt_clown_show_target_icon", "0")
 CreateConVar("ttt_clown_heal_on_activate", "0")
+CreateConVar("ttt_clown_shop_active_only", "1")
 
 CreateConVar("ttt_beggar_reveal_change", "1")
 CreateConVar("ttt_beggar_respawn", "0")
@@ -639,6 +640,7 @@ function GM:SyncGlobals()
 
     SetGlobalBool("ttt_clown_show_target_icon", GetConVar("ttt_clown_show_target_icon"):GetBool())
     SetGlobalBool("ttt_clown_hide_when_active", GetConVar("ttt_clown_hide_when_active"):GetBool())
+    SetGlobalBool("ttt_clown_shop_active_only", GetConVar("ttt_clown_shop_active_only"):GetBool())
 
     SetGlobalBool("ttt_bem_allow_change", GetConVar("ttt_bem_allow_change"):GetBool())
     SetGlobalInt("ttt_bem_sv_cols", GetConVar("ttt_bem_sv_cols"):GetBool())

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1665,32 +1665,32 @@ end
 
 local function GetTraitorCount(ply_count)
     -- get number of traitors: pct of players rounded up
-    local traitor_count = math.ceil(ply_count * math.Truncate(GetConVar("ttt_traitor_pct"):GetFloat(), 3))
+    local traitor_count = math.ceil(ply_count * math.Round(GetConVar("ttt_traitor_pct"):GetFloat(), 3))
     -- make sure there is at least 1 traitor
     return math.Clamp(traitor_count, 1, GetConVar("ttt_traitor_max"):GetInt())
 end
 
 local function GetDetectiveCount(ply_count)
-    local detective_count = math.ceil(ply_count * math.Truncate(GetConVar("ttt_detective_pct"):GetFloat(), 3))
+    local detective_count = math.ceil(ply_count * math.Round(GetConVar("ttt_detective_pct"):GetFloat(), 3))
 
     return math.Clamp(detective_count, 1, GetConVar("ttt_detective_max"):GetInt())
 end
 
 local function GetSpecialTraitorCount(ply_count)
     -- get number of special traitors: pct of traitors rounded up
-    return math.ceil(ply_count * math.Truncate(GetConVar("ttt_special_traitor_pct"):GetFloat(), 3))
+    return math.ceil(ply_count * math.Round(GetConVar("ttt_special_traitor_pct"):GetFloat(), 3))
 end
 
 local function GetSpecialInnocentCount(ply_count)
     -- get number of special innocents: pct of innocents rounded up
-    return math.ceil(ply_count * math.Truncate(GetConVar("ttt_special_innocent_pct"):GetFloat(), 3))
+    return math.ceil(ply_count * math.Round(GetConVar("ttt_special_innocent_pct"):GetFloat(), 3))
 end
 
 local function GetMonsterCount(ply_count)
     if not MONSTER_ROLES[ROLE_ZOMBIE] and not MONSTER_ROLES[ROLE_VAMPIRE] then
         return 0
     end
-    return math.ceil(ply_count * math.Truncate(GetConVar("ttt_monster_pct"):GetFloat(), 3))
+    return math.ceil(ply_count * math.Round(GetConVar("ttt_monster_pct"):GetFloat(), 3))
 end
 
 local function PrintRoleText(text)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -727,7 +727,7 @@ end
 
 local function GetPlayerName(ply)
     local name = ply:GetNWString("PlayerName", nil)
-    if name ~= nil then
+    if name == nil then
         name = ply:Nick()
     end
     return name

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -156,6 +156,10 @@ CreateConVar("ttt_veteran_full_heal", "1")
 
 -- Jester role properties
 CreateConVar("ttt_jesters_trigger_traitor_testers", "1")
+CreateConVar("ttt_jesters_visible_to_traitors", "1")
+CreateConVar("ttt_jesters_visible_to_monsters", "1")
+CreateConVar("ttt_jesters_visible_to_independents", "1")
+
 CreateConVar("ttt_jester_win_by_traitors", "1")
 CreateConVar("ttt_jester_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the Jester is killed", 0, 4)
 CreateConVar("ttt_jester_notify_sound", "0")
@@ -626,9 +630,13 @@ function GM:SyncGlobals()
     SetGlobalFloat("ttt_zombie_prime_speed_bonus", GetConVar("ttt_zombie_prime_speed_bonus"):GetFloat())
     SetGlobalFloat("ttt_zombie_thrall_speed_bonus", GetConVar("ttt_zombie_thrall_speed_bonus"):GetFloat())
 
-    SetGlobalBool("ttt_beggar_reveal_change", GetConVar("ttt_beggar_reveal_change"):GetBool())
-
     SetGlobalInt("ttt_revenger_radar_timer", GetConVar("ttt_revenger_radar_timer"):GetInt())
+
+    SetGlobalBool("ttt_jesters_visible_to_traitors", GetConVar("ttt_jesters_visible_to_traitors"):GetBool())
+    SetGlobalBool("ttt_jesters_visible_to_monsters", GetConVar("ttt_jesters_visible_to_monsters"):GetBool())
+    SetGlobalBool("ttt_jesters_visible_to_independents", GetConVar("ttt_jesters_visible_to_independents"):GetBool())
+
+    SetGlobalBool("ttt_beggar_reveal_change", GetConVar("ttt_beggar_reveal_change"):GetBool())
 
     SetGlobalBool("ttt_clown_show_target_icon", GetConVar("ttt_clown_show_target_icon"):GetBool())
     SetGlobalBool("ttt_clown_hide_when_active", GetConVar("ttt_clown_hide_when_active"):GetBool())

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -255,7 +255,7 @@ for _, role in ipairs(table.GetKeys(SHOP_ROLES)) do
 
     if role == ROLE_MERCENARY then
         CreateConVar("ttt_" .. rolestring .. "_shop_mode", "2", FCVAR_REPLICATED)
-    elseif INDEPENDENT_ROLES[role] and role ~= ROLE_ZOMBIE then
+    elseif (INDEPENDENT_ROLES[role] and role ~= ROLE_ZOMBIE) or role == ROLE_CLOWN then
         CreateConVar("ttt_" .. rolestring .. "_shop_mode", "0", FCVAR_REPLICATED)
     end
 end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -153,6 +153,8 @@ CreateConVar("ttt_deputy_use_detective_icon", "1")
 
 CreateConVar("ttt_veteran_damage_bonus", "0.5")
 CreateConVar("ttt_veteran_full_heal", "1")
+CreateConVar("ttt_veteran_heal_bonus", "0")
+CreateConVar("ttt_veteran_announce", "0")
 
 -- Jester role properties
 CreateConVar("ttt_jesters_trigger_traitor_testers", "1")

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -345,9 +345,6 @@ OldCVarWarning("ttt_par_credits_starting", "ttt_parasite_credits_starting")
 CreateConVar("ttt_mer_credits_starting", "1")
 OldCVarWarning("ttt_mer_credits_starting", "ttt_mercenary_credits_starting")
 
-CreateConVar("ttt_doc_credits_starting", "0")
-OldCVarWarning("ttt_doc_credits_starting", "ttt_doctor_credits_starting")
-
 CreateConVar("ttt_jes_credits_starting", "0")
 OldCVarWarning("ttt_jes_credits_starting", "ttt_jester_credits_starting")
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1666,32 +1666,32 @@ end
 
 local function GetTraitorCount(ply_count)
     -- get number of traitors: pct of players rounded up
-    local traitor_count = math.ceil(ply_count * GetConVar("ttt_traitor_pct"):GetFloat())
+    local traitor_count = math.ceil(ply_count * math.Truncate(GetConVar("ttt_traitor_pct"):GetFloat(), 3))
     -- make sure there is at least 1 traitor
     return math.Clamp(traitor_count, 1, GetConVar("ttt_traitor_max"):GetInt())
 end
 
 local function GetDetectiveCount(ply_count)
-    local detective_count = math.ceil(ply_count * GetConVar("ttt_detective_pct"):GetFloat())
+    local detective_count = math.ceil(ply_count * math.Truncate(GetConVar("ttt_detective_pct"):GetFloat(), 3))
 
     return math.Clamp(detective_count, 1, GetConVar("ttt_detective_max"):GetInt())
 end
 
 local function GetSpecialTraitorCount(ply_count)
     -- get number of special traitors: pct of traitors rounded up
-    return math.ceil(ply_count * GetConVar("ttt_special_traitor_pct"):GetFloat())
+    return math.ceil(ply_count * math.Truncate(GetConVar("ttt_special_traitor_pct"):GetFloat(), 3))
 end
 
 local function GetSpecialInnocentCount(ply_count)
     -- get number of special innocents: pct of innocents rounded up
-    return math.ceil(ply_count * GetConVar("ttt_special_innocent_pct"):GetFloat())
+    return math.ceil(ply_count * math.Truncate(GetConVar("ttt_special_innocent_pct"):GetFloat(), 3))
 end
 
 local function GetMonsterCount(ply_count)
     if not MONSTER_ROLES[ROLE_ZOMBIE] and not MONSTER_ROLES[ROLE_VAMPIRE] then
         return 0
     end
-    return math.ceil(ply_count * GetConVar("ttt_monster_pct"):GetFloat())
+    return math.ceil(ply_count * math.Truncate(GetConVar("ttt_monster_pct"):GetFloat(), 3))
 end
 
 local function PrintRoleText(text)

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -1102,7 +1102,7 @@ function GM:PlayerDeath(victim, infl, attacker)
             victim:SetNWInt("HauntingPower", 0)
             timer.Create(victim:Nick() .. "HauntingPower", 1, 0, function()
                 -- Make sure the victim is still in the correct spectate mode
-                local spec_mode = victim:GetNWInt("SpecMode", OBS_MODE_ROAMING)
+                local spec_mode = victim:GetObserverMode()
                 if spec_mode ~= OBS_MODE_CHASE and spec_mode ~= OBS_MODE_IN_EYE then
                     victim:Spectate(OBS_MODE_CHASE)
                 end
@@ -1306,7 +1306,7 @@ function GM:PlayerDeath(victim, infl, attacker)
         victim:SetNWInt("InfectionProgress", 0)
         timer.Create(victim:Nick() .. "InfectionProgress", 1, 0, function()
             -- Make sure the victim is still in the correct spectate mode
-            local spec_mode = victim:GetNWInt("SpecMode", OBS_MODE_ROAMING)
+            local spec_mode = victim:GetObserverMode()
             if spec_mode ~= OBS_MODE_CHASE and spec_mode ~= OBS_MODE_IN_EYE then
                 victim:Spectate(OBS_MODE_CHASE)
             end

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -1454,11 +1454,28 @@ function GM:PlayerDeath(victim, infl, attacker)
         for _, v in pairs(veterans) do
             if not v:GetNWBool("VeteranActive", false) then
                 v:SetNWBool("VeteranActive", true)
+
                 v:PrintMessage(HUD_PRINTTALK, "You are the last innocent alive!")
                 v:PrintMessage(HUD_PRINTCENTER, "You are the last innocent alive!")
+                if GetConVar("ttt_veteran_announce"):GetBool() then
+                    for _, p in ipairs(player.GetAll()) do
+                        if p ~= v and p:Alive() and not p:IsSpec() then
+                            p:PrintMessage(HUD_PRINTTALK, "The last innocent alive is a veteran!")
+                            p:PrintMessage(HUD_PRINTCENTER, "The last innocent alive is a veteran!")
+                        end
+                    end
+                end
+
                 if GetConVar("ttt_veteran_full_heal"):GetBool() then
-                    v:SetHealth(math.min(v:GetMaxHealth(), 100))
-                    v:PrintMessage(HUD_PRINTTALK, "You have been fully healed!")
+                    local heal_bonus = GetConVar("ttt_veteran_heal_bonus"):GetInt()
+                    local health = math.min(v:GetMaxHealth(), 100) + heal_bonus
+
+                    v:SetHealth(health)
+                    if heal_bonus > 0 then
+                        v:PrintMessage(HUD_PRINTTALK, "You have been fully healed (with a bonus)!")
+                    else
+                        v:PrintMessage(HUD_PRINTTALK, "You have been fully healed!")
+                    end
                 end
             end
         end

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -405,8 +405,6 @@ function plymeta:Spectate(type)
     -- NPCs should never see spectators. A workaround for the fact that gmod NPCs
     -- do not ignore them by default.
     self:SetNoTarget(true)
-    -- Save the spectate mode so it can be accessed on the client
-    self:SetNWInt("SpecMode", type)
 
     if type == OBS_MODE_ROAMING then
         self:SetMoveType(MOVETYPE_NOCLIP)

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -115,14 +115,18 @@ function plymeta:IsShopRole()
     -- If this is a jester team member with a potential shop, only give them access if there are actual things to buy
     if hasShop and self:IsJesterTeam() then
         local hasWeapon = WEPS.DoesRoleHaveWeapon(self:GetRole())
-        return hasWeapon or (self:IsClown() and GetGlobalInt("ttt_clown_shop_mode") > SHOP_SYNC_MODE_NONE)
+        -- Only allow clowns to use the shop if they have weapons or will be having weapons synced and are active or "active_only" is disabled
+        if self:IsClown() then
+            hasWeapon = (hasWeapon or GetGlobalInt("ttt_clown_shop_mode") > SHOP_SYNC_MODE_NONE) and
+                        (not GetGlobalBool("ttt_clown_shop_active_only", false) or self:GetNWBool("KillerClownActive", false))
+        end
+        return hasWeapon
     end
     return hasShop
 end
 function plymeta:CanUseShop()
     return self:IsShopRole() and
-        (not self:IsDeputy() or self:GetNWBool("HasPromotion", false)) and
-        (not self:IsClown() or self:GetNWBool("KillerClownActive", false))
+        (not self:IsDeputy() or self:GetNWBool("HasPromotion", false))
 end
 function plymeta:CanUseTraitorButton(active_only)
     if active_only and not self:IsActive() then return false end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -712,7 +712,7 @@ if SERVER then
         -- Don't let dead players, spectators, non-assassins, or failed assassins get another target
         -- And don't assign targets if the round isn't currently running
         if not IsValid(ply) or GetRoundState() > ROUND_ACTIVE or
-            not ply:IsAssassin() or ply:GetNWBool("AssassinFailed", true)
+            not ply:IsAssassin() or ply:GetNWBool("AssassinFailed", false)
         then
             return
         end
@@ -729,18 +729,18 @@ if SERVER then
                 if p:IsDetective() then
                     table.insert(detectives, p:Nick())
                 -- Exclude Glitch from this list so they don't get discovered immediately
-                elseif (INNOCENT_ROLES[p:GetRole()] or MONSTER_ROLES[p:GetRole()]) and not p:IsGlitch() then
+                elseif (p:IsInnocentTeam() or p:IsMonsterTeam()) and not p:IsGlitch() then
                     -- Don't add the former beggar to the list of enemies unless the "reveal" setting is enabled
                     if GetConVar("ttt_beggar_reveal_change"):GetBool() or not p:GetNWBool("WasBeggar", false) then
                         -- Put shop roles into a list if they should be targeted last
-                        if GetConVar("ttt_assassin_shop_roles_last"):GetBool() and SHOP_ROLES[p:GetRole()] then
+                        if GetConVar("ttt_assassin_shop_roles_last"):GetBool() and p:IsShopRole() then
                             table.insert(shops, p:Nick())
                         else
                             table.insert(enemies, p:Nick())
                         end
                     end
                 -- Exclude the Old Man because they just want to survive
-                elseif INDEPENDENT_ROLES[p:GetRole()] and not p:IsOldMan() then
+                elseif p:IsIndependentTeam() and not p:IsOldMan() then
                     table.insert(independents, p:Nick())
                 end
             end

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -103,6 +103,12 @@ function GM:TTTScoreboardColorForPlayer(ply)
     return namecolor.default
 end
 
+local function ShouldHideJesters(ply)
+    return (ply:IsTraitorTeam() and not GetGlobalBool("ttt_jesters_visible_to_traitors", false)) or
+            (ply:IsMonsterTeam() and not GetGlobalBool("ttt_jesters_visible_to_monsters", false)) or
+            (ply:IsIndependentTeam() and not GetGlobalBool("ttt_jesters_visible_to_independents", false))
+end
+
 function GM:TTTScoreboardRowColorForPlayer(ply)
     if not IsValid(ply) or GetRoundState() == ROUND_WAIT or GetRoundState() == ROUND_PREP then return defaultcolor end
 
@@ -118,7 +124,7 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
     end
 
     local hideBeggar = ply:GetNWBool("WasBeggar", false) and not GetGlobalBool("ttt_beggar_reveal_change", true)
-    local showJester = (ply:IsJesterTeam() and not ply:GetNWBool("KillerClownActive", false)) or ((ply:IsTraitor() or ply:IsInnocent()) and hideBeggar)
+    local showJester = ((ply:IsJesterTeam() and not ply:GetNWBool("KillerClownActive", false)) or ((ply:IsTraitor() or ply:IsInnocent()) and hideBeggar)) and not ShouldHideJesters(client)
     if client:IsTraitorTeam() then
         if ply:IsTraitorTeam() and not hideBeggar then
             return ply:GetRole()

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -184,7 +184,7 @@ function WEPS.HandleCanBuyOverrides(wep, role, block_randomization, sync_traitor
                 table.RemoveByValue(wep.CanBuy, role)
             -- Remove some weapons based on a random chance if it isn't blocked or bypassed
             -- Only run this on the client because there is no easy way to sync randomization between client and server
-            elseif CLIENT then
+            elseif CLIENT and not wep.BlockShopRandomization then
                 local norandomtable = WEPS.BypassRandomWeapons[role]
                 if not block_randomization and (not norandomtable or not table.HasValue(norandomtable, id)) then
                     local random_cvar_enabled = GetGlobalBool("ttt_" .. ROLE_STRINGS[role] .. "_shop_random_enabled", false)

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -131,7 +131,7 @@ function WEPS.HandleCanBuyOverrides(wep, role, block_randomization, sync_traitor
             if rolemode == SHOP_SYNC_MODE_UNION or rolemode == SHOP_SYNC_MODE_DETECTIVE then
                 -- and they can't already buy this weapon
                 if not table.HasValue(wep.CanBuy, role) and
-                    -- and detectives CAN buy this weapon, let the mercenary buy it too
+                    -- and detectives CAN buy this weapon, let the role buy it too
                     table.HasValue(wep.CanBuy, ROLE_DETECTIVE) then
                     table.insert(wep.CanBuy, role)
                 end
@@ -141,7 +141,7 @@ function WEPS.HandleCanBuyOverrides(wep, role, block_randomization, sync_traitor
             if rolemode == SHOP_SYNC_MODE_UNION or rolemode == SHOP_SYNC_MODE_TRAITOR then
                 -- and they can't already buy this weapon
                 if not table.HasValue(wep.CanBuy, role) and
-                    -- and traitors CAN buy this weapon, let the mercenary buy it too
+                    -- and traitors CAN buy this weapon, let the role buy it too
                     table.HasValue(wep.CanBuy, ROLE_TRAITOR) then
                     table.insert(wep.CanBuy, role)
                 end
@@ -151,7 +151,7 @@ function WEPS.HandleCanBuyOverrides(wep, role, block_randomization, sync_traitor
             if rolemode == SHOP_SYNC_MODE_INTERSECT then
                 -- and they can't already buy this weapon
                 if not table.HasValue(wep.CanBuy, role) and
-                    -- and detectives AND traitors CAN buy this weapon, let the mercenary buy it too
+                    -- and detectives AND traitors CAN buy this weapon, let the role buy it too
                     table.HasValue(wep.CanBuy, ROLE_DETECTIVE) and table.HasValue(wep.CanBuy, ROLE_TRAITOR) then
                     table.insert(wep.CanBuy, role)
                 end


### PR DESCRIPTION
**Fixes**
- Fixed team player count calculations not always being accurate by rounding the "_pct" convars to 3 digits to work around floating point inaccuracy
- Fixed assassin not getting a target sometimes because they were treated as having a failed contract by default
- Fixed missing ttt_clown_shop_mode
- Fixed weapons added to detective or traitor via the roleweapons system not being buyable by roles using the shop mode convars
- Fixed old man not also winning when a map declares a winning team

**Changes**
- Changed end-of-round summary to automatically add a row if there are both independents and jesters in a round (via something like a Randomat event)
- Changed parasite cure to have a 3-second charge time to prevent it from being used as an instant-kill weapon
- Changed parasite cure to never be removed if shop randomization is enabled

**Additions**
- Added convars to control whether members of the jesters teams are visible to other teams (via the head icons, color/icon on the scoreboard, etc.)
- Added ability to give the veteran a health bonus (in addition to the heal) when they are activated
- Added ability to notify other remaining players when a veteran is activated
- Added convar to control what happens when a parasite cure is used on someone who is not infected
- Added ability for the clown to always have access to their shop via a new convar

**Developer**
- Added the ability for SWEPs to not be randomized out of the shop by setting "SWEP.BlockShopRandomization = true"