### PR TITLE
Misc. changes, fixes, and additions

### DIFF
--- a/API.md
+++ b/API.md
@@ -642,11 +642,19 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 *Return:* Whether or not the given player should be prevented from being rewarded with karma (Defaults to `false`).
 
+**TTTPlayerRoleChanged(ply, oldRole, newRole)** - Called after a player's role has changed.\
+*Realm:* Client and Server\
+*Added in:* 1.2.7\
+*Parameters:*
+- *ply* - The player whose role is being changed
+- *oldRole* - The role the player had before this change
+- *newRole* - The role the player is changing to
+
 **TTTPlayerSpawnForRound(ply, deadOnly)** - Called before a player is spawned for a round. Also used when reviving a player (via a defib, zombie conversion, etc.).\
 *Realm:* Server\
 *Added in:* 1.2.7\
 *Parameters:*
-- *ply* - The player who is being spawn
+- *ply* - The player who is being spawned or respawned
 - *deadOnly* - Whether this call is specifically targetted at dead players
 
 **TTTPrintResultMessage(type)** - Called before the round win results message is printed to the top-right corner of the screen. Can be used to print a replacement message for custom win types that this would not normally handle.\

--- a/API.md
+++ b/API.md
@@ -154,7 +154,7 @@ Enumerations available globally (within the defined realm). There are additional
 - ROLE_CONVAR_TYPE_BOOL = A boolean. Will use a checkbox in the configuration UI.
 - ROLE_CONVAR_TYPE_TEXT = A text value. Will use a text box in the configuration UI.
 
-**ROLE_TEAM_\*** - Which team an external role is registered to.\
+**ROLE_TEAM_\*** - Which role team an external role is registered to. A "role team" is a way of grouping roles by common functionality and mostly maps to the logical team with the exception of the detective role team. The detective role team is part of the innocent logical team.\
 *Realm:* Client and Server\
 *Added in:* 1.0.9\
 *Values:*
@@ -381,6 +381,12 @@ Variables available when called from a Player object (within the defined realm)
 **plymeta:GetHeight()** - Gets the *estimated* height of the player based on their player model.\
 *Realm:* Client\
 *Added in:* 1.0.2
+
+**plymeta:GetRoleTeam(detectivesAreInnocent)** - Gets which "role team" a player belongs to (see ROLE_TEAM_* global enumeration).\
+*Realm:* Client and Server\
+*Added in:* 1.2.7\
+*Parameters:*
+- *detectivesAreInnocent* - Whether to include members of the detective "role team" in the innocent "role team" to match the logical teams
 
 **plymeta:GetVampirePreviousRole()** - Gets the player's previous role if they are a Vampire that has been converted or `ROLE_NONE` otherwise.\
 *Realm:* Client and Server\

--- a/API.md
+++ b/API.md
@@ -262,6 +262,16 @@ Methods available globally (within the defined realm)
 *Parameters:*
 - *aliveOnly* - Whether this filter should only include live players (Defaults to `false`).
 
