### PR TITLE
Misc. fixes and additions

### DIFF
--- a/API.md
+++ b/API.md
@@ -614,6 +614,9 @@ Changes made to SWEPs (the data structure used when defining new weapons)
 **SWEP.EquipMenuData** - Updated so `name`, `type`, and `desc` properties can be parameterless functions to allow for parameterized translation.\
 *Added in:* 1.0.8
 
+**SWEP.ShopName** - The weapon name to use in the shop menu. If not provided, `SWEP.PrintName` is used instead.\
+*Added in:* 1.1.9
+
 ## Commands
 
 ### *Client Commands*

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -162,6 +162,7 @@ ttt_vampire_convert_enable                  0       // Whether vampires have the
 ttt_vampire_show_target_icon                0       // Whether vampires have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
 ttt_vampire_damage_reduction                0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a vampire.
 ttt_vampire_fang_timer                      5       // The amount of time fangs must be used to fully drain a target's blood
+ttt_vampire_fang_timer_dead                 0       // The amount of time fangs must be used to fully drain a dead target's blood. Set to 0 to use the same time as "ttt_vampire_fang_timer"
 ttt_vampire_fang_heal                       50      // The amount of health a vVampire will heal by when they fully drain a target's blood
 ttt_vampire_fang_overheal                   25      // The amount over the vampire's normal maximum health (e.g. 100 + this ConVar) that the vampire can heal to by drinking blood.
 ttt_vampire_prime_death_mode                0       // What to do when the prime vampire(s) (e.g. playters who spawn as vampires originally) are killed. 0 - Do nothing. 1 - Kill all vampire thralls (non-prime vampires). 2 - Revert all vampire thralls (non-prime vampires) to their original role.

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -378,7 +378,7 @@ ttt_zombie_respawn_health                   100     // The amount of health a pl
 // ----------------------------------------
 
 // WEAPON SHOP SETTINGS
-ttt_shop_for_all                            0       // Whether all roles should have a shop. Roles that normally do not have a shop will need to have items added via the roleweapon system (see below). Also note that all supporting shop-related convars (such as ttt_*_credits_starting, ttt_*_shop_random_percent, ttt_*_shop_random_enabled, and ttt_*_shop_sync or ttt_*_shop_mode where applicable) will be automatically created but are not documented here to avoid confusion.
+ttt_shop_for_all                            0       // Whether all roles should have a shop. Roles that normally do not have a shop will need to have items added via the roleweapon system (see below). Also note that all supporting shop-related convars (such as ttt_*_credits_starting, ttt_*_shop_random_percent, ttt_*_shop_random_enabled, and ttt_*_shop_sync or ttt_*_shop_mode where applicable) will be automatically created but are not documented here to avoid confusion. Server must be restarted for changes to take effect
 // Random Shop Restriction Percent
 ttt_shop_random_percent                     50      // The percent chance that a weapon in the shop will be not be shown
 ttt_shop_random_position                    0       // Whether to randomize the position of the items in the shop

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -117,7 +117,7 @@ ttt_trickster_min_players                   0       // The minimum number of pla
 ttt_paramedic_min_players                   0       // The minimum number of players required to spawn the paramedic
 ttt_paladin_min_players                     0       // The minimum number of players required to spawn the paladin
 ttt_tracker_min_players                     0       // The minimum number of players required to spawn the tracker
-ttt_medium_min_players                     0       // The minimum number of players required to spawn the medium
+ttt_medium_min_players                      0       // The minimum number of players required to spawn the medium
 ttt_jester_min_players                      0       // The minimum number of players required to spawn the jester
 ttt_swapper_min_players                     0       // The minimum number of players required to spawn the swapper
 ttt_clown_min_players                       0       // The minimum number of players required to spawn the clown
@@ -239,7 +239,7 @@ ttt_detective_disable_looting               0       // Whether to disable a dete
 ttt_all_search_postround                    1       // Whether non-detectives can search bodies post-round or not
 
 // Paladin
-ttt_paladin_aura_radius                     5       // The radius of the paladins aura in meters
+ttt_paladin_aura_radius                     5       // The radius of the paladin's aura in meters
 ttt_paladin_damage_reduction                0.3     // The fraction an attacker's damage will be reduced by when they are shooting a player inside the paladin's aura
 ttt_paladin_heal_rate                       1       // The amount of heal a player inside the paladin's aura will heal each second
 ttt_paladin_protect_self                    0       // Whether the paladin's damage reduction aura will protect themselves or not
