### PR TITLE
Misc. fixes and additions

### DIFF
--- a/API.md
+++ b/API.md
@@ -225,6 +225,18 @@ This document aims to explain the things that we have added to Custom Roles for 
 *Parameters:*
 - *ply* - The target player
 
+**SetRoleMaxHealth(ply)** - Sets the target player's max health based on their role convars.\
+*Realm:* Client and Server\
+*Added in:* 1.0.15\
+*Parameters:*
+- *ply* - The target player
+
+**SetRoleStartingHealth(ply)** - Sets the target player's health based on their role convars.\
+*Realm:* Client and Server\
+*Added in:* 1.0.15\
+*Parameters:*
+- *ply* - The target player
+
 ### *Player*
 
 **plymeta:Is{RoleName}()/plymeta:Get{RoleName}()** - Dynamically created functions for each role that returns whether the player is that role. For example: `plymeta:IsTraitor()` and `plymeta:IsPhantom()` return whether the player is a traitor or a phantom, respectively.\

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the development version of my [Custom Roles for TTT](https://steamcommun
 
 1. All custom roles are disabled by default. Please read the ConVar list to find out how to turn them on.
 2. Traitor voice chat has been rebound to allow sprint to be shift by default. You will need to bind a new key to "Suit Zoom" to use traitor voice chat.
-3. The radio menu (quick chat) has been rebound to "z" by default but that can be changed in the F1 settings menu.
+3. The radio menu (quick chat) has been rebound to "n" by default but that can be changed in the F1 settings menu.
 
 ## Roles
 ### *List*

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,5 +1,17 @@
 # Beta Release Notes
 
+## 1.0.15
+**Released:**
+
+### Changes
+- Changed radio menu to default to the "n" key to avoid conflicting with the "drop ammo" key
+- Changed vampire drain/convert to automatically abort if the target is converted to a vampire by someone else before you're done
+
+### Fixes
+- Fixed error in round summary when a player started the round as a role and ended as a spectator
+- Fixed players not having their max health set correctly when being converted to a vampire
+- Fixed players who were moved to spectator by some external addon not showing as spectator on the scoreboard
+
 ## 1.0.14
 **Released: August 14th, 2021**
 

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -11,6 +11,7 @@
 - Fixed error in round summary when a player started the round as a role and ended as a spectator
 - Fixed players not having their max health set correctly when being converted to a vampire
 - Fixed players who were moved to spectator by some external addon not showing as spectator on the scoreboard
+- Fixed buttons in shop being slightly misaligned
 
 ## 1.0.14
 **Released: August 14th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -3,6 +3,10 @@
 ## 1.0.15
 **Released:**
 
+### Additions
+- Added "Buy random equipment" button to the shop
+- Added mouseover tooltip to the "Toggle favorite" button in the shop
+
 ### Changes
 - Changed radio menu to default to the "n" key to avoid conflicting with the "drop ammo" key
 - Changed vampire drain/convert to automatically abort if the target is converted to a vampire by someone else before you're done

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -251,9 +251,9 @@ function SWEP:Think()
 
         local tr = self:GetTraceEntity()
         if not self:GetOwner():KeyDown(IN_ATTACK) or tr.Entity ~= self.TargetEntity then
+            local ply = self.TargetEntity
             -- If the player is allowed to convert, do that
-            if self:GetState() == STATE_CONVERT and CanConvert(self:GetOwner()) then
-                local ply = self.TargetEntity
+            if self:GetState() == STATE_CONVERT and CanConvert(self:GetOwner()) and not ply:IsVampire() then
                 ply:StripRoleWeapons()
                 if not ply:HasWeapon("weapon_zm_improvised") then
                     ply:Give("weapon_zm_improvised")
@@ -273,9 +273,17 @@ function SWEP:Think()
                 self:FireError()
 
                 SendFullStateUpdate()
+                -- Reset the victim's max health
+                SetRoleMaxHealth(ply)
             else
                 self:Error("DRAINING ABORTED")
             end
+            return
+        end
+
+        -- If the target has been turned to a vampire by someone else, stop trying to drain them
+        if self.TargetEntity:IsVampire() then
+            self:Error("DRAINING ABORTED")
             return
         end
 

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -772,7 +772,7 @@ local function TraitorMenuPopup()
         end
 
         local dcancel = vgui.Create("DButton", dframe)
-        dcancel:SetPos(w - 13 - bw, h - bh - 16)
+        dcancel:SetPos(w - 17 - bw, h - bh - 17)
         dcancel:SetSize(bw, bh)
         dcancel:SetDisabled(false)
         dcancel:SetText(GetTranslation("close"))

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -111,7 +111,7 @@ function GM:KeyRelease(ply, key)
     end
 end
 
-local radio_button = CreateClientConVar("ttt_radio_button", "z", true, false, "What button to press to open/close the radio menu")
+local radio_button = CreateClientConVar("ttt_radio_button", "n", true, false, "What button to press to open/close the radio menu")
 function GM:PlayerButtonDown(ply, btn)
     if not IsFirstTimePredicted() then return end
     if btn == input.GetKeyCode(radio_button:GetString()) then

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -579,7 +579,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     }
 
     for id, s in pairs(scores) do
