### PR TITLE
Misc. fixes, additions, and changes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -177,6 +177,13 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *roleFileName* - The new roleFileName value to use or the original passed into the hook
 - *flashRole* - If a valid role is provided, this will cause the target player's scoreboard role to have a flashing border in the given role's color (see ROLE_* global enumeration)
 
+**TTTScoringSecondaryWins(wintype, secondaryWins)** - Called before each round summary screen is shown with the winning team. Used to add roles to the secondary win display (e.g. AND THE OLD MAN WINS).\
+*Realm:* Client\
+*Added in:* 1.4.1\
+*Parameters:*
+- *wintype* - The round win type
+- *secondaryWins* - The table of role identifiers for roles who should have a secondary win on the round summary. Insert any role identifiers you would like to display into this table
+
 **TTTScoringSummaryRender(ply, roleFileName, groupingRole, roleColor, nameLabel, startingRole, finalRole)** - Called before the round summary screen is shown. Used to modify the color, position, and icon for a player.\
 *Realm:* Client\
 *Added in:* 1.1.5\
@@ -195,21 +202,19 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *roleColor* - The new roleColor value to use or the original passed into the hook
 - *newName* - The new nameLabel value to use for the original passed into the hook *(Added in 1.2.3)*
 
-**TTTScoringWinTitle(wintype, wintitles, title, secondaryWinRole)** - Called before each round summary screen is shown with the winning team. Return the win title object to use on the summary screen.\
+**TTTScoringWinTitle(wintype, wintitles, title)** - Called before each round summary screen is shown with the winning team. Return the win title object to use on the summary screen.\
 *Realm:* Client\
 *Added in:* 1.0.14\
 *Parameters:*
 - *wintype* - The round win type
 - *wintitles* - Table of default win title parameters
 - *title* - The currently selected win title
