### PR TITLE
Fixed Glitches being shown as a T on Zombie rounds

### DIFF
--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -7,7 +7,7 @@
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
 
 ### Fixes
-- Fixed the Glitch from being shown as a Traitor to Zombies if Zombies are on the Traitor Team
+- Fixed the glitch from being shown as a traitor to zombies if zombies are on the traitor team
 
 ## 1.0.6
 **Released: July 20th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -6,6 +6,9 @@
 ### Changes
 - Changed ttt_beggar_notify_sound and ttt_beggar_notify_confetti to be off by default to better match default beggar behaviour
 
+### Fixes
+- Fixed the Glitch from being shown as a Traitor to Zombies if Zombies are on the Traitor Team
+
 ## 1.0.6
 **Released: July 20th, 2021**
 

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -121,7 +121,7 @@ function GM:PostDrawTranslucentRenderables()
                 end
                 if not hide_roles then
                     if client:IsTraitorTeam() then
-                        if (v:GetTraitor() and not hideBeggar) or v:GetGlitch() then
+                        if (v:GetTraitor() and not hideBeggar) then
                             DrawRoleIcon(ROLE_TRAITOR, true, pos, dir)
                         elseif v:GetImpersonator() then
                             -- If the impersonator is promoted, use the Detective's icon with the Impersonator's color
@@ -135,6 +135,12 @@ function GM:PostDrawTranslucentRenderables()
                             DrawRoleIcon(v:GetRole(), true, pos, dir)
                         elseif showJester then
                             DrawRoleIcon(ROLE_JESTER, false, pos, dir)
+                        elseif v:GetGlitch() then
+                            if client:IsZombie() then
+                                DrawRoleIcon(ROLE_ZOMBIE, true, pos, dir)
+                            else
+                                DrawRoleIcon(ROLE_TRAITOR, true, pos, dir)
+                            end
                         end
                     elseif client:IsMonsterTeam() then
                         if v:IsMonsterTeam() then
@@ -335,7 +341,7 @@ function GM:HUDDrawTargetID()
         if not hide_roles and GetRoundState() == ROUND_ACTIVE then
             local showJester = (ent:IsJesterTeam() and not ent:GetNWBool("KillerClownActive", false)) or ((ent:GetTraitor() or ent:GetInnocent()) and hideBeggar)
             if client:IsTraitorTeam() then
-                target_traitor = (ent:IsTraitor() and not hideBeggar) or ent:IsGlitch()
+                target_traitor = (ent:IsTraitor() and not hideBeggar) or (ent:IsGlitch() and not client:IsZombie())
                 target_hypnotist = ent:IsHypnotist()
                 target_impersonator = ent:IsImpersonator()
                 target_assassin = ent:IsAssassin()
@@ -343,7 +349,7 @@ function GM:HUDDrawTargetID()
                 target_parasite = ent:IsParasite()
                 target_vampire = ent:IsVampire() and ent:IsTraitorTeam()
                 if client:IsZombie() then
-                    target_fellow_zombie = ent:IsZombie()
+                    target_fellow_zombie = ent:IsZombie() or ent:IsGlitch()
                 else
                     target_zombie = ent:IsZombie() and ent:IsTraitorTeam()
                 end


### PR DESCRIPTION
If Zombies are on the Traitor team, Glitches would still show up as a T on Zombie rounds, outing the Glitch