@@ -270,7 +270,7 @@ ttt_jester_credits_starting                 0       // The number of credits a j
 // Swapper
 ttt_swapper_respawn_health                  100     // What amount of health to give the swapper when they are killed and respawned
 ttt_swapper_weapon_mode                     1       // How to handle weapons when the Swapper is killed. 0 - Don't swap anything. 1 - Swap role weapons (if there are any). 2 - Swap all weapons.
-ttt_swapper_notify_mode                     0       // The logic to use when notifying players that a swapper is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone.
+ttt_swapper_notify_mode                     0       // The logic to use when notifying players that a swapper is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_swapper_notify_sound                    0       // Whether to play a cheering sound when a swapper is killed
 ttt_swapper_notify_confetti                 0       // Whether to throw confetti when a swapper is a killed
 ttt_swapper_killer_health                   100     // What amount of health to give the person who killed the swapper. Set to "0" to kill them
@@ -292,7 +292,7 @@ ttt_beggar_reveal_traitor                   1       // Who the beggar is reveale
 ttt_beggar_reveal_innocent                  2       // Who the beggar is revealed to when they join the innocent team. 0 - No one. 1 - Everyone. 2 - Traitors. 3 - Innocents
 ttt_beggar_respawn                          0       // Whether the beggar respawns when they are killed before joining another team
 ttt_beggar_respawn_delay                    3       // The delay to use when respawning the begger (if "ttt_beggar_respawn" is enabled)
-ttt_beggar_notify_mode                      0       // The logic to use when notifying players that a beggar is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone.
+ttt_beggar_notify_mode                      0       // The logic to use when notifying players that a beggar is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_beggar_notify_sound                     0       // Whether to play a cheering sound when a beggar is killed
 ttt_beggar_notify_confetti                  0       // Whether to throw confetti when a beggar is a killed
 
@@ -310,7 +310,7 @@ ttt_drunk_sober_time                        180     // Time in seconds for the d
 ttt_drunk_innocent_chance                   0.7     // Chance that the drunk will become an innocent role when remembering their role
 ttt_drunk_any_role                          0       // Whether the drunk can become any enabled role (other than the drunk, the glitch, or roles that were already used this round)
 ttt_drunk_become_clown                      0       // Whether the drunk should become a clown (instead of joining the losing team) if the round would end before they sober up
-ttt_drunk_notify_mode                       0       // The logic to use when notifying players that a drunk has sobered up. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone.
+ttt_drunk_notify_mode                       0       // The logic to use when notifying players that a drunk has sobered up. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_drunk_can_be_traitor                    1       // Whether the drunk can become a traitor
 ttt_drunk_can_be_hypnotist                  1       // Whether the drunk can become a hypnotist
 ttt_drunk_can_be_impersonator               1       // Whether the drunk can become an impersonator
@@ -364,20 +364,21 @@ ttt_zombie_vision_enable                    0       // Whether zombies have thei
 ttt_zombie_spit_enable                      1       // Whether zombies have their spit attack enabled
 ttt_zombie_leap_enable                      1       // Whether zombies have their leap attack enabled
 ttt_zombie_show_target_icon                 0       // Whether zombies have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