-- *secondaryWinRole* - Which role (if any) is sharing the win for this round (see ROLE_* global enumeration) *(Added in 1.1.9)*
 
 *Return:*
 - *newTitle*
   - *txt* - The translation string to use to get the winning team text
   - *c* - The background [Color](https://wiki.facepunch.com/gmod/Color) to use
-  - *params* - Any parameters to use when translating `txt` (Optional if `new_secondary_win_role` is also omitted)
-- *newSecondaryWinRole* - Which role should share in the win for this round (see ROLE_* global enumeration) (Optional) *(Added in 1.1.9)*
+  - *params* - Any parameters to use when translating `txt`
 
 **TTTSelectRoles(choices, prevRoles)** - Called before players are randomly assigned roles. If a player is assigned a role during this hook, they will not be randomly assigned one later.\
 *Realm:* Server\

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -307,6 +307,7 @@ ttt_tracker_credits_starting                1       // The number of credits a t
 
 // Medium
 ttt_medium_spirit_color                     1       // Whether players' spirits should have different colors
+ttt_medium_dead_notify                      1       // Whether player should be notified that there is a medium when they die
 ttt_medium_credits_starting                 1       // The number of credits a medium should start with
 
 // ----------------------------------------

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -585,6 +585,7 @@ ttt_swapper_starting_health                 100     // The amount of health the 
 ttt_clown_starting_health                   100     // The amount of health the clown starts with
 ttt_beggar_starting_health                  100     // The amount of health the beggar starts with
 ttt_bodysnatcher_starting_health            100     // The amount of health the bodysnatcher starts with
+ttt_lootgoblin_starting_health              50      // The amount of health the loot goblin starts with
 ttt_drunk_starting_health                   100     // The amount of health the drunk starts with
 ttt_oldman_starting_health                  1       // The amount of health the old man starts with
 ttt_killer_starting_health                  150     // The amount of health the killer starts with
@@ -618,6 +619,7 @@ ttt_swapper_max_health                      100     // The maximum amount of hea
 ttt_clown_max_health                        100     // The maximum amount of health the clown can have
 ttt_beggar_max_health                       100     // The maximum amount of health the beggar can have
 ttt_bodysnatcher_max_health                 100     // The maximum amount of health the bodysnatcher can have
+ttt_lootgoblin_max_health                   50      // The maximum amount of health the loot goblin can have
 ttt_drunk_max_health                        100     // The maximum amount of health the drunk can have
 ttt_oldman_max_health                       1       // The maximum amount of health the old man can have
 ttt_killer_max_health                       150     // The maximum amount of health the killer can have

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -152,6 +152,7 @@ ttt_impersonator_damage_penalty             0       // Damage penalty that the i
 ttt_impersonator_credits_starting           1       // The number of credits an impersonator should start with
 ttt_impersonator_use_detective_icon         1       // Whether a promoted impersonator should show the detective icon over their head instead of the impersonator icon (only for traitors, non-traitors will use the equivalent deputy setting)
 ttt_impersonator_without_detective          0       // Whether an impersonator can spawn without a detective in the round. Will automatically promote the impersonator when they spawn
+ttt_impersonator_activation_credits         0       // The number of credits to give the impersonator when they are activated
 ttt_single_deputy_impersonator              0       // Whether only a single deputy or impersonator should spawn in a round
 ttt_deputy_impersonator_promote_any_death   0       // Whether deputy/impersonator should be promoted when any detective dies rather than only after all detectives have died
 

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -153,6 +153,7 @@ ttt_impersonator_credits_starting           1       // The number of credits an 
 ttt_impersonator_use_detective_icon         1       // Whether a promoted impersonator should show the detective icon over their head instead of the impersonator icon (only for traitors, non-traitors will use the equivalent deputy setting)
 ttt_impersonator_without_detective          0       // Whether an impersonator can spawn without a detective in the round. Will automatically promote the impersonator when they spawn
 ttt_impersonator_activation_credits         0       // The number of credits to give the impersonator when they are activated
+ttt_impersonator_detective_chance           0       // The chance that a detective will spawn as a promoted impersonator instead (e.g. 0.5 = 50% chance)
 ttt_single_deputy_impersonator              0       // Whether only a single deputy or impersonator should spawn in a round
 ttt_deputy_impersonator_promote_any_death   0       // Whether deputy/impersonator should be promoted when any detective dies rather than only after all detectives have died
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.4.1
+**Released:**
+
+### Developer
+- Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role
+
 ## 1.4.0
 **Released: November 15th, 2021**\
 Includes all beta updates from [1.3.1](#131-beta) to [1.3.7](#137-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,12 @@
 ## 1.4.1
 **Released:**
 
+### Changes
+- Changed old man to lose karma if they hurt or kill players when their adrenaline rush is not active
+- Changed so innocents that hurt or kill the old man will lose karma
+- Changed old man adrenaline rush logic so it shows what player ultimately killed them in chat rather than "You killed yourself"
+- Changed old man adrenaline rush message to also show in the center of the screen to make it more obvious when it's happening
+
 ### Fixes
 - Fixed loot goblin and old man not sharing a timelimit win with the innocents
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Additions
 - Added ability to give the impersonator credits when they are activated (disabled by default)
 - Added ability to configure a chance for a promoted impersonator to spawn instead of a detective (disabled by default)
+- Added ability to remind players that there is a medium when they die (enabled by default)
 
 ### Developer
 - Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Fixed loot goblin and old man not sharing a timelimit win with the innocents
+- Fixed loot goblin and old man not sharing a win with eachother (if they are both in the same round) on the round summary screen
 
 ### Additions
 - Added ability to give the impersonator credits when they are activated (disabled by default)
@@ -20,6 +21,8 @@
 ### Developer
 - Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role
 - Fixed TTTWinCheckComplete not being called when the win type was WIN_TIMELIMIT
+- Added new TTTScoringSecondaryWins hook to allow multiple roles to have secondary wins at the same time
+- **BREAKING CHANGE** - Removed secondaryWinRole parameter from TTTScoringWinTitle hook
 
 ## 1.4.0
 **Released: November 15th, 2021**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Additions
 - Added ability to give the impersonator credits when they are activated (disabled by default)
+- Added ability to configure a chance for a promoted impersonator to spawn instead of a detective (disabled by default)
 
 ### Developer
 - Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.4.1
 **Released:**
 
+### Fixes
+- Fixed loot goblin and old man not sharing a timelimit win with the innocents
+
 ### Additions
 - Added ability to give the impersonator credits when they are activated (disabled by default)
 - Added ability to configure a chance for a promoted impersonator to spawn instead of a detective (disabled by default)
@@ -10,6 +13,7 @@
 
 ### Developer
 - Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role
+- Fixed TTTWinCheckComplete not being called when the win type was WIN_TIMELIMIT
 
 ## 1.4.0
 **Released: November 15th, 2021**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.4.1
 **Released:**
 
+### Additions
+- Added ability to give the impersonator credits when they are activated (disabled by default)
+
 ### Developer
 - Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role
 

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -121,7 +121,7 @@ net.Receive("TTT_ResetScoreboard", function(len)
     customEvents = {}
 end)
 
-local secondary_win_role = nil
+local secondary_win_roles = {}
 net.Receive("TTT_SpawnedPlayers", function(len)
     local name = net.ReadString()
     local role = net.ReadInt(8)
@@ -132,7 +132,7 @@ net.Receive("TTT_SpawnedPlayers", function(len)
         rol = role
     })
 
-    secondary_win_role = nil
+    table.Empty(secondary_win_roles)
 end)
 
 net.Receive("TTT_LogInfo", function(len)
@@ -241,9 +241,12 @@ local function GetWinTitle(wintype)
         [WIN_MONSTER] = { txt = "hilite_win_role_plural", params = { role = "MONSTERS" }, c = GetRoleTeamColor(ROLE_TEAM_MONSTER) }
     }
     local title = wintitles[wintype]
-    local new_title, new_secondary = hook.Run("TTTScoringWinTitle", wintype, wintitles, title, secondary_win_role)
+    local new_title = hook.Run("TTTScoringWinTitle", wintype, wintitles, title)
     if new_title then title = new_title end
-    if new_secondary then secondary_win_role = new_secondary end
+
+    local secondary_wins = {}
+    hook.Run("TTTScoringSecondaryWins", wintype, secondary_wins)
+    secondary_win_roles = secondary_wins
 
     -- If this was a monster win, check that both roles are part of the monsters team still
     if wintype == WIN_MONSTER then
@@ -437,6 +440,17 @@ function CLSCORE:AddAward(y, pw, award, dpanel)
 end
 
 function CLSCORE:BuildSummaryPanel(dpanel)
+    local title = GetWinTitle(WIN_INNOCENT)
+    for i = #self.Events, 1, -1 do
+        local e = self.Events[i]
+        if e.id == EVENT_FINISH then
+            local wintype = e.win
+            if wintype == WIN_TIMELIMIT then wintype = WIN_INNOCENT end
+            title = GetWinTitle(wintype)
+            break
+        end
+    end
+
     -- Gather player information
     local scores = self.Scores
     local nicks = self.Players
@@ -546,48 +560,45 @@ function CLSCORE:BuildSummaryPanel(dpanel)
 
     -- Add 33px for each extra role
     local height_extra = (player_rows - 10) * 33
+
+    local height_extra_secondaries = 0
+    if #secondary_win_roles > 1 then
+        height_extra_secondaries = (#secondary_win_roles - 1) * 28
+    end
+
     local has_indep_and_jesters = #scores_by_section[ROLE_TEAM_INDEPENDENT] > 0 and #scores_by_section[ROLE_TEAM_JESTER] > 0
     local height_extra_jester = 0
     if has_indep_and_jesters then
         height_extra_jester = 32
     end
 
+    local height_extra_total = height_extra + height_extra_jester + height_extra_secondaries
+
     -- Build the panel
     local w, h = dpanel:GetSize()
-    if height_extra > 0 or height_extra_jester > 0 then
-        h = h + height_extra + height_extra_jester
+    if height_extra_total > 0 then
+        h = h + height_extra_total
 
         -- Make the parent panel and tab container bigger
         local pw, ph = parentPanel:GetSize()
-        ph = ph + height_extra + height_extra_jester
+        ph = ph + height_extra_total
         parentPanel:SetSize(pw, ph)
 
         local tw, th = parentTabs:GetSize()
-        th = th + height_extra + height_extra_jester
+        th = th + height_extra_total
         parentTabs:SetSize(tw, th)
 
         -- Move the buttons down
         local sx, sy = saveButton:GetPos()
-        sy = sy + height_extra + height_extra_jester
+        sy = sy + height_extra_total
         saveButton:SetPos(sx, sy)
 
         local cx, cy = closeButton:GetPos()
-        cy = cy + height_extra + height_extra_jester
+        cy = cy + height_extra_total
         closeButton:SetPos(cx, cy)
 
         -- Make this inner panel bigger
         dpanel:SetSize(w, h)
-    end
-
-    local title = GetWinTitle(WIN_INNOCENT)
-    for i = #self.Events, 1, -1 do
-        local e = self.Events[i]
-        if e.id == EVENT_FINISH then
-            local wintype = e.win
-            if wintype == WIN_TIMELIMIT then wintype = WIN_INNOCENT end
-            title = GetWinTitle(wintype)
-            break
-        end
     end
 
     local bg = vgui.Create("ColoredBox", dpanel)
@@ -615,49 +626,52 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     local ywin = 15
     winlbl:SetPos(xwin, ywin)
 
-    local exwinlbl = vgui.Create("DLabel", dpanel)
-    if secondary_win_role then
+    for i, r in ipairs(secondary_win_roles) do
+        local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = ROLE_STRINGS[secondary_win_role]:upper() }))
+        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = ROLE_STRINGS[r]:upper() }))
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2
-        local yexwin = 61
+        local yexwin = 61 + (28 * (i - 1))
         exwinlbl:SetPos(xexwin, yexwin)
