### PR TITLE
Misc. fixes

### DIFF
--- a/API.md
+++ b/API.md
@@ -509,5 +509,11 @@ Changes made to SWEPs (the data structure used when defining new weapons)
 **TTT_ClearPlayerFootsteps** - Resets the client's list of footsteps to show.\
 *Added in:* 1.0.0
 
+**TTT_RoleChanged** - Logs that a player's role has changed.\
+*Added in:* 1.0.0
+*Parameters:*
+- *String* - The player's SteamID64 value
+- *Int (Versions <= 1.1.1), UInt (Versions >= 1.1.2)* - The player's new role number
+
 **TTT_UpdateRoleNames** - Causes the client to update their local role name tables based on convar values.\
 *Added in:* 1.0.7

--- a/API.md
+++ b/API.md
@@ -513,7 +513,7 @@ Changes made to SWEPs (the data structure used when defining new weapons)
 *Added in:* 1.0.0
 *Parameters:*
 - *String* - The player's SteamID64 value
-- *Int (Versions <= 1.1.1), UInt (Versions >= 1.1.2)* - The player's new role number
+- *UInt (Versions <= 1.1.1), Int (Versions >= 1.1.2)* - The player's new role number
 
 **TTT_UpdateRoleNames** - Causes the client to update their local role name tables based on convar values.\
 *Added in:* 1.0.7

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the links below for the list of available roles in each available version:
 - Beta/Development - Please see [this](https://steamcommunity.com/workshop/filedetails/discussion/2404251054/3110277460812045123/) discussion on the Steam Workshop
 ### *Renaming*
 If you would like to rename one of the existing roles, see below for how to do it for each available version:
-- Release - Not yet available
+- Release - See [here](CONVARS.md#Renaming-Roles)
 - Beta/Development - See [here](CONVARS_BETA.md#Renaming-Roles)
 ### *Creating Custom Roles*
 If you would like to create your own role to integrate with Custom Roles for TTT, see, see [here](CREATE_YOUR_OWN_ROLE.md).\

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -3,6 +3,9 @@
 ## 1.1.2
 **Released:**
 
+### Changes
+- Changed the slot number in the weapon switch GUI to still be centered for 2 digit slots
+
 ### Fixes
 - Fixed jesters being visible via highlighting when ttt_jesters_visible_to_* was disabled
 - Fixed error in round summary caused by a player being an in invalid role state

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -6,3 +6,6 @@
 ### Fixes
 - Fixed jesters being visible via highlighting when ttt_jesters_visible_to_* was disabled
 - Fixed error in round summary caused by a player being an in invalid role state
+- Fixed weapon switch GUI not updating when you picked up a new weapon and ttt_weaponswitcher_stay was enabled
+- Fixed weapon switch GUI closing when you dropped a weapon and ttt_weaponswitcher_stay was enabled
+- Fixed weapon switch GUI closing when you tried to drop an undroppable weapon

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -12,3 +12,8 @@
 - Fixed weapon switch GUI not updating when you picked up a new weapon and ttt_weaponswitcher_stay was enabled
 - Fixed weapon switch GUI closing when you dropped a weapon and ttt_weaponswitcher_stay was enabled
 - Fixed weapon switch GUI closing when you tried to drop an undroppable weapon
+- Fixed player not appearing on the round summary screen if they were idled to spectator last round and only un-spectated during this round's preparation phase
+
+### Developers
+- Changed TTT_RoleChanged to use Int for role number
+- Changed TTT_SpawnedPlayers to use Int for role number

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,2 +1,7 @@
 # Beta Release Notes
 
+## 1.1.2
+**Released:**
+
+### Fixes
+- Fixed jesters being visible via highlighting when ttt_jesters_visible_to_* was disabled

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -5,3 +5,4 @@
 
 ### Fixes
 - Fixed jesters being visible via highlighting when ttt_jesters_visible_to_* was disabled
+- Fixed error in round summary caused by a player being an in invalid role state

--- a/gamemodes/terrortown/gamemode/cl_hudpickup.lua
+++ b/gamemodes/terrortown/gamemode/cl_hudpickup.lua
@@ -51,6 +51,8 @@ function GM:HUDWeaponPickedUp(wep)
     table.insert(self.PickupHistory, pickup)
     self.PickupHistoryLast = pickup.time
 
+    -- Refresh the weapon switcher
+    WSWITCH:Refresh()
 end
 
 function GM:HUDItemPickedUp(itemname)

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -50,6 +50,9 @@ local killer_vision = false
 local zombie_vision = false
 local vampire_vision = false
 local assassin_target_vision = false
+local jesters_visible_to_traitors = false
+local jesters_visible_to_monsters = false
+local jesters_visible_to_independents = false
 local vision_enabled = false
 
 local function AddExternalRoleDescriptions()
@@ -200,6 +203,9 @@ local function ReceiveRole()
     zombie_vision = GetGlobalBool("ttt_zombie_vision_enable")
     vampire_vision = GetGlobalBool("ttt_vampire_vision_enable")
     assassin_target_vision = GetGlobalBool("ttt_assassin_target_vision_enable")
+    jesters_visible_to_traitors = GetGlobalBool("ttt_jesters_visible_to_traitors")
+    jesters_visible_to_monsters = GetGlobalBool("ttt_jesters_visible_to_monsters")
+    jesters_visible_to_independents = GetGlobalBool("ttt_jesters_visible_to_independents")
 
     -- Disable highlights on role change
     if vision_enabled then
@@ -898,7 +904,7 @@ local function EnableTraitorHighlights(client)
         -- And add the glitch
         table.insert(allies, ROLE_GLITCH)
 
-        OnPlayerHighlightEnabled(client, allies, true, true, true)
+        OnPlayerHighlightEnabled(client, allies, jesters_visible_to_traitors, true, true)
     end)
 end
 local function EnableAssassinTargetHighlights(client)
@@ -926,9 +932,11 @@ local function EnableZombieHighlights(client)
         local hideEnemies = not zombie_vision or not hasClaws
         local allies = {}
         local traitorAllies = TRAITOR_ROLES[ROLE_ZOMBIE]
+        local showJesters = false
         -- If zombies are traitors and traitor vision or zombie vision is enabled then add all the traitor roles as allies
         if (traitor_vision or zombie_vision) and traitorAllies then
             allies = GetTeamRoles(TRAITOR_ROLES)
+            showJesters = jesters_visible_to_traitors
         -- If zombie vision is enabled, add the allied roles
         elseif zombie_vision then
             -- If they are monsters, ally with Zombies and monster-Vampires
@@ -937,12 +945,14 @@ local function EnableZombieHighlights(client)
                 if MONSTER_ROLES[ROLE_VAMPIRE] then
                     table.insert(allies, ROLE_VAMPIRE)
                 end
+                showJesters = jesters_visible_to_monsters
             else
                 allies = GetTeamRoles(INDEPENDENT_ROLES)
+                showJesters = jesters_visible_to_independents
             end
         end
 
-        OnPlayerHighlightEnabled(client, allies, true, hideEnemies, traitorAllies)
+        OnPlayerHighlightEnabled(client, allies, showJesters, hideEnemies, traitorAllies)
     end)
 end
 local function EnableVampireHighlights(client)
@@ -951,18 +961,21 @@ local function EnableVampireHighlights(client)
         local hideEnemies = not vampire_vision or not hasFangs
         local allies = {}
         local traitorAllies = TRAITOR_ROLES[ROLE_VAMPIRE]
+        local showJesters = false
         -- If vampires are traitors and traitor vision or vampire vision is enabled then add all the traitor roles as allies
         if (traitor_vision or vampire_vision) and traitorAllies then
             allies = GetTeamRoles(TRAITOR_ROLES)
+            showJesters = jesters_visible_to_traitors
         -- If vampire vision is enabled, add the allied monster roles
         elseif vampire_vision then
             allies = {ROLE_VAMPIRE}
             if MONSTER_ROLES[ROLE_ZOMBIE] then
                 table.insert(allies, ROLE_ZOMBIE)
             end
+            showJesters = jesters_visible_to_monsters
         end
 
-        OnPlayerHighlightEnabled(client, allies, true, hideEnemies, traitorAllies)
+        OnPlayerHighlightEnabled(client, allies, showJesters, hideEnemies, traitorAllies)
     end)
 end
 

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -5,7 +5,9 @@ local function SendWeaponDrop()
 
     -- If the player's current weapon is droppable then refresh the weapon switcher
     if LocalPlayer():GetActiveWeapon().AllowDrop then