-ttt_zombie_damage_penalty                   0.5     // The fraction a zombie's damage will be scaled by when they are attacking without using their claws.
-ttt_zombie_damage_reduction                 0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a zombie.
-ttt_zombie_prime_only_weapons               1       // Whether only prime zombies (e.g. players who spawn as zombies originally) are allowed to pick up weapons.
-ttt_zombie_prime_attack_damage              65      // The amount of a damage a prime zombie (e.g. player who spawned as a zombie originally) does with their claws. Server or round must be restarted for changes to take effect.
-ttt_zombie_prime_attack_delay               0.7     // The amount of time between claw attacks for a prime zombie (e.g. player who spawned as a zombie originally). Server or round must be restarted for changes to take effect.
-ttt_zombie_prime_speed_bonus                0.35    // The amount of bonus speed a prime zombie (e.g. player who spawned as a zombie originally) should get when using their claws. Server or round must be restarted for changes to take effect.
-ttt_zombie_thrall_attack_damage             45      // The amount of a damage a zombie thrall (e.g. non-prime zombie) does with their claws. Server or round must be restarted for changes to take effect.
-ttt_zombie_thrall_attack_delay              1.4     // The amount of time between claw attacks for a zombie thrall (e.g. non-prime zombie). Server or round must be restarted for changes to take effect.
-ttt_zombie_thrall_speed_bonus               0.15    // The amount of bonus speed a zombie thrall (e.g. non-prime zombie) should get when using their claws. Server or round must be restarted for changes to take effect.
-ttt_zombie_respawn_health                   100     // The amount of health a player should respawn with when they are converted to a zombie thrall.
+ttt_zombie_damage_penalty                   0.5     // The fraction a zombie's damage will be scaled by when they are attacking without using their claws
+ttt_zombie_damage_reduction                 0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a zombie
+ttt_zombie_prime_only_weapons               1       // Whether only prime zombies (e.g. players who spawn as zombies originally) are allowed to pick up weapons
+ttt_zombie_prime_attack_damage              65      // The amount of a damage a prime zombie (e.g. player who spawned as a zombie originally) does with their claws. Server or round must be restarted for changes to take effect
+ttt_zombie_prime_attack_delay               0.7     // The amount of time between claw attacks for a prime zombie (e.g. player who spawned as a zombie originally). Server or round must be restarted for changes to take effect
+ttt_zombie_prime_speed_bonus                0.35    // The amount of bonus speed a prime zombie (e.g. player who spawned as a zombie originally) should get when using their claws. Server or round must be restarted for changes to take effect
+ttt_zombie_thrall_attack_damage             45      // The amount of a damage a zombie thrall (e.g. non-prime zombie) does with their claws. Server or round must be restarted for changes to take effect
+ttt_zombie_thrall_attack_delay              1.4     // The amount of time between claw attacks for a zombie thrall (e.g. non-prime zombie). Server or round must be restarted for changes to take effect
+ttt_zombie_thrall_speed_bonus               0.15    // The amount of bonus speed a zombie thrall (e.g. non-prime zombie) should get when using their claws. Server or round must be restarted for changes to take effect
+ttt_zombie_respawn_health                   100     // The amount of health a player should respawn with when they are converted to a zombie thrall
 
 // ----------------------------------------
 
 // WEAPON SHOP SETTINGS
+ttt_shop_for_all                            0       // Whether all roles should have a shop. Roles that normally do not have a shop will need to have items added via the roleweapon system (see below). Also note that while the ttt_*_shop_random_percent and ttt_*_shop_random_enabled convars are created for each role, only the roles that have a shop by default will have their randomization convars show in the ULX module
 // Random Shop Restriction Percent
 ttt_shop_random_percent                     50      // The percent chance that a weapon in the shop will be not be shown
 ttt_shop_random_position                    0       // Whether to randomize the position of the items in the shop
@@ -435,18 +436,18 @@ ttt_mercenary_shop_mode                     2       // What additional items are
 ttt_clown_shop_mode                         0       // What additional items are available to the clown in the shop (See above for possible values)
 
 // Traitor Role Shop Sync (Server or round must be restarted for changes to take effect)
-ttt_hypnotist_shop_sync                     0       // Whether Hypnotists should have all weapons that vanilla traitors have in their weapon shop
-ttt_impersonator_shop_sync                  0       // Whether Impersonators should have all weapons that vanilla traitors have in their weapon shop
-ttt_assassin_shop_sync                      0       // Whether Assassins should have all weapons that vanilla traitors have in their weapon shop
-ttt_vampire_shop_sync                       0       // Whether Vampires should have all weapons that vanilla traitors have in their weapon shop (if they are a Traitor)
-ttt_zombie_shop_sync                        0       // Whether Zombies should have all weapons that vanilla traitors have in their weapon shop (if they are a Traitor)
-ttt_quack_shop_sync                         0       // Whether Quacks should have all weapons that vanilla traitors have in their weapon shop
-ttt_parasite_shop_sync                      0       // Whether Parasites should have all weapons that vanilla traitors have in their weapon shop
+ttt_hypnotist_shop_sync                     0       // Whether hypnotists should have all weapons that vanilla traitors have in their weapon shop
+ttt_impersonator_shop_sync                  0       // Whether impersonators should have all weapons that vanilla traitors have in their weapon shop
+ttt_assassin_shop_sync                      0       // Whether assassins should have all weapons that vanilla traitors have in their weapon shop
+ttt_vampire_shop_sync                       0       // Whether vampires should have all weapons that vanilla traitors have in their weapon shop (if they are a traitor)
+ttt_zombie_shop_sync                        0       // Whether zombies should have all weapons that vanilla traitors have in their weapon shop (if they are a traitor)
+ttt_quack_shop_sync                         0       // Whether quacks should have all weapons that vanilla traitors have in their weapon shop
+ttt_parasite_shop_sync                      0       // Whether parasites should have all weapons that vanilla traitors have in their weapon shop
 
 // Detective Role Shop Sync (Server or round must be restarted for changes to take effect)