-    else
-        exwinlbl:SetText("")
     end
 
     bg.PaintOver = function()
         draw.RoundedBox(8, 8, ywin - 5, w - 14, winlbl:GetTall() + 10, title.c)
-        if secondary_win_role then draw.RoundedBoxEx(8, 8, 65, w - 14, 28, ROLE_COLORS[secondary_win_role], false, false, true, true) end
-        draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 15, 341, 329 + height_extra, Color(164, 164, 164, 255))
-        draw.RoundedBox(0, 357, ywin + winlbl:GetTall() + 15, 341, 329 + height_extra, Color(164, 164, 164, 255))
-        local loc = ywin + winlbl:GetTall() + 47
+        for i, r in ipairs(secondary_win_roles) do
+            local round_bottom = i == #secondary_win_roles
+            local height = 28
+            draw.RoundedBoxEx(8, 8, 65 + (height * (i - 1)), w - 14, height, ROLE_COLORS[r], false, false, round_bottom, round_bottom)
+        end
+        draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 15 + height_extra_secondaries, 341, 329 + height_extra, Color(164, 164, 164, 255))
+        draw.RoundedBox(0, 357, ywin + winlbl:GetTall() + 15 + height_extra_secondaries, 341, 329 + height_extra, Color(164, 164, 164, 255))
+        local loc = ywin + winlbl:GetTall() + 47 + height_extra_secondaries
         for _ = 1, player_rows do
             draw.RoundedBox(0, 8, loc, 341, 1, Color(97, 100, 102, 255))
             draw.RoundedBox(0, 357, loc, 341, 1, Color(97, 100, 102, 255))
             loc = loc + 33
         end