-        WSWITCH:Refresh()
+        timer.Simple(0.1, function()
+            WSWITCH:Refresh()
+        end)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -3,9 +3,10 @@
 local function SendWeaponDrop()
     RunConsoleCommand("ttt_dropweapon")
 
-    -- Turn off weapon switch display if you had it open while dropping, to avoid
-    -- inconsistencies.
-    WSWITCH:Disable()
+    -- If the player's current weapon is droppable then refresh the weapon switcher
+    if LocalPlayer():GetActiveWeapon().AllowDrop then
+        WSWITCH:Refresh()
+    end
 end
 
 function GM:OnSpawnMenuOpen()

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -1219,37 +1219,15 @@ function CLSCORE:Init(events)
     -- Get start time, traitors, detectives, scores, and nicks
     local starttime = 0
     local scores, nicks, roles = {}, {}, {}
-
-    local game, selected, spawn = false, false, false
     for i = 1, #events do
         local e = events[i]
-        if e.id == EVENT_GAME then
-            if e.state == ROUND_ACTIVE then
-                starttime = e.t
-
-                if selected and spawn then
-                    break
-                end
-
-                game = true
-            end
+        if e.id == EVENT_GAME and e.state == ROUND_ACTIVE then
+            starttime = e.t
         elseif e.id == EVENT_SELECTED then
             roles = e.roles