-ttt_paladin_shop_sync                       0       // Whether Paladins should have all weapons that vanilla detectives have in their weapon shop
-ttt_tracker_shop_sync                       0       // Whether Trackers should have all weapons that vanilla detectives have in their weapon shop
-ttt_medium_shop_sync                       0       // Whether Mediums should have all weapons that vanilla detectives have in their weapon shop
+ttt_paladin_shop_sync                       0       // Whether paladins should have all weapons that vanilla detectives have in their weapon shop
+ttt_tracker_shop_sync                       0       // Whether trackers should have all weapons that vanilla detectives have in their weapon shop
+ttt_medium_shop_sync                        0       // Whether mediums should have all weapons that vanilla detectives have in their weapon shop
 
 // ----------------------------------------
 

--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -378,7 +378,7 @@ ttt_zombie_respawn_health                   100     // The amount of health a pl
 // ----------------------------------------
 
 // WEAPON SHOP SETTINGS
-ttt_shop_for_all                            0       // Whether all roles should have a shop. Roles that normally do not have a shop will need to have items added via the roleweapon system (see below). Also note that while the ttt_*_shop_random_percent and ttt_*_shop_random_enabled convars are created for each role, only the roles that have a shop by default will have their randomization convars show in the ULX module
+ttt_shop_for_all                            0       // Whether all roles should have a shop. Roles that normally do not have a shop will need to have items added via the roleweapon system (see below). Also note that all supporting shop-related convars (such as ttt_*_credits_starting, ttt_*_shop_random_percent, ttt_*_shop_random_enabled, and ttt_*_shop_sync or ttt_*_shop_mode where applicable) will be automatically created but are not documented here to avoid confusion.
 // Random Shop Restriction Percent
 ttt_shop_random_percent                     50      // The percent chance that a weapon in the shop will be not be shown
 ttt_shop_random_position                    0       // Whether to randomize the position of the items in the shop

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -10,6 +10,7 @@
 - Added the option for the paladin's damage reduction aura to protect themselves (disabled by default)
 - Added the option for the paladin's healing aura to heal themselves (enabled by default)
 - Added the option for the quack's fake parasite cure to kill uninfected users (disabled by default)
+- Added the option to set the amount of time it takes a vampire to drain a dead body to a different amount of time than if the target is alive (disabled by default)
 
 ### Changes
 - Changed the quack's fake parasite cure to display as a real parasite cure to non-traitors
@@ -20,6 +21,7 @@
 - Fixed case where multiple vampires draining the same target would have the target unfreeze when any of the vampires quit draining
 - Fixed assassin not being able to see which players are infected by a parasite on the scoreboard
 - Fixed only assassin target or parasite infection showing on the scoreboard and target ID (when you look at a player) even if a player should see both
+- Fixed vampires not being able to drain dead players
 
 ### Developer
 - Updated GetTeamRoles to take an optional lookup table of excluded roles

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,5 +1,15 @@
 # Beta Release Notes
 
+## 1.1.10
+**Released:**
+
+### Additions
+- Added the option to set the amount of time it takes a vampire to drain a dead body to a different amount of time than if the target is alive (disabled by default)
+- Added option to enable shop for all roles (disabled by default)
+
+### Fixes
+- Fixed vampires not being able to drain dead players
+
 ## 1.1.9
 **Released: September 2nd, 2021**
 
@@ -10,7 +20,6 @@
 - Added the option for the paladin's damage reduction aura to protect themselves (disabled by default)
 - Added the option for the paladin's healing aura to heal themselves (enabled by default)
 - Added the option for the quack's fake parasite cure to kill uninfected users (disabled by default)
-- Added the option to set the amount of time it takes a vampire to drain a dead body to a different amount of time than if the target is alive (disabled by default)
 - Added a message that is displayed when a traitor picks up a parasite cure to distinguish if it is real or fake
 
 ### Changes
