### PR TITLE
Added convars to control defib and hypnotist device availability

### DIFF
--- a/CONVARS_BETA.md
+++ b/CONVARS_BETA.md
@@ -142,6 +142,8 @@ ttt_single_deputy_impersonator              0       // Whether only a single dep
 
 // Hypnotist
 ttt_hypnotist_credits_starting              1       // The number of credits a hypnotist should start with
+ttt_hypnotist_device_loadout                1       // Whether the hypnotist's defib should be given to them when they spawn. Server must be restarted for changes to take effect
+ttt_hypnotist_device_shop                   0       // Whether the hypnotist's defib should be purchasable in the shop. Server must be restarted for changes to take effect
 ttt_single_paramedic_hypnotist              0       // Whether only a single paramedic or hynotist should spawn in a round
 
 // Assassin
@@ -233,6 +235,10 @@ ttt_veteran_shop_delay                      0       // Whether the veteran's pur
 
 // Doctor
 ttt_doctor_credits_starting                 1       // The number of credits a doctor should start with
+
+// Paramedic
+ttt_paramedic_device_loadout                1       // Whether the paramedic's defib should be given to them when they spawn. Server must be restarted for changes to take effect
+ttt_paramedic_device_shop                   0       // Whether the paramedic's defib should be purchasable in the shop (requires ttt_shop_for_all to be enabled). Server must be restarted for changes to take effect
 
 // ----------------------------------------
 

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,8 +1,17 @@
 # Beta Release Notes
 
+## 1.2.5
+**Released:**
+
+### Additions
+- Added ability to add the hypnotist's device to their shop (disabled by default)
+- Added ability to add the paramedic's defib to their shop (disabled by default, requires shop-for-all to be enabled)
+- Added ability to control whether the hypnotist spawns with their device (enabled by default)
+- Added ability to control whether the paramedic spawns with their defib (enabled by default)
+
 ## 1.2.4
 **Released: September 15th, 2021**
 
 ### Additions
 - Added ability for the old man to enter an adrenaline rush and hold off death for 5 seconds (enabled by default)
-- Added double barrel shotgun which is given to the old man when they enter an adrenaline rush (enabeld by default)
+- Added double barrel shotgun which is given to the old man when they enter an adrenaline rush (enabled by default)

--- a/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
@@ -41,6 +41,7 @@ SWEP.Secondary.Automatic = false
 SWEP.Secondary.Delay = 1.25
 
 SWEP.InLoadoutFor = {ROLE_HYPNOTIST}
+SWEP.InLoadoutForDefault = {ROLE_HYPNOTIST}
 
 SWEP.Charge = 0
 SWEP.Timer = -1

--- a/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
@@ -41,6 +41,7 @@ SWEP.Secondary.Automatic = false
 SWEP.Secondary.Delay = 1.25
 
 SWEP.InLoadoutFor = {ROLE_PARAMEDIC}
+SWEP.InLoadoutForDefault = {ROLE_PARAMEDIC}
 
 SWEP.Charge = 0
 SWEP.Timer = -1

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -149,6 +149,9 @@ CreateConVar("ttt_traitor_vision_enable", "0")
 CreateConVar("ttt_impersonator_damage_penalty", "0")
 CreateConVar("ttt_impersonator_use_detective_icon", "1")
 
+CreateConVar("ttt_hypnotist_device_loadout", "1")
+CreateConVar("ttt_hypnotist_device_shop", "0")
+
 CreateConVar("ttt_assassin_show_target_icon", "0")
 CreateConVar("ttt_assassin_target_vision_enable", "0")
 CreateConVar("ttt_assassin_next_target_delay", "5")
@@ -201,6 +204,9 @@ CreateConVar("ttt_veteran_damage_bonus", "0.5")
 CreateConVar("ttt_veteran_full_heal", "1")
 CreateConVar("ttt_veteran_heal_bonus", "0")
 CreateConVar("ttt_veteran_announce", "0")
+
+CreateConVar("ttt_paramedic_device_loadout", "1")
+CreateConVar("ttt_paramedic_device_shop", "0")
 
 -- Detective role properties
 CreateConVar("ttt_detective_search_only", "1")