-        draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 352 + height_extra, 690, 32, Color(164, 164, 164, 255))
+        draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 352 + height_extra + height_extra_secondaries, 690, 32, Color(164, 164, 164, 255))
         -- Add another row for jesters if we also have independents
-        if has_indep_and_jesters then draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 352 + height_extra + height_extra_jester, 690, 32, Color(164, 164, 164, 255)) end
+        if has_indep_and_jesters then draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 354 + height_extra_total, 690, 32, Color(164, 164, 164, 255)) end
     end
 
-    if secondary_win_role then winlbl:SetPos(xwin, ywin - 15) end
+    if #secondary_win_roles > 0 then winlbl:SetPos(xwin, ywin - 15) end
 
     -- Add the players to the panel
-    self:BuildPlayerList(scores_by_section[ROLE_TEAM_INNOCENT], dpanel, 317, 8, 103, 33)
-    self:BuildPlayerList(scores_by_section[ROLE_TEAM_TRAITOR], dpanel, 666, 357, 103, 33)
+    self:BuildPlayerList(scores_by_section[ROLE_TEAM_INNOCENT], dpanel, 317, 8, 103 + height_extra_secondaries, 33)
+    self:BuildPlayerList(scores_by_section[ROLE_TEAM_TRAITOR], dpanel, 666, 357, 103 + height_extra_secondaries, 33)
     if #scores_by_section[ROLE_TEAM_INDEPENDENT] > 0 then
-        self:BuildRoleLabel(scores_by_section[ROLE_TEAM_INDEPENDENT], dpanel, 666, 8, 440 + height_extra)
+        self:BuildRoleLabel(scores_by_section[ROLE_TEAM_INDEPENDENT], dpanel, 666, 8, 440 + height_extra + height_extra_secondaries)
     end
     if #scores_by_section[ROLE_TEAM_JESTER] > 0 then
         -- Move the label down more to add space
+        local spacer = 0
         if has_indep_and_jesters then
-            height_extra_jester = height_extra_jester + 2
+            spacer = 2
         end
-        self:BuildRoleLabel(scores_by_section[ROLE_TEAM_JESTER], dpanel, 666, 8, 440 + height_extra + height_extra_jester)
+        self:BuildRoleLabel(scores_by_section[ROLE_TEAM_JESTER], dpanel, 666, 8, 440 + height_extra_total + spacer)
     end
 end
 
@@ -906,27 +920,29 @@ function CLSCORE:BuildHilitePanel(dpanel)
     local ywin = 15
     winlbl:SetPos(xwin, ywin)
 
-    local exwinlbl = vgui.Create("DLabel", dpanel)
-    if secondary_win_role then
+    for i, r in ipairs(secondary_win_roles) do
+        local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = ROLE_STRINGS[secondary_win_role]:upper() }))
+        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = ROLE_STRINGS[r]:upper() }))
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2
-        local yexwin = 61
+        local yexwin = 61 + (28 * (i - 1))
         exwinlbl:SetPos(xexwin, yexwin)
-    else
-        exwinlbl:SetText("")
     end
 
     bg.PaintOver = function()
         draw.RoundedBox(8, 8, ywin - 5, w - 14, winlbl:GetTall() + 10, title.c)
-        if secondary_win_role then draw.RoundedBoxEx(8, 8, 65, w - 14, 28, ROLE_COLORS[secondary_win_role], false, false, true, true) end
+        for i, r in ipairs(secondary_win_roles) do
+            local round_bottom = i == #secondary_win_roles
+            local height = 28
+            draw.RoundedBoxEx(8, 8, 65 + (height * (i - 1)), w - 14, height, ROLE_COLORS[r], false, false, round_bottom, round_bottom)
+        end
     end
 
-    if secondary_win_role then winlbl:SetPos(xwin, ywin - 15) end
+    if #secondary_win_roles > 0 then winlbl:SetPos(xwin, ywin - 15) end
 