@@ -22,7 +31,6 @@
 - Fixed case where multiple vampires draining the same target would have the target unfreeze when any of the vampires quit draining
 - Fixed assassin not being able to see which players are infected by a parasite on the scoreboard
 - Fixed only assassin target or parasite infection showing on the scoreboard and target ID (when you look at a player) even if a player should see both
-- Fixed vampires not being able to drain dead players
 
 ### Developer
 - Updated GetTeamRoles to take an optional lookup table of excluded roles

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Fixed vampires not being able to drain dead players
+- Fixed traitors being able to see detective, special detective, and clown icons through walls
 
 ## 1.1.9
 **Released: September 2nd, 2021**

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -169,6 +169,9 @@ function GM:PostDrawTranslucentRenderables()
                             else
                                 role = v:GetNWInt("GlitchBluff", ROLE_TRAITOR)
                             end
+                        -- Disable "No Z" for other icons like the Clown and Detective-like roles
+                        else
+                            noz = false
                         end
                     elseif client:IsMonsterTeam() then
                         if v:IsMonsterTeam() then

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -304,6 +304,7 @@ CreateConVar("ttt_det_credits_traitordead", "1")
 
 -- Shop parameters
 CreateConVar("ttt_shop_for_all", 0, FCVAR_REPLICATED)
