### PR TITLE
Win fixes

### DIFF
--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,5 +1,15 @@
 # Beta Release Notes
 
+## 1.2.6
+**Released: September 25th, 2021**
+
+### Fixes
+- Fixed external roles with long names and custom win conditions having their win title cut off
+- Fixed map wins being ignored when an external role with a custom win condition was in use
+
+### Developer
+- Fixed generated win and event identifiers resetting if lua is refreshed
+
 ## 1.2.5
 **Released: September 25th, 2021**
 

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -30,6 +30,14 @@ surface.CreateFont("WinHuge", {
     extended = true
 })
 
+surface.CreateFont("WinLarge", {
+    font = "Trebuchet24",
+    size = 48,
+    weight = 1000,
+    shadow = true,
+    extended = true
+})
+
 surface.CreateFont("WinSmall", {
     font = "Trebuchet24",
     size = 32,
@@ -744,10 +752,21 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     bg:SetPos(0, 0)
 
     local winlbl = vgui.Create("DLabel", dpanel)
-    winlbl:SetFont("WinHuge")
-    winlbl:SetText(PT(title.txt, title.params or {}))
+    local winfont = "WinHuge"
+    local wintxt = PT(title.txt, title.params or {})
+    -- Scale the title down if there are too many letters
+    if #wintxt > 20 then
+        winfont = "WinLarge"
+    end
+    winlbl:SetFont(winfont)
+    winlbl:SetText(wintxt)
     winlbl:SetTextColor(COLOR_WHITE)
     winlbl:SizeToContents()
+
+    -- Set a fixed height to make sure the different font sizes don't break the layout
+    local lblw, _ = winlbl:GetSize()
+    winlbl:SetSize(lblw, 73)
+
     local xwin = (w - winlbl:GetWide())/2
     local ywin = 15
     winlbl:SetPos(xwin, ywin)
@@ -1020,10 +1039,21 @@ function CLSCORE:BuildHilitePanel(dpanel)
     bg:SetPos(0,0)
 
     local winlbl = vgui.Create("DLabel", dpanel)
-    winlbl:SetFont("WinHuge")
-    winlbl:SetText(PT(title.txt, title.params or {}))
+    local winfont = "WinHuge"
+    local wintxt = PT(title.txt, title.params or {})
+    -- Scale the title down if there are too many letters
+    if #wintxt > 20 then
+        winfont = "WinLarge"
+    end
+    winlbl:SetFont(winfont)
+    winlbl:SetText(wintxt)
     winlbl:SetTextColor(COLOR_WHITE)
     winlbl:SizeToContents()
+
+    -- Set a fixed height to make sure the different font sizes don't break the layout
+    local lblw, _ = winlbl:GetSize()
+    winlbl:SetSize(lblw, 73)
+
     local xwin = (w - winlbl:GetWide())/2
     local ywin = 15
     winlbl:SetPos(xwin, ywin)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.2.5"
+CR_VERSION = "1.2.6"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")
@@ -789,7 +789,10 @@ EVENT_BEGGARCONVERTED = 25
 EVENT_BEGGARKILLED = 26
 EVENT_INFECT = 27
 
-EVENT_MAX = 27
+-- Don't redefine this every time we load this file
+if not EVENT_MAX then
+    EVENT_MAX = 27
+end
 
 function GenerateNewEventID()
     EVENT_MAX = EVENT_MAX + 1
@@ -808,7 +811,10 @@ WIN_ZOMBIE = 9
 WIN_MONSTER = 10
 WIN_VAMPIRE = 11
 
-WIN_MAX = 11
+-- Don't redefine this every time we load this file
+if not WIN_MAX then
+    WIN_MAX = 11
+end
 
 function GenerateNewWinID()
     WIN_MAX = WIN_MAX + 1


### PR DESCRIPTION
**Fixes**
- Fixed external roles with long names and custom win conditions having their win title cut off
- Fixed map wins being ignored when an external role with a custom win condition was in use

**Developer**
- Fixed generated win and event identifiers resetting if lua is refreshed