-        if id ~= -1 then
+        if id ~= -1 and s.role > ROLE_NONE and s.role <= ROLE_MAX then
             local foundPlayer = false
             for _, v in pairs(spawnedPlayers) do
                 if v == nicks[id] then

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -605,6 +605,11 @@ function CLSCORE:BuildSummaryPanel(dpanel)
                 if IsValid(ply) then
                     alive = ply:Alive() and not ply:IsSpec()
                     finalRole = ply:GetRole()
+                    -- Sanity check to make sure only valid roles are used for icons and stuff
+                    if finalRole <= ROLE_NONE or finalRole > ROLE_MAX then
+                        finalRole = startingRole
+                    end
+
                     -- Keep the original role icon for people converted to Zombie and Vampire or the Bodysnatcher
                     if finalRole ~= ROLE_ZOMBIE and finalRole ~= ROLE_VAMPIRE and startingRole ~= ROLE_BODYSNATCHER then
                         roleFileName = ROLE_STRINGS_SHORT[finalRole]

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -282,6 +282,8 @@ L.buy_no_stock = "This weapon is out of stock: you already bought it this round.
 L.buy_pending = "You already have an order pending, wait until you receive it."
 L.buy_received = "You have received your special equipment."
 L.buy_received_delay = "You will receive your special equipment when you activate."
+L.buy_favorite_toggle = "Toggle favorite"
+L.buy_random = "Buy random equipment"
 
 L.drop_no_room = "You have no room here to drop your weapon!"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.0.13"
+CR_VERSION = "1.0.15"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")
@@ -1002,15 +1002,27 @@ if SERVER then
         end
     end
 
-    function SetRoleHealth(ply)
+    function SetRoleStartingHealth(ply)
+        if not IsValid(ply) or not ply:Alive() or ply:IsSpec() then return end
+        local role = ply:GetRole()
+        if role <= ROLE_NONE or role > ROLE_MAX then return end
+
+        local health = GetConVar("ttt_" .. ROLE_STRINGS_RAW[role] .. "_starting_health"):GetInt()
+        ply:SetHealth(health)
+    end
+
+    function SetRoleMaxHealth(ply)
         if not IsValid(ply) or not ply:Alive() or ply:IsSpec() then return end
         local role = ply:GetRole()
         if role <= ROLE_NONE or role > ROLE_MAX then return end
 
         local maxhealth = GetConVar("ttt_" .. ROLE_STRINGS_RAW[role] .. "_max_health"):GetInt()
         ply:SetMaxHealth(maxhealth)
-        local health = GetConVar("ttt_" .. ROLE_STRINGS_RAW[role] .. "_starting_health"):GetInt()
-        ply:SetHealth(health)
+    end
+
+    function SetRoleHealth(ply)
+        SetRoleMaxHealth(ply)
+        SetRoleStartingHealth(ply)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -55,7 +55,7 @@ function SendDetectiveList(ply_or_rf) SendRoleList(ROLE_DETECTIVE, ply_or_rf) en
 function SendInnocentList(ply_or_rf) SendRoleList(ROLE_INNOCENT, ply_or_rf) end
 
 function SendAllLists(ply_or_rf)
-    for role = 0, ROLE_MAX do
+    for role = ROLE_NONE, ROLE_MAX do
         SendRoleList(role, ply_or_rf)
     end
 end

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -79,7 +79,7 @@ function ScoreGroup(p)
         return group
     end
 
-    if DetectiveMode() then
+    if DetectiveMode() and p:GetRole() ~= ROLE_NONE then
         -- Show players who used the Dead Ringer as "Dead"
         if fake_dead or (p:IsSpec() and not p:Alive()) then
             if p:GetNWBool("body_searched", false) then


### PR DESCRIPTION
**Additions**
- Added "Buy random equipment" button to the shop
- Added mouseover tooltip to the "Toggle favorite" button in the shop

**Changes**
- Changed radio menu to default to the "n" key to avoid conflicting with the "drop ammo" key
- Changed vampire drain/convert to automatically abort if the target is converted to a vampire by someone else before you're done

**Fixes**
- Fixed error in round summary when a player started the round as a role and ended as a spectator
- Fixed players not having their max health set correctly when being converted to a vampire
- Fixed players who were moved to spectator by some external addon not showing as spectator on the scoreboard
- Fixed buttons in shop being slightly misaligned