+-- Add any convars that are missing once shop-for-all is enabled
 cvars.AddChangeCallback("ttt_shop_for_all", function(convar, oldValue, newValue)
     local enabled = tobool(newValue)
     if enabled then

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1857,6 +1857,7 @@ function SelectRoles()
                 for i, j in pairs(choices) do
                     if v == j then
                         index = i
+                        break
                     end
                 end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -303,30 +303,26 @@ CreateConVar("ttt_det_credits_traitorkill", "0")
 CreateConVar("ttt_det_credits_traitordead", "1")
 
 -- Shop parameters
+CreateConVar("ttt_shop_for_all", 0, FCVAR_REPLICATED)
+cvars.AddChangeCallback("ttt_shop_for_all", function(convar, oldValue, newValue)
+    local enabled = tobool(newValue)
+    if enabled then
+        for role = 0, ROLE_MAX do
+            if not SHOP_ROLES[role] then
+                CreateShopConVars(role)
+                SHOP_ROLES[role] = true
+                timer.Simple(0.25, function()
+                    SyncShopConVars(role)
+                end)
+            end
+        end
+    end
+
+    SetGlobalBool("ttt_shop_for_all", enabled)
+end)
+
 for _, role in ipairs(GetTeamRoles(SHOP_ROLES)) do
-    local rolestring = ROLE_STRINGS_RAW[role]
-    if not DEFAULT_ROLES[role] then
-        local credits = "0"
-        if TRAITOR_ROLES[role] then credits = "1"
-        elseif DETECTIVE_ROLES[role] then credits = "1"
-        elseif role == ROLE_MERCENARY then credits = "1"
-        elseif role == ROLE_KILLER then credits = "2"
-        elseif role == ROLE_DOCTOR then credits = "1" end
-        CreateConVar("ttt_" .. rolestring .. "_credits_starting", credits, FCVAR_REPLICATED)
-    end
-
-    CreateConVar("ttt_" .. rolestring .. "_shop_random_percent", "0", FCVAR_REPLICATED, "The percent chance that a weapon in the shop will not be shown for the " .. rolestring, 0, 100)
-    CreateConVar("ttt_" .. rolestring .. "_shop_random_enabled", "0", FCVAR_REPLICATED, "Whether shop randomization should run for the " .. rolestring)
-
-    if (TRAITOR_ROLES[role] and role ~= ROLE_TRAITOR) or (DETECTIVE_ROLES[role] and role ~= ROLE_DETECTIVE) or role == ROLE_ZOMBIE then -- This all happens before we run UpdateRoleState so we need to manually add zombies
-        CreateConVar("ttt_" .. rolestring .. "_shop_sync", "0", FCVAR_REPLICATED)
-    end
-
-    if role == ROLE_MERCENARY then
-        CreateConVar("ttt_" .. rolestring .. "_shop_mode", "2", FCVAR_REPLICATED)
-    elseif (INDEPENDENT_ROLES[role] and role ~= ROLE_ZOMBIE) or role == ROLE_CLOWN then
-        CreateConVar("ttt_" .. rolestring .. "_shop_mode", "0", FCVAR_REPLICATED)
-    end
+    CreateShopConVars(role)
 end
 CreateConVar("ttt_shop_random_percent", "50", FCVAR_REPLICATED, "The percent chance that a weapon in the shop will not be shown by default", 0, 100)
 CreateConVar("ttt_shop_random_position", "0", FCVAR_REPLICATED, "Whether to randomize the position of the items in the shop")
@@ -657,18 +653,7 @@ function GM:SyncGlobals()
         SetGlobalString("ttt_" .. rolestring .. "_name_plural", GetConVar("ttt_" .. rolestring .. "_name_plural"):GetString())
         SetGlobalString("ttt_" .. rolestring .. "_name_article", GetConVar("ttt_" .. rolestring .. "_name_article"):GetString())
         if SHOP_ROLES[role] then
-            SetGlobalInt("ttt_" .. rolestring .. "_shop_random_percent", GetConVar("ttt_" .. rolestring .. "_shop_random_percent"):GetInt())
-            SetGlobalBool("ttt_" .. rolestring .. "_shop_random_enabled", GetConVar("ttt_" .. rolestring .. "_shop_random_enabled"):GetBool())
-
-            local sync_cvar = "ttt_" .. rolestring .. "_shop_sync"
-            if ConVarExists(sync_cvar) then
-                SetGlobalBool(sync_cvar, GetConVar(sync_cvar):GetBool())
-            end
-
-            local mode_cvar = "ttt_" .. rolestring .. "_shop_mode"
-            if ConVarExists(mode_cvar) then
-                SetGlobalInt(mode_cvar, GetConVar(mode_cvar):GetInt())
-            end
+            SyncShopConVars(role)
         end
     end
 

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -83,6 +83,11 @@ function plymeta:IsSpecial() return self:GetRole() ~= ROLE_INNOCENT end
 function plymeta:IsCustom() return not DEFAULT_ROLES[self:GetRole()] end
 function plymeta:IsShopRole()
     local hasShop = SHOP_ROLES[self:GetRole()] or false
+    -- Don't perform the additional checks if "shop for all" is enabled
+    if GetGlobalBool("ttt_shop_for_all", false) then
+        return hasShop
+    end
+
     -- If this is a jester team member with a potential shop, only give them access if there are actual things to buy
     if hasShop and self:IsJesterTeam() then
         local hasWeapon = WEPS.DoesRoleHaveWeapon(self:GetRole())
@@ -96,8 +101,13 @@ function plymeta:IsShopRole()
     return hasShop
 end
 function plymeta:CanUseShop()
-    return self:IsShopRole() and
-        (not self:IsDeputy() or self:GetNWBool("HasPromotion", false))
+    local isShopRole = self:IsShopRole()
+    -- Don't perform the additional checks if "shop for all" is enabled
+    if GetGlobalBool("ttt_shop_for_all", false) then
+        return isShopRole
+    end
+
+    return isShopRole and (not self:IsDeputy() or self:GetNWBool("HasPromotion", false))
 end
 function plymeta:CanUseTraitorButton(active_only)
     if active_only and not self:IsActive() then return false end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -301,7 +301,8 @@ if CLIENT then
 else
     function CreateShopConVars(role)
         local rolestring = ROLE_STRINGS_RAW[role]
-        if not DEFAULT_ROLES[role] then
+        -- Add explicit ROLE_INNOCENT exclusion here in case shop-for-all is enabled
+        if not DEFAULT_ROLES[role] or role == ROLE_INNOCENT then
             local credits = "0"
             if TRAITOR_ROLES[role] then credits = "1"
             elseif DETECTIVE_ROLES[role] then credits = "1"

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -315,7 +315,7 @@ local function GiveEquipmentWeapon(sid, cls)
     local ply = player.GetBySteamID64(sid)
     local tmr = "give_equipment" .. sid
 
-    if (not IsValid(ply)) or (not ply:IsActiveSpecial()) then
+    if (not IsValid(ply)) or (not ply:IsShopRole(true)) then
         timer.Remove(tmr)
         return
     end


### PR DESCRIPTION
**Additions**
- Added the option to set the amount of time it takes a vampire to drain a dead body to a different amount of time than if the target is alive (disabled by default)
- Added option to enable shop for all roles (disabled by default)

**Fixes**
- Fixed vampires not being able to drain dead players
- Fixed traitors being able to see detective, special detective, and clown icons through walls