@@ -687,11 +693,17 @@ function GM:SyncGlobals()
 
     SetGlobalBool("ttt_deputy_use_detective_icon", GetConVar("ttt_deputy_use_detective_icon"):GetBool())
 
+    SetGlobalBool("ttt_paramedic_device_loadout", GetConVar("ttt_paramedic_device_loadout"):GetBool())
+    SetGlobalBool("ttt_paramedic_device_shop", GetConVar("ttt_paramedic_device_shop"):GetBool())
+
     SetGlobalFloat("ttt_paladin_aura_radius", GetConVar("ttt_paladin_aura_radius"):GetInt() * 52.49)
 
     SetGlobalInt("ttt_tracker_footstep_time", GetConVar("ttt_tracker_footstep_time"):GetInt())
 
     SetGlobalBool("ttt_traitor_vision_enable", GetConVar("ttt_traitor_vision_enable"):GetBool())
+
+    SetGlobalBool("ttt_hypnotist_device_loadout", GetConVar("ttt_hypnotist_device_loadout"):GetBool())
+    SetGlobalBool("ttt_hypnotist_device_shop", GetConVar("ttt_hypnotist_device_shop"):GetBool())
 
     SetGlobalBool("ttt_assassin_show_target_icon", GetConVar("ttt_assassin_show_target_icon"):GetBool())
     SetGlobalBool("ttt_assassin_target_vision_enable", GetConVar("ttt_assassin_target_vision_enable"):GetBool())

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.2.4"
+CR_VERSION = "1.2.5"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")
@@ -1057,12 +1057,38 @@ function UpdateRoleWeaponState()
     -- If the parasite is not enabled, don't let anyone buy the cure
     local parasite_cure = weapons.GetStored("weapon_par_cure")
     local fake_cure = weapons.GetStored("weapon_qua_fake_cure")
-    if not GetGlobalBool("ttt_parasite_enabled", false) then
-        table.Empty(parasite_cure.CanBuy)
-        table.Empty(fake_cure.CanBuy)
-    else
+    if GetGlobalBool("ttt_parasite_enabled", false) then
         parasite_cure.CanBuy = table.Copy(parasite_cure.CanBuyDefault)
         fake_cure.CanBuy = table.Copy(fake_cure.CanBuyDefault)
+    else
+        table.Empty(parasite_cure.CanBuy)
+        table.Empty(fake_cure.CanBuy)
+    end
+
+    -- Hypnotist
+    local hypnotist_defib = weapons.GetStored("weapon_hyp_brainwash")
+    if GetGlobalBool("ttt_hypnotist_device_loadout", false) then
+        hypnotist_defib.InLoadoutFor = table.Copy(hypnotist_defib.InLoadoutForDefault)
+    else
+        table.Empty(hypnotist_defib.InLoadoutFor)
+    end
+    if GetGlobalBool("ttt_hypnotist_device_shop", false) then
+        hypnotist_defib.CanBuy = {ROLE_HYPNOTIST}
+    else
+        hypnotist_defib.CanBuy = nil
+    end
+
+    -- Paramedic
+    local paramedic_defib = weapons.GetStored("weapon_med_defib")
+    if GetGlobalBool("ttt_paramedic_device_loadout", false) then
+        paramedic_defib.InLoadoutFor = table.Copy(paramedic_defib.InLoadoutForDefault)
+    else
+        table.Empty(paramedic_defib.InLoadoutFor)
+    end
+    if GetGlobalBool("ttt_paramedic_device_shop", false) then
+        paramedic_defib.CanBuy = {ROLE_PARAMEDIC}
+    else
+        paramedic_defib.CanBuy = nil
     end
 
     if SERVER then


### PR DESCRIPTION
**Additions**
- Added ability to add the hypnotist's device to their shop (disabled by default)
- Added ability to add the paramedic's defib to their shop (disabled by default, requires shop-for-all to be enabled)
- Added ability to control whether the hypnotist spawns with their device (enabled by default)
- Added ability to control whether the paramedic spawns with their defib (enabled by default)

**NOTE**: The weapons do _not_ have icons for the shop. If we want to do that we'll have to figure out what they should look like