### PR TITLE
Misc. fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,14 @@
 # Release Notes
 
 ## 1.3.3 (Beta)
-**Released:**
+**Released: October 24th, 2021**
 
 ### Fixes
 - Fixed deputy and impersonator not being promoted if they spawned in a round without a detective team role and ttt_deputy_impersonator_promote_any_death was enabled
 - Fixed loot goblin jump height calculation to work for more size scales than just the default
 
 ## 1.3.2 (Beta)
-**Released: October 21th, 2021**
+**Released: October 21st, 2021**
 
 ### Additions
 - Added ability for an old man having an adrenaline rush to have target ID information (icon over the head, ring and text when you look at them) (enabled by default)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.3.3 (Beta)
+**Released:**
+
+### Fixes
+- Fixed deputy and impersonator not being promoted if they spawned in a round without a detective team role and ttt_deputy_impersonator_promote_any_death was enabled
+- Fixed loot goblin jump height calculation to work for more size scales than just the default
+
 ## 1.3.2 (Beta)
 **Released: October 21th, 2021**
 

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
@@ -20,9 +20,10 @@ function ShouldPromoteDetectiveLike()
         end
     end
 
-    -- If they should be promoted when any detective has died, just check that there is a dead detective
-    if GetConVar("ttt_deputy_impersonator_promote_any_death"):GetBool() then
-        return dead > 0
+    -- If they should be promoted when any detective has died, promote them if there is a death
+    -- If there isn't a death, fall back to the default logic
+    if GetConVar("ttt_deputy_impersonator_promote_any_death"):GetBool() and dead > 0 then
+        return true
     end
 
     -- Otherwise, only promote if there are no living detectives

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
@@ -41,7 +41,7 @@ function plymeta:HandleDetectiveLikePromotion()
     net.Send(self)
 end
 
-function plymeta:GetDetectiveLike() return self:IsDetectiveTeam() or ((self:GetDeputy() or self:GetImpersonator()) and self:IsRoleActive()) end
+function plymeta:GetDetectiveLike() return self:IsDetectiveTeam() or ((self:IsDeputy() or self:IsImpersonator()) and self:IsRoleActive()) end
 function plymeta:GetDetectiveLikePromotable() return (self:IsDeputy() or self:IsImpersonator()) and not self:IsRoleActive() end
 function plymeta:IsActiveDetectiveLike() return self:IsActive() and self:IsDetectiveLike() end
 

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -75,8 +75,17 @@ local function StartGoblinTimers()
 
                 local scale = lootgoblin_size:GetFloat()
                 v:SetPlayerScale(scale)
-                -- Compensate the jump power so they have roughly the same jump height as normal
-                v:SetJumpPower(defaultJumpPower * (scale + 1))
+                local jumpPower = defaultJumpPower
+                -- Compensate the jump power of smaller players so they have roughly the same jump height as normal
+                -- In testing, scales >= 1 all seem to work fine with the default jump power and that's not the intent of this role anyway
+                if scale < 1 then
+                    -- Derived formula is y = -120x + 280
+                    -- We take the base jump power out of this as a known constant and then
+                    -- give a small jump boost of 5 extra power to "round up" the jump estimates
+                    -- so that smaller sizes can still clear jump+crouch blocks
+                    jumpPower = jumpPower + (-(120 * scale) + 125)
+                end
+                v:SetJumpPower(jumpPower)
                 -- TODO: Speed boost?
             elseif revealMode == JESTER_NOTIFY_EVERYONE or
                     (v:IsActiveTraitorTeam() and (revealMode == JESTER_NOTIFY_TRAITOR or JESTER_NOTIFY_DETECTIVE_AND_TRAITOR)) or

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.3.2"
+CR_VERSION = "1.3.3"
 
 function CRVersion(version)
     local installedVersionRaw = string.Split(CR_VERSION, ".")

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -715,7 +715,7 @@ end
 
 net.Receive("TTT_ConfigureRoleWeapons", function(len, ply)
     if not IsPlayer(ply) or not ply:IsAdmin() then
-        ErrorNoHalt("Player withing admin access attempted to configure role weapons: " .. ply:Nick() .. " (" .. ply:SteamID() .. ")\n")
+        ErrorNoHalt("Player without admin access attempted to configure role weapons: " .. ply:Nick() .. " (" .. ply:SteamID() .. ")\n")
         return
     end
 


### PR DESCRIPTION
**Fixes**
- Fixed deputy and impersonator not being promoted if they spawned in a round without a detective team role and ttt_deputy_impersonator_promote_any_death was enabled
- Fixed loot goblin jump height calculation to work for more size scales than just the default