-    local ysubwin = ywin + winlbl:GetTall()
+    local ysubwin = ywin + winlbl:GetTall() + ((#secondary_win_roles - 1) * 28)
     local partlbl = vgui.Create("DLabel", dpanel)
 
     local plytxt = PT(numtr == 1 and "hilite_players2" or "hilite_players1",

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -50,12 +50,12 @@ local function IdentifyBody(ply, rag)
         return
     end
 
-    local role = rag.was_role
-    local traitor = TRAITOR_ROLES[rag.was_role]
-    if not hook.Run("TTTCanIdentifyCorpse", ply, rag, traitor) then
+    if not hook.Run("TTTCanIdentifyCorpse", ply, rag, TRAITOR_ROLES[rag.was_role]) then
         return
     end
 
+    -- do this after the hook in case it wants to change some of that data
+    local role = rag.was_role
     local finder = ply:Nick()
     local nick = CORPSE.GetPlayerNick(rag, "")
 
@@ -76,7 +76,8 @@ local function IdentifyBody(ply, rag)
             deadply:SetNWBool("body_searched", true)
             deadply:SetNWBool("body_found", true)
 
-            if traitor then
+            -- Don't cache this in case the hook wants to change the corpse's role
+            if TRAITOR_ROLES[role] then
                 -- update innocent team's list of whichever traitor role this corpse was
                 SendRoleList(role, GetInnocentTeamFilter(false))
             end
@@ -188,12 +189,13 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
         return
     end
 
-    local role = rag.was_role
-    if not hook.Run("TTTCanSearchCorpse", ply, rag, covert, long_range, TRAITOR_ROLES[role]) then
+    if not hook.Run("TTTCanSearchCorpse", ply, rag, covert, long_range, TRAITOR_ROLES[rag.was_role]) then
         return
     end
 
     -- init a heap of data we'll be sending
+    -- do this after the hook in case it wants to change some of that data
+    local role = rag.was_role
     local nick = CORPSE.GetPlayerNick(rag)
     local eq = rag.equipment or EQUIP_NONE
     local c4 = rag.bomb_wire or -1

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1521,10 +1521,9 @@ function SelectRoles()
         for _ = 1, detective_count do
             if #options > 0 then
                 local plyPick = math.random(1, #options)
-                local ply = options[plyPick]
+                local ply = table.remove(options, plyPick)
                 table.insert(detectives, ply)
                 table.RemoveByValue(choices, ply)
-                table.remove(options, plyPick)
             end
         end
     end
@@ -1534,9 +1533,8 @@ function SelectRoles()
     for _ = 1, traitor_count do
         if #choices > 0 then
             local plyPick = math.random(1, #choices)
-            local ply = choices[plyPick]
+            local ply = table.remove(choices, plyPick)
             table.insert(traitors, ply)
-            table.remove(choices, plyPick)
         end
     end
 
@@ -1553,12 +1551,11 @@ function SelectRoles()
         for _ = 1, max_special_detective_count do
             if #specialDetectiveRoles ~= 0 and math.random() <= GetConVar("ttt_special_detective_chance"):GetFloat() and #detectives > 0 then
                 local plyPick = math.random(1, #detectives)
-                local ply = detectives[plyPick]
+                local ply = table.remove(detectives, plyPick)
                 local rolePick = math.random(1, #specialDetectiveRoles)
                 local role = specialDetectiveRoles[rolePick]
                 ply:SetRole(role)
                 PrintRole(ply, role)
-                table.remove(detectives, plyPick)
                 for i = #specialDetectiveRoles, 1, -1 do
                     if specialDetectiveRoles[i] == role then
                         table.remove(specialDetectiveRoles, i)
@@ -1568,10 +1565,29 @@ function SelectRoles()
         end
     end
 
+    local has_impersonator = table.HasValue(specialTraitorRoles, ROLE_IMPERSONATOR)
+    local impersonator_chance = GetConVar("ttt_impersonator_detective_chance"):GetFloat()
     -- Any of these left are vanilla detectives
     for _, v in pairs(detectives) do
-        v:SetRole(ROLE_DETECTIVE)
-        PrintRole(v, ROLE_DETECTIVE)
+        -- By chance have this detective actually be a promoted impersonator
+        if #traitors > 0 and has_impersonator and math.random() < impersonator_chance then
+            v:SetRole(ROLE_IMPERSONATOR)
+            PrintRole(v, ROLE_IMPERSONATOR)
+            v:HandleDetectiveLikePromotion()
+
+            -- Move a player from "traitors" to "choices" and update the table copies to keep the team counts the same
+            local plyPick = math.random(1, #traitors)
+            local ply = table.remove(traitors, plyPick)
+            table.insert(choices, ply)
+            traitors_copy = table.Copy(traitors)
+            choices_copy = table.Copy(choices)
+
+            -- Only allow one to be an impersonator
+            has_impersonator = false
+        else
+            v:SetRole(ROLE_DETECTIVE)
+            PrintRole(v, ROLE_DETECTIVE)
+        end
     end
 
     if ((GetConVar("ttt_zombie_enabled"):GetBool() and math.random() <= GetConVar("ttt_zombie_round_chance"):GetFloat() and (forcedTraitorCount <= 0) and (forcedSpecialTraitorCount <= 0)) or hasRole[ROLE_ZOMBIE]) and TRAITOR_ROLES[ROLE_ZOMBIE] then
@@ -1589,12 +1605,11 @@ function SelectRoles()
             for _ = 1, max_special_traitor_count do
                 if #specialTraitorRoles ~= 0 and math.random() <= GetConVar("ttt_special_traitor_chance"):GetFloat() and #traitors > 0 then
                     local plyPick = math.random(1, #traitors)
-                    local ply = traitors[plyPick]
+                    local ply = table.remove(traitors, plyPick)
                     local rolePick = math.random(1, #specialTraitorRoles)
                     local role = specialTraitorRoles[rolePick]
                     ply:SetRole(role)
                     PrintRole(ply, role)
-                    table.remove(traitors, plyPick)
                     for i = #specialTraitorRoles, 1, -1 do
                         if specialTraitorRoles[i] == role then
                             table.remove(specialTraitorRoles, i)
@@ -1621,12 +1636,11 @@ function SelectRoles()
 
         if #independentRoles ~= 0 then
             local plyPick = math.random(1, #choices)
-            local ply = choices[plyPick]
+            local ply = table.remove(choices, plyPick)
             local rolePick = math.random(1, #independentRoles)
             local role = independentRoles[rolePick]
             ply:SetRole(role)
             PrintRole(ply, role)
-            table.remove(choices, plyPick)
             for i = #independentRoles, 1, -1 do
                 if independentRoles[i] == role then
                     table.remove(independentRoles, i)
@@ -1641,12 +1655,11 @@ function SelectRoles()
 
         if #jesterRoles ~= 0 then
             local plyPick = math.random(1, #choices)
-            local ply = choices[plyPick]
+            local ply = table.remove(choices, plyPick)
             local rolePick = math.random(1, #jesterRoles)
             local role = jesterRoles[rolePick]
             ply:SetRole(role)
             PrintRole(ply, role)
-            table.remove(choices, plyPick)
             for i = #jesterRoles, 1, -1 do
                 if jesterRoles[i] == role then
                     table.remove(jesterRoles, i)
@@ -1672,7 +1685,7 @@ function SelectRoles()
         for _ = 1, max_special_innocent_count do
             if #specialInnocentRoles ~= 0 and math.random() <= GetConVar("ttt_special_innocent_chance"):GetFloat() and #choices > 0 then
                 local plyPick = math.random(1, #choices)
-                local ply = choices[plyPick]
+                local ply = table.remove(choices, plyPick)
                 local rolePick = math.random(1, #specialInnocentRoles)
                 local role = specialInnocentRoles[rolePick]
                 if role == ROLE_GLITCH and glitch_mode == GLITCH_SHOW_AS_SPECIAL_TRAITOR then
@@ -1685,7 +1698,6 @@ function SelectRoles()
                 end
                 ply:SetRole(role)
                 PrintRole(ply, role)
-                table.remove(choices, plyPick)
                 for i = #specialInnocentRoles, 1, -1 do
                     if specialInnocentRoles[i] == role then
                         table.remove(specialInnocentRoles, i)
@@ -1703,12 +1715,11 @@ function SelectRoles()
 
             if #monsterRoles ~= 0 and math.random() <= GetConVar("ttt_monster_chance"):GetFloat() and #choices > 0 and not monster_chosen then
                 local plyPick = math.random(1, #choices)
-                local ply = choices[plyPick]
+                local ply = table.remove(choices, plyPick)
                 local rolePick = math.random(1, #monsterRoles)
                 local role = monsterRoles[rolePick]
                 ply:SetRole(role)
                 PrintRole(ply, role)
-                table.remove(choices, plyPick)
                 for i = #monsterRoles, 1, -1 do
                     if monsterRoles[i] == role then
                         table.remove(monsterRoles, i)

--- a/gamemodes/terrortown/gamemode/roles/clown/clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/clown.lua
@@ -26,10 +26,8 @@ end)
 -- WIN CHECKS --
 ----------------
 
-local unblockable_wins = {WIN_TIMELIMIT}
 local function HandleClownWinBlock(win_type)
     if win_type == WIN_NONE then return win_type end
-    if table.HasValue(unblockable_wins, win_type) then return win_type end
 
     local clown = player.GetLivingRole(ROLE_CLOWN)
     if not IsPlayer(clown) then return win_type end

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
@@ -20,16 +20,19 @@ local plymeta = FindMetaTable("Player")
 function plymeta:HandleDetectiveLikePromotion()
     self:SetNWBool("HasPromotion", true)
 
-    if self:IsDeputy() then
-        local credits = GetConVar("ttt_deputy_activation_credits"):GetInt()
+    local role = self:GetRole()
+    local rolestring = ROLE_STRINGS_RAW[role]
+    local convar = "ttt_" .. rolestring .. "_activation_credits"
+    if ConVarExists(convar) then
+        local credits = GetConVar(convar):GetInt()
         if credits > 0 then
             self:AddCredits(credits)
         end
+    end
 
-        -- Give the deputy their shop items if purchase was delayed
-        if self.bought and GetConVar("ttt_deputy_shop_delay"):GetBool() then
-            self:GiveDelayedShopItems()
-        end
+    -- Give the player their shop items if purchase was delayed
+    if DELAYED_SHOP_ROLES[role] and self.bought and GetConVar("ttt_" .. rolestring .. "_shop_delay"):GetBool() then
+        self:GiveDelayedShopItems()
     end
 
     net.Start("TTT_Promotion")

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -260,10 +260,8 @@ local function StopDrunkTimers()
     if timer.Exists("waitfordrunkrespawn") then timer.Remove("waitfordrunkrespawn") end
 end
 
-local unblockable_wins = {WIN_TIMELIMIT}
 local function HandleDrunkWinBlock(win_type)
     if win_type == WIN_NONE then return win_type end
-    if table.HasValue(unblockable_wins, win_type) then return win_type end
 
     local drunk = player.GetLivingRole(ROLE_DRUNK)
     if not IsPlayer(drunk) then return win_type end

--- a/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
+++ b/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
@@ -8,6 +8,7 @@ local impersonator_damage_penalty = CreateConVar("ttt_impersonator_damage_penalt
 local impersonator_use_detective_icon = CreateConVar("ttt_impersonator_use_detective_icon", "1")
 CreateConVar("ttt_impersonator_without_detective", "0")
 CreateConVar("ttt_impersonator_activation_credits", "0")
+CreateConVar("ttt_impersonator_detective_chance", "0")
 
 hook.Add("TTTSyncGlobals", "Impersonator_TTTSyncGlobals", function()
     SetGlobalBool("ttt_impersonator_use_detective_icon", impersonator_use_detective_icon:GetBool())

--- a/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
+++ b/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
@@ -7,6 +7,7 @@ AddCSLuaFile()
 local impersonator_damage_penalty = CreateConVar("ttt_impersonator_damage_penalty", "0")
 local impersonator_use_detective_icon = CreateConVar("ttt_impersonator_use_detective_icon", "1")
 CreateConVar("ttt_impersonator_without_detective", "0")
+CreateConVar("ttt_impersonator_activation_credits", "0")
 
 hook.Add("TTTSyncGlobals", "Impersonator_TTTSyncGlobals", function()
     SetGlobalBool("ttt_impersonator_use_detective_icon", impersonator_use_detective_icon:GetBool())

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -73,9 +73,9 @@ end)
 -- WIN CHECKS --
 ----------------
 
-hook.Add("TTTScoringWinTitle", "LootGoblin_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
+hook.Add("TTTScoringSecondaryWins", "LootGoblin_TTTScoringSecondaryWins", function(wintype, secondary_wins)
     if lootgoblin_wins then
-        return title, ROLE_LOOTGOBLIN
+        table.insert(secondary_wins, ROLE_LOOTGOBLIN)
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/medium/medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/medium.lua
@@ -5,6 +5,7 @@ AddCSLuaFile()
 -------------
 
 local medium_spirit_color = CreateConVar("ttt_medium_spirit_color", "1")
+local medium_dead_notify = CreateConVar("ttt_medium_dead_notify", "1")
 
 hook.Add("TTTSyncGlobals", "Medium_TTTSyncGlobals", function()
     SetGlobalBool("ttt_medium_spirit_color", medium_spirit_color:GetBool())
@@ -66,5 +67,11 @@ hook.Add("PlayerDeath", "Medium_Spirits_PlayerDeath", function(victim, infl, att
         spirit:SetNWVector("SpiritColor", col)
         spirit:Spawn()
         spirits[victim:SteamID64()] = spirit
+
+        -- Let the player who died know there is a medium
+        if medium_dead_notify:GetBool() then
+            victim:PrintMessage(HUD_PRINTTALK, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
+            victim:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS_EXT[ROLE_MEDIUM] .. " senses your spirit.")
+        end
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/medium/medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/medium.lua
@@ -71,7 +71,7 @@ hook.Add("PlayerDeath", "Medium_Spirits_PlayerDeath", function(victim, infl, att
         -- Let the player who died know there is a medium
         if medium_dead_notify:GetBool() then
             victim:PrintMessage(HUD_PRINTTALK, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
-            victim:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS_EXT[ROLE_MEDIUM] .. " senses your spirit.")
+            victim:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
         end
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
@@ -37,9 +37,9 @@ end)
 -- WIN CHECKS --
 ----------------
 
-hook.Add("TTTScoringWinTitle", "OldMan_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
+hook.Add("TTTScoringSecondaryWins", "OldMan_TTTScoringSecondaryWins", function(wintype, secondary_wins)
     if oldman_wins then
-        return title, ROLE_OLDMAN
+        table.insert(secondary_wins, ROLE_OLDMAN)
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
@@ -66,48 +66,87 @@ ROLE_ON_ROLE_ASSIGNED[ROLE_OLDMAN] = function(ply)
 end
 
 hook.Add("EntityTakeDamage", "OldMan_EntityTakeDamage", function(ent, dmginfo)
-    if not IsValid(ent) then return end
+    if GetRoundState() ~= ROUND_ACTIVE then return end
+    if not IsPlayer(ent) or not ent:IsOldMan() then return end
+
+    local adrenalineTime = oldman_adrenaline_rush:GetInt()
+    -- Don't run this if adrenaline rush is disabled
+    if adrenalineTime <= 0 then return end
+
+    -- Only give the Old Man an adrenaline rush once
+    if ent:GetNWBool("AdrenalineRushed", false) then return end
 
     local att = dmginfo:GetAttacker()
-    if GetRoundState() >= ROUND_ACTIVE and ent:IsPlayer() then
-        local adrenalineTime = oldman_adrenaline_rush:GetInt()
-        if ent:IsOldMan() and adrenalineTime > 0 then
-            local damage = dmginfo:GetDamage()
-            local health = ent:Health()
-
-            if ent:IsRoleActive() then -- If they are mid adrenaline rush then they take no damage
-                dmginfo:ScaleDamage(0)
-                dmginfo:SetDamage(0)
-            elseif IsPlayer(att) and damage >= health then -- If they are attacked by a player that would have killed them they enter an adrenaline rush
-                dmginfo:SetDamage(health - 1)
-                ent:SetNWBool("AdrenalineRush", true)
-                if oldman_adrenaline_ramble:GetBool() then
-                    ent:EmitSound("oldmanramble.wav")
-                end
-                ent:PrintMessage(HUD_PRINTTALK, "You are having an adrenaline rush! You will die in " .. tostring(adrenalineTime) .. " seconds.")
-
-                if oldman_adrenaline_shotgun:GetBool() then
-                    for _, wep in ipairs(ent:GetWeapons()) do
-                        if wep.Kind == WEAPON_HEAVY then
-                            ent:StripWeapon(wep:GetClass())
-                        end
-                    end
-                    ent:Give("weapon_old_dbshotgun")
-                    ent:SelectWeapon("weapon_old_dbshotgun")
-                end
-
-                timer.Create(ent:Nick() .. "AdrenalineRush", adrenalineTime, 1, function()
-                    ent:SetNWBool("AdrenalineRush", false)
-                    if ent:IsActiveOldMan() then ent:Kill() end -- Only kill them if they are still the old man
-                end)
-            end
+    local damage = dmginfo:GetDamage()
+    local health = ent:Health()
+    if ent:IsRoleActive() then -- If they are mid adrenaline rush then they take no damage
+        dmginfo:ScaleDamage(0)
+        dmginfo:SetDamage(0)
+    elseif IsPlayer(att) and damage >= health then -- If they are attacked by a player that would have killed them they enter an adrenaline rush
+        dmginfo:SetDamage(health - 1)
+        ent:SetNWBool("AdrenalineRush", true)
+        if oldman_adrenaline_ramble:GetBool() then
+            ent:EmitSound("oldmanramble.wav")
         end
+        local message = "You are having an adrenaline rush! You will die in " .. tostring(adrenalineTime) .. " seconds."
+        ent:PrintMessage(HUD_PRINTTALK, message)
+        ent:PrintMessage(HUD_PRINTCENTER, message)
+
+        if oldman_adrenaline_shotgun:GetBool() then
+            for _, wep in ipairs(ent:GetWeapons()) do
+                if wep.Kind == WEAPON_HEAVY then
+                    ent:StripWeapon(wep:GetClass())
+                end
+            end
+            ent:Give("weapon_old_dbshotgun")
+            ent:SelectWeapon("weapon_old_dbshotgun")
+        end
+
+        timer.Create(ent:Nick() .. "AdrenalineRush", adrenalineTime, 1, function()
+            ent:SetNWBool("AdrenalineRush", false)
+            ent:SetNWBool("AdrenalineRushed", true)
+            -- Only kill them if they are still the old man
+            if ent:IsActiveOldMan() then
+                local inflictor = dmginfo:GetInflictor()
+                if not IsValid(inflictor) then
+                    inflictor = att
+                end
+
+                -- Use TakeDamage instead of Kill so it properly applies karma
+                local dmg = DamageInfo()
+                dmg:SetDamageType(dmginfo:GetDamageType())
+                dmg:SetAttacker(att)
+                dmg:SetInflictor(inflictor)
+                -- Use 10 so damage scaling doesn't mess with it. The worse damage factor (0.1) will still deal 1 damage after scaling a 10 down
+                -- Karma ignores excess damage anyway
+                dmg:SetDamage(10)
+                dmg:SetDamageForce(Vector(0, 0, 1))
+
+                ent:TakeDamageInfo(dmg)
+            end
+        end)
     end
 end)
 
 hook.Add("TTTPrepareRound", "OldMan_Adrenaline_TTTPrepareRound", function()
     for _, v in pairs(player.GetAll()) do
         v:SetNWBool("AdrenalineRush", false)
+        v:SetNWBool("AdrenalineRushed", false)
         timer.Remove(v:Nick() .. "AdrenalineRush")
+    end
+end)
+
+-----------
+-- KARMA --
+-----------
+
+hook.Add("TTTKarmaShouldGivePenalty", "OldMan_TTTKarmaShouldGivePenalty", function(attacker, victim)
+    -- Innocents will lose karma for killing an Old Man
+    if attacker:IsInnocentTeam() and victim:IsOldMan() then
+        return true
+    end
+    -- Old Man has no karma, positive or negative, while their adrenaline rush is active
+    if attacker:IsOldMan() then
+        return not attacker:GetNWBool("AdrenalineRush", false)
     end
 end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.4.0"
+CR_VERSION = "1.4.1"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Changes**
- Changed old man to lose karma if they hurt or kill players when their adrenaline rush is not active
- Changed so innocents that hurt or kill the old man will lose karma
- Changed old man adrenaline rush logic so it shows what player ultimately killed them in chat rather than "You killed yourself"
- Changed old man adrenaline rush message to also show in the center of the screen to make it more obvious when it's happening

**Fixes**
- Fixed loot goblin and old man not sharing a timelimit win with the innocents
- Fixed loot goblin and old man not sharing a win with eachother (if they are both in the same round) on the round summary screen

**Additions**
- Added ability to give the impersonator credits when they are activated (disabled by default)
- Added ability to configure a chance for a promoted impersonator to spawn instead of a detective (disabled by default)
- Added ability to remind players that there is a medium when they die (enabled by default)

**Developer**
- Changed TTTCanIdentifyCorpse and TTTCanSearchCorpse hooks to allow changing the corpse's stored role
- Fixed TTTWinCheckComplete not being called when the win type was WIN_TIMELIMIT
- Added new TTTScoringSecondaryWins hook to allow multiple roles to have secondary wins at the same time
- **BREAKING CHANGE** - Removed secondaryWinRole parameter from TTTScoringWinTitle hook