-
-            if game and spawn then
-                break
-            end
-
-            selected = true
         elseif e.id == EVENT_SPAWN then
             scores[e.sid64] = ScoreInit()
             nicks[e.sid64] = e.ni
-
-            if game and selected then
-                break
-            end
-
-            spawn = true
         end
     end
 

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -606,7 +606,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
                     alive = ply:Alive() and not ply:IsSpec()
                     finalRole = ply:GetRole()
                     -- Sanity check to make sure only valid roles are used for icons and stuff
-                    if finalRole <= ROLE_NONE or finalRole > ROLE_MAX then
+                    if finalRole and finalRole <= ROLE_NONE or finalRole > ROLE_MAX then
                         finalRole = startingRole
                     end
 

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -233,7 +233,7 @@ end)
 
 net.Receive("TTT_SpawnedPlayers", function(len)
     local name = net.ReadString()
-    local role = net.ReadUInt(8)
+    local role = net.ReadInt(8)
     table.insert(spawnedPlayers, name)
     CLSCORE:AddEvent({
         id = EVENT_SPAWN,
@@ -251,7 +251,7 @@ end)
 
 net.Receive("TTT_RoleChanged", function(len)
     local s64 = net.ReadString()
-    local role = net.ReadUInt(8)
+    local role = net.ReadInt(8)
     local ply = GetPlayerFromSteam64(s64)
     local name = "UNKNOWN"
     if IsValid(ply) then

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -312,21 +312,19 @@ function WSWITCH:SelectAndConfirm(slot)
 end
 
 function WSWITCH:Refresh()
-    timer.Simple(0.1, function()
-        local wep_active = LocalPlayer():GetActiveWeapon()
+    local wep_active = LocalPlayer():GetActiveWeapon()
 
-        self:UpdateWeaponCache()
+    self:UpdateWeaponCache()
 
-        -- make our active weapon the initial selection
-        local toselect = 1
-        for k, w in pairs(self.WeaponCache) do
-            if w == wep_active then
-                toselect = k
-                break
-            end
+    -- make our active weapon the initial selection
+    local toselect = 1
+    for k, w in pairs(self.WeaponCache) do
+        if w == wep_active then
+            toselect = k
+            break
         end
-        self:SetSelected(toselect)
-    end)
+    end
+    self:SetSelected(toselect)
 end
 
 local function QuickSlot(ply, cmd, args)

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -266,19 +266,7 @@ function WSWITCH:Enable()
     if self.Show == false then
         self.Show = true
 
-        local wep_active = LocalPlayer():GetActiveWeapon()
-
-        self:UpdateWeaponCache()
-
-        -- make our active weapon the initial selection
-        local toselect = 1
-        for k, w in pairs(self.WeaponCache) do
-            if w == wep_active then
-                toselect = k
-                break
-            end
-        end
-        self:SetSelected(toselect)
+        WSWITCH:Refresh()
     end
 
     -- cache for speed, checked every Think
@@ -324,15 +312,21 @@ function WSWITCH:SelectAndConfirm(slot)
 end
 
 function WSWITCH:Refresh()
-    local wasShown = self.Show
-    self:Disable()
+    timer.Simple(0.1, function()
+        local wep_active = LocalPlayer():GetActiveWeapon()
 
-    -- If the menu was already open, wait a short delay and reopen it
-    if wasShown then
-        timer.Simple(0.1, function()
-            self:Enable()
-        end)
-    end
+        self:UpdateWeaponCache()
+
+        -- make our active weapon the initial selection
+        local toselect = 1
+        for k, w in pairs(self.WeaponCache) do
+            if w == wep_active then
+                toselect = k
+                break
+            end
+        end
+        self:SetSelected(toselect)
+    end)
 end
 
 local function QuickSlot(ply, cmd, args)

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -116,7 +116,13 @@ function WSWITCH:DrawWeapon(x, y, c, wep)
     end
 
     -- Slot
-    local spec = { text = wep.Slot + 1, font = "Trebuchet22", pos = { x + 4, y }, yalign = TEXT_ALIGN_CENTER, color = c.text }
+    local x_offset = 4
+    local slot = wep.Slot + 1
+    -- Offset two-digit numbers less so they fit on the backgorund properly
+    if slot >= 10 then
+        x_offset = 0
+    end
+    local spec = { text = slot, font = "Trebuchet22", pos = { x + x_offset, y }, yalign = TEXT_ALIGN_CENTER, color = c.text }
     draw.TextShadow(spec, 1, c.shadow)
 
     -- Name

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -323,6 +323,18 @@ function WSWITCH:SelectAndConfirm(slot)
     WSWITCH:ConfirmSelection()
 end
 
+function WSWITCH:Refresh()
+    local wasShown = self.Show
+    self:Disable()
+
+    -- If the menu was already open, wait a short delay and reopen it
+    if wasShown then
+        timer.Simple(0.1, function()
+            self:Enable()
+        end)
+    end
+end
+
 local function QuickSlot(ply, cmd, args)
     if (not IsValid(ply)) or (not args) or #args ~= 1 then return end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1408,7 +1408,7 @@ function BeginRound()
         if v:Alive() and v:IsTerror() then
             net.Start("TTT_SpawnedPlayers")
             net.WriteString(v:Nick())
-            net.WriteUInt(v:GetRole(), 8)
+            net.WriteInt(v:GetRole(), 8)
             net.Broadcast()
         end
     end

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -100,7 +100,7 @@ function plymeta:SetRoleAndBroadcast(role)
     if SERVER then
         net.Start("TTT_RoleChanged")
         net.WriteString(self:SteamID64())
-        net.WriteUInt(role, 8)
+        net.WriteInt(role, 8)
         net.Broadcast()
     end
 end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.1.0"
+CR_VERSION = "1.1.2"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")


### PR DESCRIPTION
**Changes**
- Changed the slot number in the weapon switch GUI to still be centered for 2 digit slots

**Fixes**
- Fixed jesters being visible via highlighting when ttt_jesters_visible_to_* was disabled
- Fixed error in round summary caused by a player being an in invalid role state
- Fixed weapon switch GUI not updating when you picked up a new weapon and ttt_weaponswitcher_stay was enabled
- Fixed weapon switch GUI closing when you dropped a weapon and ttt_weaponswitcher_stay was enabled
- Fixed weapon switch GUI closing when you tried to drop an undroppable weapon
- Fixed player not appearing on the round summary screen if they were idled to spectator last round and only un-spectated during this round's preparation phase

**Developers**
- Changed TTT_RoleChanged to use Int for role number
- Changed TTT_SpawnedPlayers to use Int for role number