+**OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies, traitorAllies)** - Handles player highlighting (colored glow around players) rules for the local player.\
+*Realm:* Client\
+*Added in:* 1.2.7\
+*Parameters:*
+- *client* - The local player
+- *alliedRoles* - Table of role IDs that should show as allied to the current player
+- *showJesters* - Whether jester roles should be highlighted in the jester color. If `false`, jesters will appear in the generic enemy color instead
+- *hideEnemies* - Whether enemy roles (e.g. anyone that isn't an ally or a jester if *showJesters* is enabled) should be highlighted
+- *traitorAllies* - Whether this role's allies are traitors. If `true`, allied roles will be shown in the traitor color. Otherwise allied roles will be shown in the innocent color
+
 **RegisterRole(roleTable)** - Registers a role with Custom Roles for TTT. See [here](CREATE_YOUR_OWN_ROLE.md) for instructions on how to create a role and role table structure.\
 *Realm:* Client and Server\
 *Added in:* 1.0.9
@@ -596,6 +606,49 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 *Return:* Whether or not the given player should be able to identify the given corpse (Defaults to `false`).
 
+**TTTEventFinishText(e)** - Called before the event text for the "round finished" event is rendered in the end-of-round summary's Events tab.\
+*Realm:* Client\
+*Added in:* 1.2.7\
+*Parameters:*
+- *e* - Event parameters. Contains the following properties:
+  - `id` - The event identifier (always `EVENT_FINISH`)
+  - `t` - The time when this event occurred
+  - `win` - The win condition identifier
+
+*Return:* Text to show in events list at the end of the round
+
+**TTTEventFinishIconText(e, winString, roleString)** - Called before the event icon for the "round finished" event is rendered in the end-of-round summary's Events tab. Used to change the mouseover text for the icon.\
+*Realm:* Client\
+*Added in:* 1.2.7\
+*Parameters:*
+- *e* - Event parameters. Contains the following properties:
+  - `id` - The event identifier (always `EVENT_FINISH`)
+  - `t` - The time when this event occurred
+  - `win` - The win condition identifier
+- *winString* - The translation string that will be used to display the icon mouseover text
+- *roleString* - The role string to use in place of the `role` placeholder in the translation string
+
+*Return:*
+- *winString* - The new winString value to use or the original passed into the hook
+- *roleString* - The new roleString value to use or the original passed into the hook
+
+**TTTKarmaGiveReward(ply, reward, victim)** - Called before a player is rewarded with karma. Used to block a player's karma reward.\
+*Realm:* Server\
+*Added in:* 1.2.7\
+*Parameters:*
+- *ply* - The player who will be rewarded karma
+- *reward* - The amount of karma the player will be rewarded with
+- *victim* - The victim of the event that is rewarding the player with karma. If this is not a player, karma is being rewarded as part of the end of the round
+
+*Return:* Whether or not the given player should be prevented from being rewarded with karma (Defaults to `false`).
+
+**TTTPlayerSpawnForRound(ply, deadOnly)** - Called before a player is spawned for a round. Also used when reviving a player (via a defib, zombie conversion, etc.).\
+*Realm:* Server\
+*Added in:* 1.2.7\
+*Parameters:*
+- *ply* - The player who is being spawn
+- *deadOnly* - Whether this call is specifically targetted at dead players
+
 **TTTPrintResultMessage(type)** - Called before the round win results message is printed to the top-right corner of the screen. Can be used to print a replacement message for custom win types that this would not normally handle.\
 *Realm:* Server\
 *Added in:* 1.0.14\
@@ -780,6 +833,10 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 *Return:* The stamina value to assign to the player. If none is provided, the player's stamina will not be changed.
 
+**TTTSyncGlobals()** - Called when the server is syncing convars to global variables for client access.\
+*Realm:* Server\
+*Added in:* 1.2.7
+
 **TTTTargetIDPlayerHealth(ply, client, text, clr)** - Called before a player's heath status (shown when you look at a player) is rendered.\
 *Realm:* Client\
 *Added in:* 1.2.5\
@@ -913,6 +970,10 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
 - *clr* - The new clr value to use or the original passed into the hook
+
+**TTTUpdateRoleState()** - Called after role states and role weapon states have been updated. At this point you can be assured that a role belongs to the team it has been configured to be on.\
+*Realm:* Client and Server\
+*Added in:* 1.2.7
 
 ## SWEPs
 Changes made to SWEPs (the data structure used when defining new weapons)

--- a/API.md
+++ b/API.md
@@ -704,7 +704,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 *Parameters:*
 - *ply* - The player being rendered
 - *client* - The local player
-- *color* - The background [Color](https://wiki.facepunch.com/gmod/Global.Color) to use
+- *color* - The background [Color](https://wiki.facepunch.com/gmod/Color) to use
 - *roleFileName* - The portion of the scoring icon path that indicates which role it belongs to. Used in the following icon path pattern: "vgui/ttt/tab_{roleFileName}.png"
 
 *Return:*
@@ -719,7 +719,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ply* - The player being rendered
 - *roleFileName* - The portion of the scoring icon path that indicates which role it belongs to. Used in the following icon path pattern: "vgui/ttt/score_{roleFileName}.png"
 - *groupingRole* - The role to use when determining the section to of the summary screen to put this player in
-- *roleColor* - The background [Color](https://wiki.facepunch.com/gmod/Global.Color) to use behind the role icon
+- *roleColor* - The background [Color](https://wiki.facepunch.com/gmod/Color) to use behind the role icon
 - *nameLabel* - The name that is going to be used for this player on the round summary *(Added in 1.2.3)*
 
 *Return:*
@@ -740,7 +740,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 *Return:*
 - *newTitle*
   - *txt* - The translation string to use to get the winning team text
-  - *c* - The background [Color](https://wiki.facepunch.com/gmod/Global.Color) to use
+  - *c* - The background [Color](https://wiki.facepunch.com/gmod/Color) to use
   - *params* - Any parameters to use when translating `txt` (Optional if `new_secondary_win_role` is also omitted)
 - *newSecondaryWinRole* - Which role should share in the win for this round (see ROLE_* global enumeration) (Optional) *(Added in 1.1.9)*
 
@@ -841,6 +841,23 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 *Return:* The stamina value to assign to the player. If none is provided, the player's stamina will not be changed.
 
+**TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)** - .\
+*Realm:* Client\
+*Added in:* 1.2.7\
+*Parameters:*
+- *ply* - The target player being rendered
+- *client* - The local player
+- *shouldSmoke* - Whether the player would normally emit smoke
+- *smokeColor* - What [Color](https://wiki.facepunch.com/gmod/Color) the smoke will be. (Defaults to `COLOR_BLACK`)
+- *smokeParticle* - What particle the smoke will use. Should be the relative path the the `.vmt` file for the particle. (Defaults to `"particle/snow.vmt"`)
+- *smokeOffset* - A [Vector](https://wiki.facepunch.com/gmod/Vector) representing the relative offset from the player's feet. (Defaults to `Vector(0, 0, 30)`)
+
+*Return:*
+- *shouldSmoke* - The new shouldSmoke value to use or the original passed into the hook
+- *smokeColor* - The new smokeColor value to use or the original passed into the hook
+- *smokeParticle* - The new smokeParticle value to use or the original passed into the hook
+- *smokeOffset* - The new smokeOffset value to use or the original passed into the hook
+
 **TTTSyncGlobals()** - Called when the server is syncing convars to global variables for client access.\
 *Realm:* Server\
 *Added in:* 1.2.7
@@ -852,7 +869,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ply* - The target player being rendered
 - *client* - The local player
 - *text* - The health-related text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
@@ -865,7 +882,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ent* - The target entity being rendered. Guaranteed to not be a player.
 - *client* - The local player
 - *text* - The label for the hint-related text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
@@ -878,7 +895,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ent* - The target entity being rendered. Not necessarily a player so be sure to check `ent:IsPlayer()` if needed
 - *client* - The local player
 - *text* - The hint-related text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
@@ -891,7 +908,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ply* - The target player being rendered
 - *client* - The local player
 - *text* - The karma-related text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
@@ -915,7 +932,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ply* - The target player being rendered
 - *client* - The local player
 - *text* - The player's name text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
@@ -931,7 +948,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 *Return:*
 - *newVisible* - The new ringVisible value to use or the original passed into the hook
-- *colorOverride* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) to use for the ring. Return `false` if you don't want to override the color. *NOTE:* For some reason colors that are near-black do not render so try a lighter color if you are having trouble
+- *colorOverride* - The [Color](https://wiki.facepunch.com/gmod/Color) to use for the ring. Return `false` if you don't want to override the color. *NOTE:* For some reason colors that are near-black do not render so try a lighter color if you are having trouble
 
 **TTTTargetIDPlayerRoleIcon(ply, client, role, noZ, colorRole, hideBeggar, showJester, hideBodysnatcher)** - Called before player Target ID icon (over their head) is rendered allowing changing the icon and color shown.\
 *Realm:* Client\
@@ -958,7 +975,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ent* - The target entity being rendered. Not necessarily a player so be sure to check `ent:IsPlayer()` if needed
 - *client* - The local player
 - *text* - The first line of text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 - *secondaryText* - The second line of text being shown
 
 *Return:*
@@ -973,7 +990,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *ent* - The target ragdoll being rendered
 - *client* - The local player
 - *text* - The ragdoll's name text being shown
-- *clr* - The [Color](https://wiki.facepunch.com/gmod/Global.Color) of the text being used
+- *clr* - The [Color](https://wiki.facepunch.com/gmod/Color) of the text being used
 
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all

--- a/API.md
+++ b/API.md
@@ -572,6 +572,14 @@ Custom and modified event hooks available within the defined realm. A list of de
 
 For example, if there is a hook that returns three parameters: `first`, `second`, and `third` and you want to modify the `second` parameter you must return the `first` parameter as non-`nil` as well, like this: `return first, newSecond`. Any return parameters after `second` can be omitted and the default value will be used.
 
+**TTTBlockPlayerFootstepSound(ply)** - Called when a player is making a footstep. Used to determine if the player's footstep sound should be stopped.\
+*Realm:* Client and Server\
+*Added in:* 1.2.7\
+*Parameters:*
+- *ply* - The player who is making footsteps
+
+*Return:* Whether or not the given player's footstep sounds should be stopped (Defaults to `false`).
+
 **TTTCanIdentifyCorpse(ply, rag, wasTraitor)** - Changed `was_traitor` parameter to be `true` for any member of the traitor team, rather than just the traitor role.\
 *Realm:* Server\
 *Added in:* 1.0.5\

--- a/CREATE_YOUR_OWN_ROLE.md
+++ b/CREATE_YOUR_OWN_ROLE.md
@@ -20,7 +20,8 @@
    1. [Custom Win Conditions](#Custom-Win-Conditions)
       1. [Win Identifier](#Win-Identifier)
       1. [Win Condition](#Win-Condition)
-      1. [Round Summary Screen](#Round-Summary-Screen)
+      1. [Round Summary Title](#Round-Summary-Title)
+      1. [Round Summary Events](#Round-Summary-Events)
       1. [Round Result Message](#Round-Result-Message)
       1. [Full Win Condition Example](#Full-Win-Condition-Example)
    1. [Role Registration](#Role-Registration)
@@ -467,9 +468,9 @@ end
 
 We'll leave the actual logic to determine whether our role wins blank as an exercise for you to fill out on your own. Once our role can actually win we need to define two more hooks to let everyone know when that it happened.
 
-#### Round Summary Screen
+#### Round Summary Title
 
-The first hook to show that our role won is the one for the round summary screen. This hook (which runs on the client side) allows you to return an object which describes the text to show when your win condition happens.
+The first hook to show that our role won is the one for the big text on the round summary screen. This hook (which runs on the client side) allows you to return an object which describes the text to show when your win condition happens.
 
 The first property of the object that the hook expects is `txt` which is the translation string for the text being shown. There are two default translation strings that are available specifically for this purpose. Choose whichever one makes sense for your role:
 
@@ -493,6 +494,34 @@ if CLIENT then
     end)
 end
 ```
+
+#### Round Summary Events
+
+Another part of the round summary screen that we want to tie into the is Events tab. When the round ends we add a row to the Events tab for the major events that occurred during that round. The part that we care about, specifically, is the text for the "round finished" event which is implemented by the two hooks below:
+
+```lua
+if CLIENT then
+    hook.Add("TTTEventFinishText", "SummonerEventFinishText", function(e)
+        if e.win == WIN_SUMMONER then
+            return LANG.GetParamTranslation("ev_win_summoner", { role = ROLE_STRINGS[ROLE_SUMMONER]:lower() })
+        end
+    end)
+
+    hook.Add("TTTEventFinishIconText", "SummonerEventFinishIconText", function(e, win_string, role_string)
+        if e.win == WIN_SUMMONER then
+            return win_string, ROLE_STRINGS_PLURAL[ROLE_SUMMONER]
+        end
+    end)
+
+    hook.Add("Initialize", "SummonerClientInitialize", function()
+        LANG.AddToLanguage("english", "ev_win_summoner", "The {role}'s army of minions has won them the round!")
+    end)
+end
+```
+
+The first hook (`TTTEventFinishText`) is used to control the text to show in the row on the Events tab itself. We recommend using a translateable string (as we do in the example) but that is not strictly necessary. The `Initialize` hook in the example above is only used to set up the translation string to use.
+
+The second hook (`TTTEventFinishIconText`) is used to control the text that shows when you hover over the icon in the row on the Events tab. The second hook's first return value is the name of a translation string and in most cases doesn't need to be changed at all. In the most common case the only thing you need to do is return the plural string for the winning role (or team) as the second return value.
 
 #### Round Result Message
 
@@ -531,6 +560,7 @@ If we piece together all the bits of code from the preivous sections it would co
 
         if CLIENT then
             LANG.AddToLanguage("english", "win_summoner", "The {role}'s minions have overwhelmed their enemies!")
+            LANG.AddToLanguage("english", "ev_win_summoner", "The {role}'s army of minions has won them the round!")
         end
     end)
 
@@ -555,6 +585,18 @@ If we piece together all the bits of code from the preivous sections it would co
         end)
     end
     if CLIENT then
+        hook.Add("TTTEventFinishText", "SummonerEventFinishText", function(e)
+            if e.win == WIN_SUMMONER then
+                return LANG.GetParamTranslation("ev_win_summoner", { role = ROLE_STRINGS[ROLE_SUMMONER]:lower() })
+            end
+        end)
+
+        hook.Add("TTTEventFinishIconText", "SummonerEventFinishIconText", function(e, win_string, role_string)
+            if e.win == WIN_SUMMONER then
+                return win_string, ROLE_STRINGS_PLURAL[ROLE_SUMMONER]
+            end
+        end)
+
         hook.Add("TTTScoringWinTitle", "SummonerScoringWinTitle", function(wintype, wintitles, title, secondaryWinRole)
             if wintype == WIN_SUMMONER then
                 return { txt = "hilite_win_role_singular", params = { role = ROLE_STRINGS[ROLE_SUMMONER]:upper() }, c = ROLE_COLORS[ROLE_SUMMONER] }

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -15,7 +15,8 @@
 - Added TTTKarmaGiveReward hook to block a player from receiving karma
 - Added TTTPlayerSpawnForRound hook to react to when a player is spawned (or respawed)
 - Added TTTEventFinishText and TTTEventFinishIconText hooks to add detail to the round finished event row for custom win conditions
-- Added new TTTPlayerRoleChanged hook to react to when a player's role changes
+- Added TTTPlayerRoleChanged hook to react to when a player's role changes
+- Added TTTShouldPlayerSmoke hook to affect whether a player should smoke and how that should look
 - Added plymeta:GetRoleTeam to get the appropriate ROLE_TEAM_* enum value for the player
 - Changed OnPlayerHighlightEnabled to be globally available so other roles can use the same highlighting logic
 - Fixed returning false for the first parameter of TTTTargetIDPlayerRoleIcon not stopping the role icon from showing

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -6,6 +6,10 @@
 ### Changes
 - Changed custom win events to show in the end-of-round summary's Events tab with an "unknown win event" message until the new TTTEventFinishText hooks are used
 
+### Fixes
+- Fixed vampire prime death effects still happening after the round has ended
+- Fixed external roles with custom win conditions blocking jester wins
+
 ### Developer
 - Added TTTBlockPlayerFootstepSound hook to block a player's footstep sound
 - Added TTTKarmaGiveReward hook to block a player from receiving karma

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -19,6 +19,7 @@
 - Added TTTShouldPlayerSmoke hook to affect whether a player should smoke and how that should look
 - Added plymeta:GetRoleTeam to get the appropriate ROLE_TEAM_* enum value for the player
 - Changed OnPlayerHighlightEnabled to be globally available so other roles can use the same highlighting logic
+- Changed all EXTERNAL_ROLE_* tables to be named ROLE_* in preparation for role separation
 - Fixed returning false for the first parameter of TTTTargetIDPlayerRoleIcon not stopping the role icon from showing
 
 ## 1.2.6

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -1,5 +1,11 @@
 # Beta Release Notes
 
+## 1.2.7
+**Released:**
+
+### Developer
+- Added TTTBlockPlayerFootstepSound hook to block a player's footstep sound
+
 ## 1.2.6
 **Released: September 25th, 2021**
 

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -11,6 +11,7 @@
 - Added TTTKarmaGiveReward hook to block a player from receiving karma
 - Added TTTPlayerSpawnForRound hook to react to when a player is spawned (or respawed)
 - Added TTTEventFinishText and TTTEventFinishIconText hooks to add detail to the round finished event row for custom win conditions
+- Added new TTTPlayerRoleChanged hook to react to when a player's role changes
 - Added plymeta:GetRoleTeam to get the appropriate ROLE_TEAM_* enum value for the player
 - Changed OnPlayerHighlightEnabled to be globally available so other roles can use the same highlighting logic
 - Fixed returning false for the first parameter of TTTTargetIDPlayerRoleIcon not stopping the role icon from showing

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -5,6 +5,7 @@
 
 ### Developer
 - Added TTTBlockPlayerFootstepSound hook to block a player's footstep sound
+- Added plymeta:GetRoleTeam to get the appropriate ROLE_TEAM_* enum value for the player
 
 ## 1.2.6
 **Released: September 25th, 2021**

--- a/RELEASE_BETA.md
+++ b/RELEASE_BETA.md
@@ -3,9 +3,17 @@
 ## 1.2.7
 **Released:**
 
+### Changes
+- Changed custom win events to show in the end-of-round summary's Events tab with an "unknown win event" message until the new TTTEventFinishText hooks are used
+
 ### Developer
 - Added TTTBlockPlayerFootstepSound hook to block a player's footstep sound
+- Added TTTKarmaGiveReward hook to block a player from receiving karma
+- Added TTTPlayerSpawnForRound hook to react to when a player is spawned (or respawed)
+- Added TTTEventFinishText and TTTEventFinishIconText hooks to add detail to the round finished event row for custom win conditions
 - Added plymeta:GetRoleTeam to get the appropriate ROLE_TEAM_* enum value for the player
+- Changed OnPlayerHighlightEnabled to be globally available so other roles can use the same highlighting logic
+- Fixed returning false for the first parameter of TTTTargetIDPlayerRoleIcon not stopping the role icon from showing
 
 ## 1.2.6
 **Released: September 25th, 2021**

--- a/gamemodes/terrortown/entities/entities/ttt_crowbar/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_crowbar/shared.lua
@@ -24,7 +24,7 @@ function ENT:Think()
 end
 
 function ENT:Use(activator, caller)
-    if activator:GetKiller() then
+    if activator:IsKiller() then
         activator:Give("weapon_kil_crowbar")
         self:Remove()
     end

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -178,7 +178,7 @@ function GetEquipmentForRole(role, promoted, block_randomization)
                 if not available[i.id] and
                     -- Detective -> Detective-like
                     (sync_detective_like or
-                    -- Traitor OR Detective or Detective-only modes, Detective -> Mercenary/Killer Clown
+                    -- Traitor OR Detective or Detective-only modes, Detective -> Sync Role
                     (rolemode == SHOP_SYNC_MODE_UNION or rolemode == SHOP_SYNC_MODE_DETECTIVE)) then
                     table.insert(tbl[role], i)
                     available[i.id] = true
@@ -854,7 +854,7 @@ local function TraitorMenuPopup()
     end
 
     -- Credit transferring, but only for roles that have a shop and are allowed to transfer
-    if credits > 0 and hasShop and not (ply:IsMercenary() or ply:IsKiller() or ply:IsJesterTeam()) then
+    if credits > 0 and hasShop and (ply:IsTraitorTeam() or ply:IsMonsterTeam()) then
         local dtransfer = CreateTransferMenu(dsheet)
         dsheet:AddSheet(GetTranslation("xfer_name"), dtransfer, "icon16/group_gear.png", false, false, GetTranslation("equip_tooltip_xfer"))
         show = true

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -649,7 +649,7 @@ local function TraitorMenuPopup()
                 end
 
                 -- Don't show equipment items that you already own that are listed as "loadout" because you were given it for free
-                local externalLoadout = EXTERNAL_ROLE_LOADOUT_ITEMS[ply:GetRole()] and table.HasValue(EXTERNAL_ROLE_LOADOUT_ITEMS[ply:GetRole()], item.name)
+                local externalLoadout = ROLE_LOADOUT_ITEMS[ply:GetRole()] and table.HasValue(ROLE_LOADOUT_ITEMS[ply:GetRole()], item.name)
                 if not ItemIsWeapon(item) and ply:HasEquipmentItem(item.id) and (item.loadout or externalLoadout) then
                     ic:Remove()
                 else

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -55,8 +55,8 @@ local jesters_visible_to_monsters = false
 local jesters_visible_to_independents = false
 local vision_enabled = false
 
-local function AddExternalRoleTranslations()
-    for role, lang_table in pairs(EXTERNAL_ROLE_TRANSLATIONS) do
+local function AddRoleTranslations()
+    for role, lang_table in pairs(ROLE_TRANSLATIONS) do
         for lang, string_table in pairs(lang_table) do
             for name, value in pairs(string_table) do
                 LANG.AddToLanguage(lang, name, value)
@@ -72,7 +72,7 @@ function GM:Initialize()
 
     LANG.Init()
 
-    AddExternalRoleTranslations()
+    AddRoleTranslations()
 
     self.BaseClass:Initialize()
 end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -925,7 +925,7 @@ end)
 
 -- Player highlights
 
-local function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies, traitorAllies)
+function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies, traitorAllies)
     if GetRoundState() ~= ROUND_ACTIVE then return end
     local enemies = {}
     local friends = {}

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -588,10 +588,10 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     local nicks = self.Players
 
     local scores_by_section = {
-        [ROLE_INNOCENT] = {},
-        [ROLE_TRAITOR] = {},
-        [ROLE_KILLER] = {},
-        [ROLE_JESTER] = {}
+        [ROLE_TEAM_INNOCENT] = {},
+        [ROLE_TEAM_TRAITOR] = {},
+        [ROLE_TEAM_INDEPENDENT] = {},
+        [ROLE_TEAM_JESTER] = {}
     }
 
     for id, s in pairs(scores) do
@@ -685,24 +685,24 @@ function CLSCORE:BuildSummaryPanel(dpanel)
                 }
 
                 if INNOCENT_ROLES[groupingRole] then
-                    table.insert(scores_by_section[ROLE_INNOCENT], playerInfo)
+                    table.insert(scores_by_section[ROLE_TEAM_INNOCENT], playerInfo)
                 elseif TRAITOR_ROLES[groupingRole] or MONSTER_ROLES[groupingRole] then
-                    table.insert(scores_by_section[ROLE_TRAITOR], playerInfo)
+                    table.insert(scores_by_section[ROLE_TEAM_TRAITOR], playerInfo)
                 elseif INDEPENDENT_ROLES[groupingRole] then
-                    table.insert(scores_by_section[ROLE_KILLER], playerInfo)
+                    table.insert(scores_by_section[ROLE_TEAM_INDEPENDENT], playerInfo)
                 else
-                    table.insert(scores_by_section[ROLE_JESTER], playerInfo)
+                    table.insert(scores_by_section[ROLE_TEAM_JESTER], playerInfo)
                 end
             end
         end
     end
 
     -- Minimum of 10 rows, maximum of whichever team has more players
-    local player_rows = math.max(10, math.max(#scores_by_section[ROLE_INNOCENT], #scores_by_section[ROLE_TRAITOR]))
+    local player_rows = math.max(10, math.max(#scores_by_section[ROLE_TEAM_INNOCENT], #scores_by_section[ROLE_TEAM_TRAITOR]))
 
     -- Add 33px for each extra role
     local height_extra = (player_rows - 10) * 33
-    local has_indep_and_jesters = #scores_by_section[ROLE_KILLER] > 0 and #scores_by_section[ROLE_JESTER] > 0
+    local has_indep_and_jesters = #scores_by_section[ROLE_TEAM_INDEPENDENT] > 0 and #scores_by_section[ROLE_TEAM_JESTER] > 0
     local height_extra_jester = 0
     if has_indep_and_jesters then
         height_extra_jester = 32
@@ -803,17 +803,17 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     if secondary_win_role then winlbl:SetPos(xwin, ywin - 15) end
 
     -- Add the players to the panel
-    self:BuildPlayerList(scores_by_section[ROLE_INNOCENT], dpanel, 317, 8, 103, 33)
-    self:BuildPlayerList(scores_by_section[ROLE_TRAITOR], dpanel, 666, 357, 103, 33)
-    if #scores_by_section[ROLE_KILLER] > 0 then
-        self:BuildRoleLabel(scores_by_section[ROLE_KILLER], dpanel, 666, 8, 440 + height_extra)
+    self:BuildPlayerList(scores_by_section[ROLE_TEAM_INNOCENT], dpanel, 317, 8, 103, 33)
+    self:BuildPlayerList(scores_by_section[ROLE_TEAM_TRAITOR], dpanel, 666, 357, 103, 33)
+    if #scores_by_section[ROLE_TEAM_INDEPENDENT] > 0 then
+        self:BuildRoleLabel(scores_by_section[ROLE_TEAM_INDEPENDENT], dpanel, 666, 8, 440 + height_extra)
     end
-    if #scores_by_section[ROLE_JESTER] > 0 then
+    if #scores_by_section[ROLE_TEAM_JESTER] > 0 then
         -- Move the label down more to add space
         if has_indep_and_jesters then
             height_extra_jester = height_extra_jester + 2
         end
-        self:BuildRoleLabel(scores_by_section[ROLE_JESTER], dpanel, 666, 8, 440 + height_extra + height_extra_jester)
+        self:BuildRoleLabel(scores_by_section[ROLE_TEAM_JESTER], dpanel, 666, 8, 440 + height_extra + height_extra_jester)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_scoring_events.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring_events.lua
@@ -59,6 +59,9 @@ local is_dmg = util.BitSet
 -- Round end event
 Event(EVENT_FINISH,
       { text = function(e)
+                  local result = hook.Run("TTTEventFinishText", e)
+                  if result then return result end
+
                   if e.win == WIN_TRAITOR then
                      return PT("ev_win_traitor", { role = ROLE_STRINGS_PLURAL[ROLE_TRAITOR]:lower() })
                   elseif e.win == WIN_INNOCENT then
@@ -69,8 +72,8 @@ Event(EVENT_FINISH,
                      return PT("ev_win_clown", { role = ROLE_STRINGS[ROLE_CLOWN]:lower() })
                   elseif e.win == WIN_OLDMAN then
                      return PT("ev_win_oldman", { role = ROLE_STRINGS[ROLE_OLDMAN]:lower() })
-                  elseif e.win == WIN_KILLER then
-                     return PT("ev_win_killer", { role = ROLE_STRINGS[ROLE_KILLER]:lower() })
+                    elseif e.win == WIN_KILLER then
+                       return PT("ev_win_killer", { role = ROLE_STRINGS[ROLE_KILLER]:lower() })
                   elseif e.win == WIN_MONSTER then
                      local monster_role = GetWinningMonsterRole()
                      if monster_role == ROLE_VAMPIRE then
@@ -86,6 +89,8 @@ Event(EVENT_FINISH,
                   elseif e.win == WIN_TIMELIMIT then
                      return PT("ev_win_time", { role = ROLE_STRINGS_PLURAL[ROLE_TRAITOR]:lower() })
                   end
+
+                  return PT("ev_win_unknown", { id = e.win })
                end,
         icon = function(e)
                   local role_string = ""
@@ -101,8 +106,8 @@ Event(EVENT_FINISH,
                   elseif e.win == WIN_OLDMAN then
                      role_string = ROLE_STRINGS[ROLE_OLDMAN]
                      win_string = "ev_win_icon_also"
-                  elseif e.win == WIN_KILLER then
-                     role_string = ROLE_STRINGS[ROLE_KILLER]
+                    elseif e.win == WIN_KILLER then
+                       role_string = ROLE_STRINGS[ROLE_KILLER]
                   elseif e.win == WIN_MONSTER then
                      local monster_role = GetWinningMonsterRole()
                      if monster_role == ROLE_VAMPIRE then
@@ -116,8 +121,17 @@ Event(EVENT_FINISH,
                      role_string = ROLE_STRINGS_PLURAL[ROLE_ZOMBIE]
                   elseif e.win == WIN_VAMPIRE then
                      role_string = ROLE_STRINGS_PLURAL[ROLE_VAMPIRE]
-                  else
+                  elseif e.win == WIN_TIMELIMIT then
                      win_string = "ev_win_icon_time"
+                  end
+
+                  local new_win_string, new_role_string = hook.Run("TTTEventFinishIconText", e, win_string, role_string)
+                  if new_win_string then win_string = new_win_string end
+                  if new_role_string then role_string = new_role_string end
+
+                  -- If we're supposed to be winning as a role but nobody set the role string, use the unknown string instead
+                  if win_string == "ev_win_icon" and #role_string == 0 then
+                    return star_icon, PT("ev_win_unknown", { id = e.win })
                   end
 
                   return star_icon, PT(win_string, { role = role_string })

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -98,7 +98,7 @@ function GM:PostDrawTranslucentRenderables()
 
             -- Only show the "KILL" target if the setting is enabled
             local showKillIcon = ((client:IsAssassin() and GetGlobalBool("ttt_assassin_show_target_icon", false) and client:GetNWString("AssassinTarget") == v:Nick()) or
-                                    (client:IsKiller() and GetGlobalBool("ttt_killer_show_target_icon", false)) or
+            (client:IsKiller() and GetGlobalBool("ttt_killer_show_target_icon", false)) or
                                     (client:IsZombie() and GetGlobalBool("ttt_zombie_show_target_icon", false) and client.GetActiveWeapon and IsValid(client:GetActiveWeapon()) and client:GetActiveWeapon():GetClass() == "weapon_zom_claws") or
                                     (client:IsVampire() and GetGlobalBool("ttt_vampire_show_target_icon", false)) or
                                     (client:IsClown() and client:GetNWBool("KillerClownActive", false) and GetGlobalBool("ttt_clown_show_target_icon", false)))
@@ -189,7 +189,7 @@ function GM:PostDrawTranslucentRenderables()
                 end
 
                 local newRole, newNoZ, newColorRole = hook.Run("TTTTargetIDPlayerRoleIcon", v, client, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
-                if newRole then role = newRole end
+                if newRole or (type(newRole) == "boolean" and not newRole) then role = newRole end
                 if type(newNoZ) == "boolean" then noz = newNoZ end
                 if newColorRole then color_role = newColorRole end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -106,10 +106,10 @@ for role = 0, ROLE_MAX do
     local starting_health = "100"
     if role == ROLE_OLDMAN then starting_health = "1"
     elseif role == ROLE_KILLER then starting_health = "150"
-    elseif EXTERNAL_ROLE_STARTING_HEALTH[role] then starting_health = EXTERNAL_ROLE_STARTING_HEALTH[role] end
+    elseif ROLE_STARTING_HEALTH[role] then starting_health = ROLE_STARTING_HEALTH[role] end
 
     local max_health = nil
-    if EXTERNAL_ROLE_MAX_HEALTH[role] then max_health = EXTERNAL_ROLE_MAX_HEALTH[role] end
+    if ROLE_MAX_HEALTH[role] then max_health = ROLE_MAX_HEALTH[role] end
 
     CreateConVar("ttt_" .. rolestring .. "_starting_health", starting_health, FCVAR_REPLICATED)
     CreateConVar("ttt_" .. rolestring .. "_max_health", max_health or starting_health, FCVAR_REPLICATED)
@@ -359,7 +359,7 @@ CreateConVar("ttt_shop_random_percent", "50", FCVAR_REPLICATED, "The percent cha
 CreateConVar("ttt_shop_random_position", "0", FCVAR_REPLICATED, "Whether to randomize the position of the items in the shop")
 
 -- Create the starting credit convar for all roles that have credits but don't have a shop
-local shopless_credit_roles = table.UnionedKeys(CAN_LOOT_CREDITS_ROLES, EXTERNAL_ROLE_STARTING_CREDITS, shop_roles)
+local shopless_credit_roles = table.UnionedKeys(CAN_LOOT_CREDITS_ROLES, ROLE_STARTING_CREDITS, shop_roles)
 for _, role in ipairs(shopless_credit_roles) do
     CreateCreditConVar(role)
 end
@@ -2501,8 +2501,8 @@ function HandleRoleEquipment()
             end
         end
 
-        if id >= ROLE_EXTERNAL_START and EXTERNAL_ROLE_SHOP_ITEMS[id] then
-            for _, v in pairs(EXTERNAL_ROLE_SHOP_ITEMS[id]) do
+        if id >= ROLE_EXTERNAL_START and ROLE_SHOP_ITEMS[id] then
+            for _, v in pairs(ROLE_SHOP_ITEMS[id]) do
                 table.insert(WEPS.BuyableWeapons[id], v)
                 table.insert(roleweapons, v)
             end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -662,6 +662,9 @@ end
 -- Convar replication is broken in gmod, so we do this.
 -- I don't like it any more than you do, dear reader.
 function GM:SyncGlobals()
+    -- For some reason hooking "SyncGlobals" directly is unreliable so... here we go
+    hook.Run("TTTSyncGlobals")
+
     SetGlobalBool("ttt_detective", ttt_detective:GetBool())
     SetGlobalBool("ttt_haste", ttt_haste:GetBool())
     SetGlobalInt("ttt_time_limit_minutes", GetConVar("ttt_time_limit_minutes"):GetInt())

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -1113,6 +1113,7 @@ L.ev_win_time = "The {role} ran out of time and lost!"
 L.ev_win_icon = "{role} won"
 L.ev_win_icon_time = "Time Limit"
 L.ev_win_icon_also = "{role} also won"
+L.ev_win_unknown = "Unknown win type with ID: {id}"
 
 --- Awards/highlights
 

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -604,7 +604,7 @@ local function CheckCreditAward(victim, attacker)
     local valid_attacker = IsPlayer(attacker)
 
     -- DETECTIVE AWARD
-    if valid_attacker and (victim:IsTraitorTeam() or victim:IsMonsterTeam() or victim:IsKiller() or victim:IsZombie()) then
+    if valid_attacker and not (victim:IsInnocentTeam() or victim:IsJesterTeam()) then
         local amt = GetConVar("ttt_det_credits_traitordead"):GetInt()
 
         -- If size is 0, awards are off
@@ -2322,6 +2322,7 @@ function GM:Tick()
             end
 
             HandleRoleForcedWeapons(ply)
+            hook.Run("TTTPlayerAliveThink", ply)
         elseif tm == TEAM_SPEC then
             if ply.propspec then
                 PROPSPEC.Recharge(ply)

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -303,6 +303,7 @@ end
 function plymeta:SpawnForRound(dead_only)
     hook.Call("PlayerSetModel", GAMEMODE, self)
     hook.Call("TTTPlayerSetColor", GAMEMODE, self)
+    hook.Call("TTTPlayerSpawnForRound", GAMEMODE, self, dead_only)
 
     -- Workaround to prevent GMod sprint from working
     self:SetRunSpeed(self:GetWalkSpeed())

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -10,6 +10,13 @@ function plymeta:IsSpec() return self:Team() == TEAM_SPEC end
 
 AccessorFunc(plymeta, "role", "Role", FORCE_NUMBER)
 
+local oldSetRole = plymeta.SetRole
+function plymeta:SetRole(role)
+    local oldRole = self:GetRole()
+    oldSetRole(self, role)
+    hook.Run("TTTPlayerRoleChanged", self, oldRole, role)
+end
+
 -- Player is alive and in an active round
 function plymeta:IsActive() return self:IsTerror() and GetRoundState() == ROUND_ACTIVE end
 

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -74,6 +74,22 @@ function plymeta:IsSameTeam(target)
     end
     return self:GetRole() == target:GetRole()
 end
+function plymeta:GetRoleTeam(detectivesAreInnocent)
+    if self:IsTraitorTeam() then
+        return ROLE_TEAM_TRAITOR
+    elseif self:IsMonsterTeam() then
+        return ROLE_TEAM_MONSTER
+    elseif self:IsJesterteam() then
+        return ROLE_TEAM_JESTER
+    elseif self:IsIndependentTeam() then
+        return ROLE_TEAM_INDEPENDENT
+    elseif self:IsInnocentTeam() then
+        if not detectivesAreInnocent and self:IsDetectiveTeam() then
+            return ROLE_TEAM_DETECTIVE
+        end
+        return ROLE_TEAM_INNOCENT
+    end
+end
 
 plymeta.IsDetectiveLike = plymeta.GetDetectiveLike
 plymeta.IsDetectiveLikePromotable = plymeta.GetDetectiveLikePromotable

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -174,7 +174,7 @@ function plymeta:ShouldActLikeJester()
 
     -- Check if this role has an external definition for "ShouldActLikeJester" and use that
     local role = self:GetRole()
-    if EXTERNAL_ROLE_SHOULD_ACT_LIKE_JESTER[role] then return EXTERNAL_ROLE_SHOULD_ACT_LIKE_JESTER[role](self) end
+    if ROLE_SHOULD_ACT_LIKE_JESTER[role] then return ROLE_SHOULD_ACT_LIKE_JESTER[role](self) end
 
     return self:IsJesterTeam()
 end
@@ -249,7 +249,7 @@ function plymeta:IsRoleActive()
 
     -- Check if this role has an external definition for "IsActive" and use that
     local role = self:GetRole()
-    if EXTERNAL_ROLE_IS_ACTIVE[role] then return EXTERNAL_ROLE_IS_ACTIVE[role](self) end
+    if ROLE_IS_ACTIVE[role] then return ROLE_IS_ACTIVE[role](self) end
 
     return true
 end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1197,6 +1197,8 @@ function UpdateRoleState()
             end
         end
     end
+
+    hook.Run("TTTUpdateRoleState")
 end
 
 function GetWinningMonsterRole()

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1027,6 +1027,10 @@ function GM:PlayerFootstep(ply, pos, foot, sound, volume, rf)
         -- do not play anything, just prevent normal sounds from playing
         return true
     end
+
+    if hook.Run("TTTBlockPlayerFootstepSound", ply) then
+        return true
+    end
 end
 
 -- Predicted move speed changes

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -307,7 +307,7 @@ else
         if not DEFAULT_ROLES[role] or role == ROLE_INNOCENT then
             local rolestring = ROLE_STRINGS_RAW[role]
             local credits = "0"
-            if EXTERNAL_ROLE_STARTING_CREDITS[role] then credits = EXTERNAL_ROLE_STARTING_CREDITS[role]
+            if ROLE_STARTING_CREDITS[role] then credits = ROLE_STARTING_CREDITS[role]
             elseif TRAITOR_ROLES[role] then credits = "1"
             elseif DETECTIVE_ROLES[role] then credits = "1"
             elseif role == ROLE_MERCENARY then credits = "1"
@@ -619,15 +619,15 @@ ROLE_TEAM_INDEPENDENT = 3
 ROLE_TEAM_MONSTER = 4
 ROLE_TEAM_DETECTIVE = 5
 
-EXTERNAL_ROLE_TRANSLATIONS = {}
-EXTERNAL_ROLE_SHOP_ITEMS = {}
-EXTERNAL_ROLE_LOADOUT_ITEMS = {}
-EXTERNAL_ROLE_CONVARS = {}
-EXTERNAL_ROLE_STARTING_CREDITS = {}
-EXTERNAL_ROLE_STARTING_HEALTH = {}
-EXTERNAL_ROLE_MAX_HEALTH = {}
-EXTERNAL_ROLE_IS_ACTIVE = {}
-EXTERNAL_ROLE_SHOULD_ACT_LIKE_JESTER = {}
+ROLE_TRANSLATIONS = {}
+ROLE_SHOP_ITEMS = {}
+ROLE_LOADOUT_ITEMS = {}
+ROLE_CONVARS = {}
+ROLE_STARTING_CREDITS = {}
+ROLE_STARTING_HEALTH = {}
+ROLE_MAX_HEALTH = {}
+ROLE_IS_ACTIVE = {}
+ROLE_SHOULD_ACT_LIKE_JESTER = {}
 
 ROLE_CONVAR_TYPE_NUM = 0
 ROLE_CONVAR_TYPE_BOOL = 1
@@ -678,34 +678,34 @@ function RegisterRole(tbl)
 
     -- Allow roles to have translations automatically added for them
     if type(tbl.translations) == "table" then
-        EXTERNAL_ROLE_TRANSLATIONS[roleID] = tbl.translations
+        ROLE_TRANSLATIONS[roleID] = tbl.translations
     else
-        EXTERNAL_ROLE_TRANSLATIONS[roleID] = {}
+        ROLE_TRANSLATIONS[roleID] = {}
     end
 
     -- Ensure that at least english is present
-    if not EXTERNAL_ROLE_TRANSLATIONS[roleID]["english"] then
-        EXTERNAL_ROLE_TRANSLATIONS[roleID]["english"] = {}
+    if not ROLE_TRANSLATIONS[roleID]["english"] then
+        ROLE_TRANSLATIONS[roleID]["english"] = {}
     end
 
     -- Create the role description translation automatically
-    EXTERNAL_ROLE_TRANSLATIONS[roleID]["english"]["info_popup_" .. tbl.nameraw] = tbl.desc
+    ROLE_TRANSLATIONS[roleID]["english"]["info_popup_" .. tbl.nameraw] = tbl.desc
 
     if tbl.shop then
-        EXTERNAL_ROLE_SHOP_ITEMS[roleID] = tbl.shop
+        ROLE_SHOP_ITEMS[roleID] = tbl.shop
         AddRoleAssociations(SHOP_ROLES, {roleID})
     end
 
     if type(tbl.startingcredits) == "number" then
-        EXTERNAL_ROLE_STARTING_CREDITS[roleID] = tbl.startingcredits
+        ROLE_STARTING_CREDITS[roleID] = tbl.startingcredits
     end
 
     if type(tbl.startinghealth) == "number" then
-        EXTERNAL_ROLE_STARTING_HEALTH[roleID] = tbl.startinghealth
+        ROLE_STARTING_HEALTH[roleID] = tbl.startinghealth
     end
 
     if type(tbl.maxhealth) == "number" then
-        EXTERNAL_ROLE_MAX_HEALTH[roleID] = tbl.maxhealth
+        ROLE_MAX_HEALTH[roleID] = tbl.maxhealth
     end
 
     if type(tbl.canlootcredits) == "boolean" then
@@ -721,15 +721,15 @@ function RegisterRole(tbl)
     end
 
     if tbl.loadout then
-        EXTERNAL_ROLE_LOADOUT_ITEMS[roleID] = tbl.loadout
+        ROLE_LOADOUT_ITEMS[roleID] = tbl.loadout
     end
 
     if type(tbl.isactive) == "function" then
-        EXTERNAL_ROLE_IS_ACTIVE[roleID] = tbl.isactive
+        ROLE_IS_ACTIVE[roleID] = tbl.isactive
     end
 
     if type(tbl.shouldactlikejester) == "function" then
-        EXTERNAL_ROLE_SHOULD_ACT_LIKE_JESTER[roleID] = tbl.shouldactlikejester
+        ROLE_SHOULD_ACT_LIKE_JESTER[roleID] = tbl.shouldactlikejester
     end
 
     -- List of objects that describe convars for ULX support, in the following format:
@@ -747,7 +747,7 @@ function RegisterRole(tbl)
     --     type = ROLE_CONVAR_TYPE_TEXT -- The type of convar (will be used to determine the control, in this case a textbox)
     -- }
     if tbl.convars then
-        EXTERNAL_ROLE_CONVARS[roleID] = tbl.convars
+        ROLE_CONVARS[roleID] = tbl.convars
     end
 end
 

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -46,8 +46,8 @@ local function GetLoadoutWeapons(r)
         -- Initialize the table for every role
         for wrole = 0, ROLE_MAX do
             tbl[wrole] = {}
-            if wrole >= ROLE_EXTERNAL_START and EXTERNAL_ROLE_LOADOUT_ITEMS[wrole] then
-                for _, v in pairs(EXTERNAL_ROLE_LOADOUT_ITEMS[wrole]) do
+            if wrole >= ROLE_EXTERNAL_START and ROLE_LOADOUT_ITEMS[wrole] then
+                for _, v in pairs(ROLE_LOADOUT_ITEMS[wrole]) do
                     if weapons.GetStored(v) then
                         table.insert(tbl[wrole], v)
                     end
@@ -118,7 +118,7 @@ local function GiveLoadoutItems(ply)
         end
     end
 
-    local ext_items = EXTERNAL_ROLE_LOADOUT_ITEMS[role]
+    local ext_items = ROLE_LOADOUT_ITEMS[role]
     if ext_items then
         for _, item in pairs(ext_items) do
             if not weapons.GetStored(item) then


### PR DESCRIPTION
**Changes**
- Changed custom win events to show in the end-of-round summary's Events tab with an "unknown win event" message until the new TTTEventFinishText hooks are used

**Fixes**
- Fixed vampire prime death effects still happening after the round has ended
- Fixed external roles with custom win conditions blocking jester wins

**Developer**
- Added TTTBlockPlayerFootstepSound hook to block a player's footstep sound
- Added TTTKarmaGiveReward hook to block a player from receiving karma
- Added TTTPlayerSpawnForRound hook to react to when a player is spawned (or respawed)
- Added TTTEventFinishText and TTTEventFinishIconText hooks to add detail to the round finished event row for custom win conditions
- Added TTTPlayerRoleChanged hook to react to when a player's role changes
- Added TTTShouldPlayerSmoke hook to affect whether a player should smoke and how that should look
- Added plymeta:GetRoleTeam to get the appropriate ROLE_TEAM_* enum value for the player
- Changed OnPlayerHighlightEnabled to be globally available so other roles can use the same highlighting logic
- Changed all EXTERNAL_ROLE_* tables to be named ROLE_* in preparation for role separation
- Fixed returning false for the first parameter of TTTTargetIDPlayerRoleIcon not stopping the role icon from showing