### PR TITLE
Misc. fixes and additions

### DIFF
--- a/API/GLOBAL_VARIABLES.md
+++ b/API/GLOBAL_VARIABLES.md
@@ -53,6 +53,10 @@ Variables available globally (within the defined realm)
 *Realm:* Client and Server\
 *Added in:* 1.2.5
 
+**EVENTS_BY_ROLE** - Table of event IDs for each role.\
+*Realm:* Client and Server\
+*Added in:* 1.4.2
+
 **INDEPENDENT_ROLES** - Lookup table for whether a role is on the independent team.\
 *Realm:* Client and Server\
 *Added in:* 1.0.0
@@ -116,3 +120,7 @@ Variables available globally (within the defined realm)
 **WIN_MAX** - The maximum win state identifier.\
 *Realm:* Client and Server\
 *Added in:* 1.2.5
+
+**WINS_BY_ROLE** - Table of win IDs for each role.\
+*Realm:* Client and Server\
+*Added in:* 1.4.2

--- a/API/METHODS_GLOBAL.md
+++ b/API/METHODS_GLOBAL.md
@@ -23,13 +23,17 @@ Methods available globally (within the defined realm)
 
 *Returns*: An accessible position around the given position or `false` if none can be found
 
-**GenerateNewEventID()** - Generates a new ID to be used for custom scoring events.\
+**GenerateNewEventID(role)** - Generates a new ID to be used for custom scoring events.\
 *Realm:* Client and Server\
-*Added in:* 1.2.5
+*Added in:* 1.2.5\
+*Parameters:*
+- *role* - The ID of the role that the generated event ID belongs to *(Added in 1.4.2)*
 
-**GenerateNewWinID()** - Generates a new ID to be used for custom win conditions.\
+**GenerateNewWinID(role)** - Generates a new ID to be used for custom win conditions.\
 *Realm:* Client and Server\
-*Added in:* 1.2.5
+*Added in:* 1.2.5\
+*Parameters:*
+- *role* - The ID of the role that the generated win ID belongs to *(Added in 1.4.2)*
 
 **GetEquipmentItemById(id)** - Gets an equipment item's definition by their ID.\
 *Realm:* Client and Server\

--- a/API/METHODS_GLOBAL.md
+++ b/API/METHODS_GLOBAL.md
@@ -27,13 +27,13 @@ Methods available globally (within the defined realm)
 *Realm:* Client and Server\
 *Added in:* 1.2.5\
 *Parameters:*
-- *role* - The ID of the role that the generated event ID belongs to *(Added in 1.4.2)*
+- *role* - The ID of the role that the generated event ID belongs to. Pass `ROLE_NONE` if this should not be associated with any role *(Added in 1.4.2)*
 
 **GenerateNewWinID(role)** - Generates a new ID to be used for custom win conditions.\
 *Realm:* Client and Server\
 *Added in:* 1.2.5\
 *Parameters:*
-- *role* - The ID of the role that the generated win ID belongs to *(Added in 1.4.2)*
+- *role* - The ID of the role that the generated win ID belongs to. Pass `ROLE_NONE` if this should not be associated with any role *(Added in 1.4.2)*
 
 **GetEquipmentItemById(id)** - Gets an equipment item's definition by their ID.\
 *Realm:* Client and Server\

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -307,6 +307,7 @@ ttt_tracker_credits_starting                1       // The number of credits a t
 
 // Medium
 ttt_medium_spirit_color                     1       // Whether players' spirits should have different colors
+ttt_medium_spirit_vision                    1       // Whether players' spirits should be able to see eachother
 ttt_medium_dead_notify                      1       // Whether player should be notified that there is a medium when they die
 ttt_medium_credits_starting                 1       // The number of credits a medium should start with
 

--- a/CREATE_YOUR_OWN_ROLE.md
+++ b/CREATE_YOUR_OWN_ROLE.md
@@ -561,15 +561,15 @@ To create a custom win condition, you will need to define a global unique win id
 
 #### Win Identifier
 
-The identifier must be unique to make sure you can differentiate between your role's win and any other role's win. Starting in version 1.2.5, Custom Roles for TTT provides a method for generating a unique win identifier for you. If you want to ensure compatibility with Custom Roles for TTT prior to version 1.2.5 you shoud come up with your own unique number for your role.
+The identifier must be unique to make sure you can differentiate between your role's win and any other role's win. Starting in version 1.2.5, Custom Roles for TTT provides a method for generating a unique win identifier for you. If you want to ensure compatibility with Custom Roles for TTT prior to version 1.2.5 you should come up with your own unique number for your role.
 
-The following code should be run on both the server and the client and will generate a new win condition identifier. It then saves the generated value to the global `WIN_SUMMONER` value to be used later:
+The following code should be run on both the server and the client and will generate a new win condition identifier. Be sure to use the role ID for your new role when calling the `GenerateNewWinID` method. After the `GenerateNewWinID` method is called, the code below then saves the generated value to the global `WIN_SUMMONER` value to be used later:
 
 ```lua
 hook.Add("Initialize", "SummonerInitialize", function()
     -- Use 245 if we're on Custom Roles for TTT earlier than version 1.2.5
     -- 245 is summation of the ASCII values for the characters "S", "U", and "M"
-    WIN_SUMMONER = GenerateNewWinID and GenerateNewWinID() or 245
+    WIN_SUMMONER = GenerateNewWinID and GenerateNewWinID(ROLE_SUMMONER) or 245
 end)
 ```
 
@@ -696,7 +696,7 @@ ROLE.translations = {
 hook.Add("Initialize", "SummonerInitialize", function()
     -- Use 245 if we're on Custom Roles for TTT earlier than version 1.2.5
     -- 245 is summation of the ASCII values for the characters "S", "U", and "M"
-    WIN_SUMMONER = GenerateNewWinID and GenerateNewWinID() or 245
+    WIN_SUMMONER = GenerateNewWinID and GenerateNewWinID(ROLE_SUMMONER) or 245
 end)
 
 if SERVER then

--- a/CREATE_YOUR_OWN_ROLE.md
+++ b/CREATE_YOUR_OWN_ROLE.md
@@ -617,7 +617,7 @@ Putting all the properties together, the hook would look something like the foll
 if CLIENT then
     hook.Add("TTTScoringWinTitle", "SummonerScoringWinTitle", function(wintype, wintitles, title, secondaryWinRole)
         if wintype == WIN_SUMMONER then
-            return { txt = "hilite_win_role_singular", params = { role = ROLE_STRINGS[ROLE_SUMMONER]:upper() }, c = ROLE_COLORS[ROLE_SUMMONER] }
+            return { txt = "hilite_win_role_singular", params = { role = string.upper(ROLE_STRINGS[ROLE_SUMMONER]) }, c = ROLE_COLORS[ROLE_SUMMONER] }
         end
     end)
 end
@@ -631,7 +631,7 @@ Another part of the round summary screen that we want to tie into the is Events 
 if CLIENT then
     hook.Add("TTTEventFinishText", "SummonerEventFinishText", function(e)
         if e.win == WIN_SUMMONER then
-            return LANG.GetParamTranslation("ev_win_summoner", { role = ROLE_STRINGS[ROLE_SUMMONER]:lower() })
+            return LANG.GetParamTranslation("ev_win_summoner", { role = string.lower(ROLE_STRINGS[ROLE_SUMMONER]) })
         end
     end)
 
@@ -722,7 +722,7 @@ end
 if CLIENT then
     hook.Add("TTTEventFinishText", "SummonerEventFinishText", function(e)
         if e.win == WIN_SUMMONER then
-            return LANG.GetParamTranslation("ev_win_summoner", { role = ROLE_STRINGS[ROLE_SUMMONER]:lower() })
+            return LANG.GetParamTranslation("ev_win_summoner", { role = string.lower(ROLE_STRINGS[ROLE_SUMMONER]) })
         end
     end)
 
@@ -734,7 +734,7 @@ if CLIENT then
 
     hook.Add("TTTScoringWinTitle", "SummonerScoringWinTitle", function(wintype, wintitles, title, secondaryWinRole)
         if wintype == WIN_SUMMONER then
-            return { txt = "hilite_win_role_singular", params = { role = ROLE_STRINGS[ROLE_SUMMONER]:upper() }, c = ROLE_COLORS[ROLE_SUMMONER] }
+            return { txt = "hilite_win_role_singular", params = { role = string.upper(ROLE_STRINGS[ROLE_SUMMONER]) }, c = ROLE_COLORS[ROLE_SUMMONER] }
         end
     end)
 end

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,13 @@
 # Release Notes
 
-## 1.4.1 (Beta)
+## 1.4.2 (Beta)
 **Released:**
+
+### Changes
+- Ported change from base TTT: "TTT uses new permissions.EnableVoiceChat"
+
+## 1.4.1 (Beta)
+**Released: December 4th, 2021**
 
 ### Changes
 - Changed old man to lose karma if they hurt or kill players when their adrenaline rush is not active

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 - Fixed round summary highlights player stats spacing
 - Fixed killing a jester team member causing the team kill "awards" to show on the round summary highlight tab
 - Fixed medium being told there was a medium when they died
+- Fixed assassin not getting a new target when their target's role changes to one that is an invalid target
 
 ### Developer
 - Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.4.2 (Beta)
 **Released:**
 
+### Additions
+- Added ability to allow spirits to see eachother when there is a medium (enabled by default)
+
 ### Changes
 - Ported change from base TTT: "TTT uses new permissions.EnableVoiceChat"
 - Changed large parts across most of the addon in an attempt to increase performance
@@ -12,6 +15,7 @@
 - Fixed freeze in round summary when a player has multi-byte characters in their name
 - Fixed round summary highlights player stats spacing
 - Fixed killing a jester team member causing the team kill "awards" to show on the round summary highlight tab
+- Fixed medium being told there was a medium when they died
 
 ### Developer
 - Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 ### Changes
 - Ported change from base TTT: "TTT uses new permissions.EnableVoiceChat"
 
+### Fixes
+- Fixed bodysnatcher killed event redefining existing event ID
+
 ## 1.4.1 (Beta)
 **Released: December 4th, 2021**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 - Fixed bodysnatcher killed event redefining existing event ID
 - Fixed freeze in round summary when a player has multi-byte characters in their name
 - Fixed round summary highlights player stats spacing
+- Fixed killing a jester team member causing the team kill "awards" to show on the round summary highlight tab
 
 ### Developer
 - Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,14 @@
 ### Fixes
 - Fixed bodysnatcher killed event redefining existing event ID
 
+### Developer
+- Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role
+- Added warning message to `GenerateNewEventID` when role parameter is missing so developers know to update
+- Added parameter to `GenerateNewWinID` to allow roles to associate generated win IDs back to the role
+- Added warning message to `GenerateNewWinID` when role parameter is missing so developers know to update
+
+*NOTE*: If the role parameter is not passed, we try to figure out the role that the generated ID belongs to but this is not promised to work. Developers should update to use the new parameter as soon as possible
+
 ## 1.4.1 (Beta)
 **Released: December 4th, 2021**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,10 +5,12 @@
 
 ### Changes
 - Ported change from base TTT: "TTT uses new permissions.EnableVoiceChat"
+- Changed large parts across most of the addon in an attempt to increase performance
 
 ### Fixes
 - Fixed bodysnatcher killed event redefining existing event ID
 - Fixed freeze in round summary when a player has multi-byte characters in their name
+- Fixed round summary highlights player stats spacing
 
 ### Developer
 - Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@
 - Added parameter to `GenerateNewWinID` to allow roles to associate generated win IDs back to the role
 - Added warning message to `GenerateNewWinID` when role parameter is missing so developers know to update
 
-*NOTE*: If the role parameter is not passed, we try to figure out the role that the generated ID belongs to but this is not promised to work. Developers should update to use the new parameter as soon as possible
+*NOTE*: If the role parameter is not passed, we try to figure out the role that the generated ID belongs to but this is not promised to work. Developers should update to use the new parameter as soon as possible. Developers who are using these methods to generate IDs not linked to roles should pass `ROLE_NONE`.
 
 ## 1.4.1 (Beta)
 **Released: December 4th, 2021**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - Fixed bodysnatcher killed event redefining existing event ID
+- Fixed freeze in round summary when a player has multi-byte characters in their name
 
 ### Developer
 - Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role

--- a/gamemodes/terrortown/entities/entities/tot_smokenade/init.lua
+++ b/gamemodes/terrortown/entities/entities/tot_smokenade/init.lua
@@ -2,6 +2,12 @@ AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+local ents = ents
+local IsValid = IsValid
+local math = math
+local timer = timer
+local util = util
+
 -- Initialize
 function ENT:Initialize()
     util.PrecacheSound("weapons/ar2/npc_ar2_altfire.wav")

--- a/gamemodes/terrortown/entities/entities/ttt_bomb_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_bomb_station.lua
@@ -1,6 +1,5 @@
 AddCSLuaFile()
 
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local timer = timer

--- a/gamemodes/terrortown/entities/entities/ttt_bomb_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_bomb_station.lua
@@ -1,5 +1,11 @@
 AddCSLuaFile()
 
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local timer = timer
+local util = util
+
 if CLIENT then
     ENT.Icon = "vgui/ttt/icon_bombstation"
     ENT.PrintName = "bstation_name"

--- a/gamemodes/terrortown/entities/entities/ttt_c4/cl_init.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/cl_init.lua
@@ -2,6 +2,14 @@
 
 include("shared.lua")
 
+local draw = draw
+local IsValid = IsValid
+local net = net
+local surface = surface
+local table = table
+local util = util
+local vgui = vgui
+
 local starttime = C4_MINIMUM_TIME
 
 local T = LANG.GetTranslation

--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -1,6 +1,20 @@
 -- c4 explosive
 
+local cam = cam
+local concommand = concommand
+local draw = draw
+local ents = ents
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
 local math = math
+local net = net
+local player = player
+local surface = surface
+local table = table
+local timer = timer
+local util = util
 
 if SERVER then
     AddCSLuaFile("cl_init.lua")

--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -6,7 +6,6 @@ local draw = draw
 local ents = ents
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/entities/entities/ttt_crowbar/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_crowbar/shared.lua
@@ -1,4 +1,7 @@
 AddCSLuaFile()
+
+local IsValid = IsValid
+
 ENT.Type            = "anim"
 ENT.Base            = "ttt_basegrenade_proj"
 

--- a/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local ents = ents
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local render = render
 local table = table

--- a/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -1,5 +1,13 @@
 AddCSLuaFile()
 
+local ents = ents
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local render = render
+local table = table
+local util = util
+
 if CLIENT then
     local GetPTranslation = LANG.GetParamTranslation
     local hint_params = {usekey = Key("+use", "USE"), detective = ROLE_STRINGS_PLURAL[ROLE_DETECTIVE]}

--- a/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -1,6 +1,10 @@
 
 AddCSLuaFile()
 
+local concommand = concommand
+local ents = ents
+local IsValid = IsValid
+
 ENT.Type = "anim"
 ENT.Base = "base_anim"
 

--- a/gamemodes/terrortown/entities/entities/ttt_kil_crowbar/init.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_kil_crowbar/init.lua
@@ -1,6 +1,10 @@
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+local ents = ents
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+
 ENT.DidCollide = false
 
 local damage = 50

--- a/gamemodes/terrortown/entities/entities/ttt_kil_crowbar/init.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_kil_crowbar/init.lua
@@ -2,7 +2,6 @@ AddCSLuaFile("shared.lua")
 include("shared.lua")
 
 local ents = ents
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 
 ENT.DidCollide = false

--- a/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
@@ -1,5 +1,3 @@
-local IsPlayer = IsPlayer
-
 ENT.Type = "point"
 ENT.Base = "base_point"
 

--- a/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
@@ -1,3 +1,5 @@
+local IsPlayer = IsPlayer
+
 ENT.Type = "point"
 ENT.Base = "base_point"
 

--- a/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
@@ -1,6 +1,11 @@
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+local concommand = concommand
+local hook = hook
+local IsValid = IsValid
+local net = net
+
 -- serverside only
 ENT.RemoveOnPress = false
 

--- a/gamemodes/terrortown/entities/entities/ttt_traitor_check.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_traitor_check.lua
@@ -1,3 +1,8 @@
+local ipairs = ipairs
+local IsValid = IsValid
+
+local GetAllPlayers = player.GetAll
+
 ENT.Type = "brush"
 ENT.Base = "base_brush"
 
@@ -19,7 +24,7 @@ function ENT:CountTraitors()
     local maxs = self:LocalToWorld(self:OBBMaxs())
 
     local trs = 0
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         if (IsValid(ply) and ply:Alive()) and
                 (ply:IsActiveTraitorTeam() or
                 (ply:IsActiveJesterTeam() and GetConVar("ttt_jesters_trigger_traitor_testers"):GetBool()) or

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -7,6 +7,16 @@
 
 AddCSLuaFile()
 
+local IsValid = IsValid
+local math = math
+local net = net
+local player = player
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local util = util
+
 SWEP.HoldType = "pistol"
 SWEP.LimitedStock = true
 

--- a/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
@@ -201,7 +201,7 @@ if SERVER then
         net.Send(ply)
 
         local owner = self:GetOwner()
-        hook.Run("TTTPlayerDefibRoleChange", owner, ply)
+        hook.Call("TTTPlayerDefibRoleChange", nil, owner, ply)
 
         net.Start("TTT_Hypnotised")
         net.WriteString(ply:Nick())

--- a/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
@@ -7,6 +7,18 @@
 
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local util = util
+
 SWEP.HoldType = "pistol"
 SWEP.LimitedStock = true
 

--- a/gamemodes/terrortown/entities/weapons/weapon_kil_crowbar.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_kil_crowbar.lua
@@ -1,3 +1,7 @@
+local ents = ents
+local IsValid = IsValid
+local util = util
+
 SWEP.HoldType  = "melee"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_kil_knife.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_kil_knife.lua
@@ -1,5 +1,13 @@
 AddCSLuaFile()
 
+local draw = draw
+local ents = ents
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local surface = surface
+local util = util
+
 SWEP.HoldType = "knife"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_kil_knife.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_kil_knife.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local draw = draw
 local ents = ents
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local surface = surface

--- a/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
@@ -196,7 +196,7 @@ if SERVER then
         net.Send(ply)
 
         local owner = self:GetOwner()
-        hook.Run("TTTPlayerDefibRoleChange", owner, ply)
+        hook.Call("TTTPlayerDefibRoleChange", nil, owner, ply)
 
         net.Start("TTT_Zombified")
         net.WriteString(ply:Nick())

--- a/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
@@ -7,6 +7,18 @@
 
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local util = util
+
 SWEP.HoldType = "pistol"
 SWEP.LimitedStock = true
 

--- a/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
@@ -7,6 +7,16 @@
 
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local math = math
+local net = net
+local player = player
+local surface = surface
+local string = string
+local timer = timer
+local util = util
+
 SWEP.HoldType = "pistol"
 SWEP.LimitedStock = true
 

--- a/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
@@ -182,7 +182,7 @@ if SERVER then
         net.Send(ply)
 
         local owner = self:GetOwner()
-        hook.Run("TTTPlayerDefibRoleChange", owner, ply)
+        hook.Call("TTTPlayerDefibRoleChange", nil, owner, ply)
 
         ply:SpawnForRound(true)
         ply:SetCredits(credits)

--- a/gamemodes/terrortown/entities/weapons/weapon_old_dbshotgun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_old_dbshotgun.lua
@@ -1,5 +1,8 @@
 if SERVER then AddCSLuaFile() end
 
+local IsValid = IsValid
+local math = math
+
 SWEP.HoldType = "shotgun"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
@@ -1,6 +1,5 @@
 AddCSLuaFile()
 
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local pairs = pairs

--- a/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_par_cure.lua
@@ -1,5 +1,15 @@
 AddCSLuaFile()
 
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local timer = timer
+local util = util
+
 if CLIENT then
     local GetPTranslation = LANG.GetParamTranslation
     SWEP.PrintName = "Parasite Cure"
@@ -12,7 +22,7 @@ if CLIENT then
         type =  "item_weapon",
         desc = function()
             return GetPTranslation("cure_desc", {
-                parasites = ROLE_STRINGS_PLURAL[ROLE_PARASITE]:lower()
+                parasites = string.lower(ROLE_STRINGS_PLURAL[ROLE_PARASITE])
             })
         end
     };

--- a/gamemodes/terrortown/entities/weapons/weapon_pha_exorcism.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_pha_exorcism.lua
@@ -1,6 +1,5 @@
 AddCSLuaFile()
 
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local pairs = pairs

--- a/gamemodes/terrortown/entities/weapons/weapon_pha_exorcism.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_pha_exorcism.lua
@@ -1,5 +1,15 @@
 AddCSLuaFile()
 
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local timer = timer
+local util = util
+
 if CLIENT then
     local GetPTranslation = LANG.GetParamTranslation
     SWEP.PrintName = "Exorcism Device"
@@ -12,7 +22,7 @@ if CLIENT then
         type = "item_weapon",
         desc = function()
             return GetPTranslation("exor_desc", {
-                phantom = ROLE_STRINGS[ROLE_PHANTOM]:lower()
+                phantom = string.lower(ROLE_STRINGS[ROLE_PHANTOM])
             })
         end
     };

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_bomb_station.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_bomb_station.lua
@@ -1,5 +1,8 @@
 AddCSLuaFile()
 
+local ents = ents
+local IsValid = IsValid
+
 SWEP.HoldType = "normal"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_fake_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_fake_cure.lua
@@ -1,5 +1,15 @@
 AddCSLuaFile()
 
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local timer = timer
+local util = util
+
 if CLIENT then
     local GetPTranslation = LANG.GetParamTranslation
     SWEP.PrintName = "Parasite Cure"
@@ -13,7 +23,7 @@ if CLIENT then
         type =  "item_weapon",
         desc = function()
             return GetPTranslation("fake_cure_desc", {
-                parasite = ROLE_STRINGS[ROLE_PARASITE]:lower()
+                parasite = string.lower(ROLE_STRINGS[ROLE_PARASITE])
             })
         end
     };

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_fake_cure.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_fake_cure.lua
@@ -1,6 +1,5 @@
 AddCSLuaFile()
 
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local pairs = pairs

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_station_bomb.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_station_bomb.lua
@@ -1,5 +1,11 @@
 AddCSLuaFile()
 
+local ents = ents
+local IsValid = IsValid
+local math = math
+local surface = surface
+local timer = timer
+
 SWEP.HoldType = "slam"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_decoy.lua
@@ -1,6 +1,10 @@
 
 AddCSLuaFile()
 
+local ents = ents
+local IsValid = IsValid
+local util = util
+
 SWEP.HoldType              = "normal"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_health_station.lua
@@ -1,5 +1,8 @@
 AddCSLuaFile()
 
+local ents = ents
+local IsValid = IsValid
+
 SWEP.HoldType               = "normal"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_teleport.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_teleport.lua
@@ -4,7 +4,6 @@ AddCSLuaFile()
 
 local ents = ents
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local player = player

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_teleport.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_teleport.lua
@@ -2,6 +2,17 @@
 
 AddCSLuaFile()
 
+local ents = ents
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local player = player
+local surface = surface
+local table = table
+local timer = timer
+local util = util
+
 SWEP.HoldType                = "normal"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -2,6 +2,14 @@
 
 AddCSLuaFile()
 
+local draw = draw
+local ipairs = ipairs
+local IsValid = IsValid
+local math = math
+local surface = surface
+local table = table
+local util = util
+
 ---- TTT SPECIAL EQUIPMENT FIELDS
 
 -- This must be set to one of the WEAPON_ types in TTT weapons for weapon

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local ents = ents
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -1,5 +1,16 @@
 AddCSLuaFile()
 
+local ents = ents
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local player = player
+local resource = resource
+local surface = surface
+local timer = timer
+local util = util
+
 if CLIENT then
     SWEP.PrintName = "Fangs"
     SWEP.EquipMenuData = {
@@ -308,31 +319,32 @@ function SWEP:FireError()
     self:SetNextPrimaryFire(CurTime() + 0.1)
 end
 
+local CreateEntity = ents.Create
 function SWEP:DropBones()
     local pos = self.TargetEntity:GetPos()
 
-    local skull = ents.Create("prop_physics")
+    local skull = CreateEntity("prop_physics")
     if not IsValid(skull) then return end
     skull:SetModel("models/Gibs/HGIBS.mdl")
     skull:SetPos(pos)
     skull:Spawn()
     skull:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 
-    local ribs = ents.Create("prop_physics")
+    local ribs = CreateEntity("prop_physics")
     if not IsValid(ribs) then return end
     ribs:SetModel("models/Gibs/HGIBS_rib.mdl")
     ribs:SetPos(pos + Vector(0, 0, 15))
     ribs:Spawn()
     ribs:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 
-    local spine = ents.Create("prop_physics")
+    local spine = CreateEntity("prop_physics")
     if not IsValid(ribs) then return end
     spine:SetModel("models/Gibs/HGIBS_spine.mdl")
     spine:SetPos(pos + Vector(0, 0, 30))
     spine:Spawn()
     spine:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 
-    local scapula = ents.Create("prop_physics")
+    local scapula = CreateEntity("prop_physics")
     if not IsValid(scapula) then return end
     scapula:SetModel("models/Gibs/HGIBS_scapula.mdl")
     scapula:SetPos(pos + Vector(0, 0, 45))

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -2,6 +2,16 @@
 
 AddCSLuaFile()
 
+local draw = draw
+local ents = ents
+local ipairs = ipairs
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local player = player
+local timer = timer
+local util = util
+
 DEFINE_BASECLASS "weapon_tttbase"
 
 SWEP.HoldType               = "pistol"

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -1,5 +1,10 @@
 AddCSLuaFile()
 
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local util = util
+
 SWEP.HoldType = "melee"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -1,6 +1,5 @@
 AddCSLuaFile()
 
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local util = util

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -1,5 +1,12 @@
 AddCSLuaFile()
 
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local timer = timer
+local util = util
+
 if CLIENT then
     SWEP.PrintName = "Claws"
     SWEP.EquipMenuData = {

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -1,6 +1,5 @@
 AddCSLuaFile()
 
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/cl_awards.lua
+++ b/gamemodes/terrortown/gamemode/cl_awards.lua
@@ -4,8 +4,10 @@
 -- not and another one should be tried.
 
 -- some globals we'll use a lot
-local table = table
+local math = math
 local pairs = pairs
+local table = table
+local util = util
 
 local is_dmg = function(dmg_t, bit)
                         -- deal with large-number workaround for TableToJSON by
@@ -22,21 +24,21 @@ local function GetRoleName(s)
 end
 
 local function GetRole(players, id)
-    local player = players[id]
-    return player and player.role or ROLE_NONE
+    local ply = players[id]
+    return ply and ply.role or ROLE_NONE
 end
 
 local function GetName(players, id)
-    local player = players[id]
-    return player and player.nick or nil
+    local ply = players[id]
+    return ply and ply.nick or nil
 end
 
 local function GetNameAndRole(players, id)
-    local player = players[id]
-    if not player then return nil, nil end
+    local ply = players[id]
+    if not ply then return nil, nil end
 
-    local name = player.nick or nil
-    local role = player.role or ROLE_NONE
+    local name = ply.nick or nil
+    local role = ply.role or ROLE_NONE
     return name, role
 end
 

--- a/gamemodes/terrortown/gamemode/cl_disguise.lua
+++ b/gamemodes/terrortown/gamemode/cl_disguise.lua
@@ -1,6 +1,10 @@
+local concommand = concommand
+local surface = surface
+local vgui = vgui
+
 DISGUISE = {}
 
-local trans = LANG.GetTranslation
+local T = LANG.GetTranslation
 
 function DISGUISE.CreateMenu(parent)
     local dform = vgui.Create("DForm", parent)
@@ -11,12 +15,12 @@ function DISGUISE.CreateMenu(parent)
     local owned = LocalPlayer():HasEquipmentItem(EQUIP_DISGUISE)
 
     if not owned then
-       dform:Help(trans("disg_not_owned"))
+       dform:Help(T("disg_not_owned"))
        return dform
     end
 
     local dcheck = vgui.Create("DCheckBoxLabel", dform)
-    dcheck:SetText(trans("disg_enable"))
+    dcheck:SetText(T("disg_enable"))
     dcheck:SetIndent(5)
     dcheck:SetValue(LocalPlayer():GetNWBool("disguised", false))
     dcheck.OnChange = function(s, val)
@@ -24,9 +28,9 @@ function DISGUISE.CreateMenu(parent)
                       end
     dform:AddItem(dcheck)
 
-    dform:Help(trans("disg_help1"))
+    dform:Help(T("disg_help1"))
 
-    dform:Help(trans("disg_help2"))
+    dform:Help(T("disg_help2"))
 
     dform:SetVisible(true)
 
@@ -40,7 +44,7 @@ function DISGUISE.Draw(client)
     surface.SetFont("TabLarge")
     surface.SetTextColor(255, 0, 0, 230)
 
-    local text = trans("disg_hud")
+    local text = T("disg_hud")
     local _, h = surface.GetTextSize(text)
 
     local label_top = 140

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -18,6 +18,8 @@ local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 local StringFind = string.find
 local StringLower = string.lower
+local TableHasValue = table.HasValue
+local TableInsert = table.insert
 
 -- create ClientConVars
 local numColsVar = CreateClientConVar("ttt_bem_cols", 4, true, false, "Sets the number of columns in the Traitor/Detective menu's item list.")
@@ -34,8 +36,8 @@ local showLoadoutEquipment = CreateClientConVar("ttt_show_loadout_equipment", 0,
 local Equipment = { }
 
 local function UpdateWeaponList(role, lst, weapon)
-    if not table.HasValue(lst[role], weapon) then
-        table.insert(lst[role], weapon)
+    if not TableHasValue(lst[role], weapon) then
+        TableInsert(lst[role], weapon)
     end
 end
 
@@ -144,7 +146,7 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
 
                 -- add this buyable weapon to all relevant equipment tables
                 for _, r in pairs(v.CanBuy) do
-                    table.insert(tbl[r], base)
+                    TableInsert(tbl[r], base)
                 end
             end
         end
@@ -158,7 +160,7 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
             for _, i in pairs(is) do
                 if i then
                     -- Mark custom items
-                    i.custom = not table.HasValue(DefaultEquipment[r], i.id)
+                    i.custom = not TableHasValue(DefaultEquipment[r], i.id)
 
                     -- Run through this again to make sure non-custom equipment is saved to be synced below
                     if not ItemIsWeapon(i) and i.custom then
@@ -168,11 +170,11 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
                         end
 
                         if r == ROLE_TRAITOR then
-                            table.insert(traitor_equipment, i)
-                            table.insert(traitor_equipment_ids, i.id)
+                            TableInsert(traitor_equipment, i)
+                            TableInsert(traitor_equipment_ids, i.id)
                         elseif r == ROLE_DETECTIVE then
-                            table.insert(detective_equipment, i)
-                            table.insert(detective_equipment_ids, i.id)
+                            TableInsert(detective_equipment, i)
+                            TableInsert(detective_equipment_ids, i.id)
                         end
                     end
                 end
@@ -183,8 +185,8 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
         if rolemode == SHOP_SYNC_MODE_INTERSECT then
             for idx, i in pairs(traitor_equipment_ids) do
                 -- Traitor AND Detective mode, (Detective && Traitor) -> Sync Role
-                if not available[i] and table.HasValue(detective_equipment_ids, i) then
-                    table.insert(tbl[role], traitor_equipment[idx])
+                if not available[i] and TableHasValue(detective_equipment_ids, i) then
+                    TableInsert(tbl[role], traitor_equipment[idx])
                     available[i] = true
                 end
             end
@@ -196,7 +198,7 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
                     (sync_traitor_weapons or
                     -- Traitor OR Detective or Traitor-only modes, Traitor -> Sync Role
                     (rolemode == SHOP_SYNC_MODE_UNION or rolemode == SHOP_SYNC_MODE_TRAITOR)) then
-                    table.insert(tbl[role], i)
+                    TableInsert(tbl[role], i)
                     available[i.id] = true
                 end
             end
@@ -207,7 +209,7 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
                     (promoted or
                     -- Traitor OR Detective or Detective-only modes, Detective -> Sync Role
                     (rolemode == SHOP_SYNC_MODE_UNION or rolemode == SHOP_SYNC_MODE_DETECTIVE)) then
-                    table.insert(tbl[role], i)
+                    TableInsert(tbl[role], i)
                     available[i.id] = true
                 end
             end
@@ -220,7 +222,7 @@ function GetEquipmentForRole(role, promoted, block_randomization, block_exclusio
                 local equip = GetEquipmentItemByName(v)
                 -- If this exists and isn't already in the list, add it to the role's list
                 if equip ~= nil and not available[equip.id] then
-                    table.insert(tbl[role], equip)
+                    TableInsert(tbl[role], equip)
                     available[equip.id] = true
                 end
             end
@@ -277,7 +279,7 @@ local function HasEquipmentItem(item)
     local client = LocalPlayer()
     -- Don't allow the delayed shop roles to buy the same equipment item twice if delayed acceptance is enabled
     if client.bought and client:ShouldDelayShopPurchase() then
-        return table.HasValue(client.bought, tostring(item.id))
+        return TableHasValue(client.bought, tostring(item.id))
     end
 
     return client:HasEquipmentItem(item.id)
@@ -502,7 +504,7 @@ local function TraitorMenuPopup()
         local owned_ids = {}
         for _, wep in ipairs(ply:GetWeapons()) do
             if IsValid(wep) and wep.IsEquipment and wep:IsEquipment() then
-                table.insert(owned_ids, wep:GetClass())
+                TableInsert(owned_ids, wep:GetClass())
             end
         end
 
@@ -574,7 +576,7 @@ local function TraitorMenuPopup()
             local orderable = update_preqs(item)
             return (not orderable) or
                     -- already owned
-                    table.HasValue(owned_ids, item.id) or
+                    TableHasValue(owned_ids, item.id) or
                     (tonumber(item.id) and ply:HasEquipmentItem(tonumber(item.id))) or
                     -- already carrying a weapon for this slot
                     (ItemIsWeapon(item) and (not CanCarryWeapon(item))) or
@@ -683,7 +685,7 @@ local function TraitorMenuPopup()
                 end
 
                 -- Don't show equipment items that you already own that are listed as "loadout" because you were given it for free
-                local externalLoadout = ROLE_LOADOUT_ITEMS[ply:GetRole()] and table.HasValue(ROLE_LOADOUT_ITEMS[ply:GetRole()], item.name)
+                local externalLoadout = ROLE_LOADOUT_ITEMS[ply:GetRole()] and TableHasValue(ROLE_LOADOUT_ITEMS[ply:GetRole()], item.name)
                 if not ItemIsWeapon(item) and ply:HasEquipmentItem(item.id) and (item.loadout or externalLoadout) and not showLoadoutEquipment:GetBool() then
                     ic:Remove()
                 else
@@ -709,7 +711,7 @@ local function TraitorMenuPopup()
                 local panels = {}
                 for i = 1, 9 do
                     for _, p in pairs(paneltable[i]) do
-                        table.insert(panels, p)
+                        TableInsert(panels, p)
                     end
                 end
 
@@ -736,7 +738,7 @@ local function TraitorMenuPopup()
             local filtered = {}
             for _, v in pairs(roleitems) do
                 if v and v["name"] and StringFind(StringLower(SafeTranslate(v["name"])), StringLower(value)) then
-                    table.insert(filtered, v)
+                    TableInsert(filtered, v)
                 end
             end
             FillEquipmentList(filtered)
@@ -853,7 +855,7 @@ local function TraitorMenuPopup()
             local buyable_items = {}
             for _, item_panel in pairs(item_panels) do
                 if item_panel.item and not CannotBuyItem(item_panel.item) then
-                    table.insert(buyable_items, item_panel)
+                    TableInsert(buyable_items, item_panel)
                 end
             end
 
@@ -945,7 +947,7 @@ local function ReceiveBought()
     for _ = 1, num do
         local s = net.ReadString()
         if s ~= "" then
-            table.insert(ply.bought, s)
+            TableInsert(ply.bought, s)
         end
     end
 

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -1,7 +1,20 @@
 include("shared.lua")
 
+local concommand = concommand
+local hook = hook
+local ipairs = ipairs
+local math = math
+local net = net
+local pairs = pairs
+local surface = surface
+local string = string
+local table = table
+local vgui = vgui
+local weapons = weapons
+
 ---- Traitor equipment menu
 
+local GetWeapon = weapons.GetStored
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 
@@ -249,7 +262,7 @@ local function CanCarryWeapon(item)
     -- Don't allow delayed shop roles to buy any weapon that has a kind matching one of the weapons they've already bought
     if item.kind and client.bought and client:ShouldDelayShopPurchase() then
         for _, id in ipairs(client.bought) do
-            local wep = weapons.GetStored(id)
+            local wep = GetWeapon(id)
             if wep and wep.Kind == item.kind then
                 return false
             end
@@ -721,7 +734,7 @@ local function TraitorMenuPopup()
             local roleitems = GetEquipmentForRole(ply:GetRole(), ply:IsDetectiveLike() and not ply:IsDetectiveTeam(), false)
             local filtered = {}
             for _, v in pairs(roleitems) do
-                if v and v["name"] and string.find(SafeTranslate(v["name"]):lower(), value:lower()) then
+                if v and v["name"] and string.find(string.lower(SafeTranslate(v["name"])), string.lower(value)) then
                     table.insert(filtered, v)
                 end
             end

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -7,7 +7,6 @@ local math = math
 local net = net
 local pairs = pairs
 local surface = surface
-local string = string
 local table = table
 local vgui = vgui
 local weapons = weapons
@@ -17,6 +16,8 @@ local weapons = weapons
 local GetWeapon = weapons.GetStored
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
+local StringFind = string.find
+local StringLower = string.lower
 
 -- create ClientConVars
 local numColsVar = CreateClientConVar("ttt_bem_cols", 4, true, false, "Sets the number of columns in the Traitor/Detective menu's item list.")
@@ -734,7 +735,7 @@ local function TraitorMenuPopup()
             local roleitems = GetEquipmentForRole(ply:GetRole(), ply:IsDetectiveLike() and not ply:IsDetectiveTeam(), false)
             local filtered = {}
             for _, v in pairs(roleitems) do
-                if v and v["name"] and string.find(string.lower(SafeTranslate(v["name"])), string.lower(value)) then
+                if v and v["name"] and StringFind(StringLower(SafeTranslate(v["name"])), StringLower(value)) then
                     table.insert(filtered, v)
                 end
             end

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -1,5 +1,17 @@
 ---- Help screen
 
+local concommand = concommand
+local cvars = cvars
+local file = file
+local hook = hook
+local ipairs = ipairs
+local pairs = pairs
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local vgui = vgui
+
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 
@@ -676,7 +688,7 @@ local function TutorialUsefulKeys(pnl, lbl)
 
     -- Fifth line
         htmlData = htmlData .. "<div style='height: 40px;'>"
-            key = GetConVar("ttt_radio_button"):GetString():upper()
+            key = string.upper(GetConVar("ttt_radio_button"):GetString())
             htmlData = htmlData .. "<span style='" .. fontStyle .. keyMappingStyles .. "'>" .. key .. "</span>"
             htmlData = htmlData .. "<span style='" .. fontStyle .. " color: white;'> will open the </span>"
             color = ROLE_COLORS[ROLE_INNOCENT]

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -809,8 +809,8 @@ local function ShowTutorialPage(pnl, page)
         roleIcon:SetPos(roleIcon:GetX() - 3, roleIcon:GetY() + 7)
 
         -- If nobody wants to handle this page themselves,
-        if not hook.Run("TTTTutorialRolePage", role, pnl, titleLabel, roleIcon) then
-            local roleText = hook.Run("TTTTutorialRoleText", role, titleLabel, roleIcon)
+        if not hook.Call("TTTTutorialRolePage", nil, role, pnl, titleLabel, roleIcon) then
+            local roleText = hook.Call("TTTTutorialRoleText", nil, role, titleLabel, roleIcon)
 
             local html = vgui.Create("DHTML", pnl)
             html:Dock(FILL)
@@ -851,7 +851,7 @@ local function ShowRoleTutorial(role)
     end
 
     -- Otherwise check if there are special rules for this role
-    if hook.Run("TTTTutorialRoleEnabled", role) then
+    if hook.Call("TTTTutorialRoleEnabled", nil, role) then
         return true
     end
     return false

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -270,7 +270,7 @@ local function SpecHUDPaint(client)
 
     local tgt = client:GetObserverTarget()
     if client:ShouldShowSpectatorHUD() then
-        hook.Run("TTTSpectatorShowHUD", client, tgt)
+        hook.Call("TTTSpectatorShowHUD", nil, client, tgt)
     elseif IsPlayer(tgt) then
         HUD:ShadowedText(tgt:Nick(), "TimeLeft", ScrW() / 2, margin, COLOR_WHITE, TEXT_ALIGN_CENTER)
     elseif IsValid(tgt) and tgt:GetNWEntity("spec_owner", nil) == client then
@@ -409,7 +409,7 @@ local function InfoPaint(client)
     end
 
     -- Allow other addons to add stuff to the player info HUD
-    hook.Run("TTTHUDInfoPaint", client, label_left, label_top)
+    hook.Call("TTTHUDInfoPaint", nil, client, label_left, label_top)
 end
 
 -- Paints player status HUD element in the bottom left

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -2,10 +2,13 @@
 
 HUD = {}
 
-local surface = surface
-local draw = draw
+local hook = hook
 local math = math
+local pairs = pairs
+local surface = surface
 local string = string
+local table = table
+local util = util
 
 local GetTranslation = LANG.GetTranslation
 local GetLang = LANG.GetUnsafeLanguageTable

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -11,6 +11,7 @@ local util = util
 
 local GetTranslation = LANG.GetTranslation
 local GetLang = LANG.GetUnsafeLanguageTable
+local TableCount = table.Count
 local interp = string.Interp
 local format = string.format
 
@@ -139,7 +140,7 @@ function HUD:PaintPowersHUD(powers, max_power, current_power, colors, title, sub
         draw.SimpleText(subtitle, "TabLarge", ScrW() / 2, margin, COLOR_WHITE, TEXT_ALIGN_CENTER)
     end
 
-    if powers and table.Count(powers) > 0 then
+    if powers and TableCount(powers) > 0 then
         local command_count = 0
         for _, p in pairs(powers) do
             if p > 0 then

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -6,13 +6,13 @@ local hook = hook
 local math = math
 local pairs = pairs
 local surface = surface
-local string = string
 local table = table
 local util = util
 
 local GetTranslation = LANG.GetTranslation
 local GetLang = LANG.GetUnsafeLanguageTable
 local interp = string.Interp
+local format = string.format
 
 local hide_role = false
 
@@ -318,7 +318,7 @@ local function InfoPaint(client)
         if ammo_clip ~= -1 then
             local ammo_y = health_y + bar_height + margin
             HUD:PaintBar(8, x + margin, ammo_y, bar_width, bar_height, ammo_colors, ammo_clip / ammo_max)
-            local text = string.format("%i + %02i", ammo_clip, ammo_inv)
+            local text = format("%i + %02i", ammo_clip, ammo_inv)
 
             HUD:ShadowedText(text, "HealthAmmo", bar_width, ammo_y, COLOR_WHITE, TEXT_ALIGN_RIGHT, TEXT_ALIGN_RIGHT)
         end

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -2,12 +2,13 @@
 
 HUD = {}
 
-local hook = hook
 local pairs = pairs
 local surface = surface
 local table = table
 local util = util
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetTranslation = LANG.GetTranslation
 local GetLang = LANG.GetUnsafeLanguageTable
 local MathMax = math.max
@@ -270,7 +271,7 @@ local function SpecHUDPaint(client)
 
     local tgt = client:GetObserverTarget()
     if client:ShouldShowSpectatorHUD() then
-        hook.Call("TTTSpectatorShowHUD", nil, client, tgt)
+        CallHook("TTTSpectatorShowHUD", nil, client, tgt)
     elseif IsPlayer(tgt) then
         HUD:ShadowedText(tgt:Nick(), "TimeLeft", ScrW() / 2, margin, COLOR_WHITE, TEXT_ALIGN_CENTER)
     elseif IsValid(tgt) and tgt:GetNWEntity("spec_owner", nil) == client then
@@ -409,55 +410,55 @@ local function InfoPaint(client)
     end
 
     -- Allow other addons to add stuff to the player info HUD
-    hook.Call("TTTHUDInfoPaint", nil, client, label_left, label_top)
+    CallHook("TTTHUDInfoPaint", nil, client, label_left, label_top)
 end
 
 -- Paints player status HUD element in the bottom left
 function GM:HUDPaint()
     local client = LocalPlayer()
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTTargetID") then
-        hook.Call("HUDDrawTargetID", GAMEMODE)
+    if RunHook("HUDShouldDraw", "TTTTargetID") then
+        RunHook("HUDDrawTargetID")
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTMStack") then
+    if RunHook("HUDShouldDraw", "TTTMStack") then
         MSTACK:Draw(client)
     end
 
     if (not client:Alive()) or client:Team() == TEAM_SPEC then
-        if hook.Call("HUDShouldDraw", GAMEMODE, "TTTSpecHUD") then
+        if RunHook("HUDShouldDraw", "TTTSpecHUD") then
             SpecHUDPaint(client)
         end
 
         return
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTRadar") then
+    if RunHook("HUDShouldDraw", "TTTRadar") then
         RADAR:Draw(client)
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTTButton") then
+    if RunHook("HUDShouldDraw", "TTTTButton") then
         TBHUD:Draw(client)
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTWSwitch") then
+    if RunHook("HUDShouldDraw", "TTTWSwitch") then
         WSWITCH:Draw(client)
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTVoice") then
+    if RunHook("HUDShouldDraw", "TTTVoice") then
         VOICE.Draw(client)
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTDisguise") then
+    if RunHook("HUDShouldDraw", "TTTDisguise") then
         DISGUISE.Draw(client)
     end
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTPickupHistory") then
-        hook.Call("HUDDrawPickupHistory", GAMEMODE)
+    if RunHook("HUDShouldDraw", "TTTPickupHistory") then
+        RunHook("HUDDrawPickupHistory")
     end
 
     -- Draw bottom left info panel
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTInfoPanel") then
+    if RunHook("HUDShouldDraw", "TTTInfoPanel") then
         InfoPaint(client)
     end
 end

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -3,7 +3,6 @@
 HUD = {}
 
 local hook = hook
-local math = math
 local pairs = pairs
 local surface = surface
 local table = table
@@ -11,6 +10,10 @@ local util = util
 
 local GetTranslation = LANG.GetTranslation
 local GetLang = LANG.GetUnsafeLanguageTable
+local MathMax = math.max
+local MathClamp = math.Clamp
+local MathRound = math.Round
+local MathCeil = math.ceil
 local TableCount = table.Count
 local interp = string.Interp
 local format = string.format
@@ -102,7 +105,7 @@ local function RoundedMeter(bs, x, y, w, h, color)
         surface.DrawTexturedRectRotated(x + w - bs / 2, y + bs / 2, bs, bs, 270)
         surface.DrawTexturedRectRotated(x + w - bs / 2, y + h - bs / 2, bs, bs, 180)
     else
-        surface.DrawRect(x + math.max(w - bs, bs), y, bs / 2, h)
+        surface.DrawRect(x + MathMax(w - bs, bs), y, bs / 2, h)
     end
 
 end
@@ -117,7 +120,7 @@ function HUD:PaintBar(r, x, y, w, h, colors, value)
     draw.RoundedBox(8, x - 1, y - 1, w + 2, h + 2, colors.background)
 
     -- Fill
-    local width = w * math.Clamp(value, 0, 1)
+    local width = w * MathClamp(value, 0, 1)
 
     if width > 0 then
         RoundedMeter(r, x, y, width, h, colors.fill)
@@ -151,7 +154,7 @@ function HUD:PaintPowersHUD(powers, max_power, current_power, colors, title, sub
         local current_command = 1
         for t, p in pairs(powers) do
             if p > 0 then
-                local percentage = math.Round(100 * (p / max_power))
+                local percentage = MathRound(100 * (p / max_power))
                 draw.SimpleText(interp(t, { num = percentage }), "TabLarge", ScrW() / 4 + ((ScrW() / (2 * (command_count + 1))) * current_command), margin, current_power >= p and COLOR_GREEN or COLOR_RED, TEXT_ALIGN_CENTER)
                 current_command = current_command + 1
             end
@@ -262,7 +265,7 @@ local function SpecHUDPaint(client)
     HUD:ShadowedText(text, "TraitorState", x + margin, round_y, COLOR_WHITE)
 
     -- Draw round/prep/post time remaining
-    text = util.SimpleTime(math.max(0, GetGlobalFloat("ttt_round_end", 0) - CurTime()), "%02i:%02i")
+    text = util.SimpleTime(MathMax(0, GetGlobalFloat("ttt_round_end", 0) - CurTime()), "%02i:%02i")
     HUD:ShadowedText(text, "TimeLeft", time_x + margin, time_y, COLOR_WHITE)
 
     local tgt = client:GetObserverTarget()
@@ -298,13 +301,13 @@ local function InfoPaint(client)
     local bar_width = width - (margin * 2)
 
     -- Draw health
-    local health = math.max(0, client:Health())
-    local maxHealth = math.max(0, client:GetMaxHealth())
+    local health = MathMax(0, client:Health())
+    local maxHealth = MathMax(0, client:GetMaxHealth())
     local health_y = y + margin
 
     HUD:PaintBar(8, x + margin, health_y, bar_width, bar_height, health_colors, health / maxHealth)
-    HUD:PaintBar(8, x + margin, health_y, bar_width, bar_height, overhealth_colors, math.max(0, health - maxHealth) / maxHealth)
-    HUD:PaintBar(8, x + margin, health_y, bar_width, bar_height, extraoverhealth_colors, math.max(0, health - (2 * maxHealth)) / maxHealth)
+    HUD:PaintBar(8, x + margin, health_y, bar_width, bar_height, overhealth_colors, MathMax(0, health - maxHealth) / maxHealth)
+    HUD:PaintBar(8, x + margin, health_y, bar_width, bar_height, extraoverhealth_colors, MathMax(0, health - (2 * maxHealth)) / maxHealth)
 
     HUD:ShadowedText(tostring(health), "HealthAmmo", bar_width, health_y, COLOR_WHITE, TEXT_ALIGN_RIGHT, TEXT_ALIGN_RIGHT)
 
@@ -367,7 +370,7 @@ local function InfoPaint(client)
     if is_haste then
         local hastetime = GetGlobalFloat("ttt_haste_end", 0) - CurTime()
         if hastetime < 0 then
-            if (not is_traitor) or (math.ceil(CurTime()) % 7 <= 2) then
+            if (not is_traitor) or (MathCeil(CurTime()) % 7 <= 2) then
                 -- innocent or blinking "overtime"
                 text = L.overtime
                 font = "Trebuchet18"
@@ -377,21 +380,21 @@ local function InfoPaint(client)
                 rx = rx - 3
             else
                 -- traitor and not blinking "overtime" right now, so standard endtime display
-                text = util.SimpleTime(math.max(0, endtime), "%02i:%02i")
+                text = util.SimpleTime(MathMax(0, endtime), "%02i:%02i")
                 color = COLOR_RED
             end
         else
             -- still in starting period
             local t = hastetime
-            if is_traitor and math.ceil(CurTime()) % 6 < 2 then
+            if is_traitor and MathCeil(CurTime()) % 6 < 2 then
                 t = endtime
                 color = COLOR_RED
             end
-            text = util.SimpleTime(math.max(0, t), "%02i:%02i")
+            text = util.SimpleTime(MathMax(0, t), "%02i:%02i")
         end
     else
         -- bog standard time when haste mode is off (or round not active)
-        text = util.SimpleTime(math.max(0, endtime), "%02i:%02i")
+        text = util.SimpleTime(MathMax(0, endtime), "%02i:%02i")
     end
 
     HUD:ShadowedText(text, font, rx, ry, color)

--- a/gamemodes/terrortown/gamemode/cl_hudpickup.lua
+++ b/gamemodes/terrortown/gamemode/cl_hudpickup.lua
@@ -3,10 +3,11 @@ include("shared.lua")
 local math = math
 local pairs = pairs
 local surface = surface
-local string = string
 local table = table
 
 local TryTranslation = LANG.TryTranslation
+local StringUpper = string.upper
+local StringLower = string.lower
 
 GM.PickupHistory = {}
 GM.PickupHistoryLast = 0
@@ -37,7 +38,7 @@ function GM:HUDWeaponPickedUp(wep)
 
     local pickup = {}
     pickup.time = CurTime()
-    pickup.name = string.upper(name)
+    pickup.name = StringUpper(name)
     pickup.holdtime = 5
     pickup.font = "DefaultBold"
     pickup.fadein = 0.04
@@ -94,7 +95,7 @@ end
 function GM:HUDAmmoPickedUp(itemname, amount)
     if not (IsValid(LocalPlayer()) and LocalPlayer():Alive()) then return end
 
-    local itemname_trans = TryTranslation(string.lower("ammo_" .. itemname))
+    local itemname_trans = TryTranslation(StringLower("ammo_" .. itemname))
 
     if custom_ammo:GetBool() then
         if itemname == "alyxgun" then
@@ -108,7 +109,7 @@ function GM:HUDAmmoPickedUp(itemname, amount)
 
     if self.PickupHistory then
 
-        local localized_name = string.upper(itemname_trans)
+        local localized_name = StringUpper(itemname_trans)
         for k, v in pairs(self.PickupHistory) do
             if v.name == localized_name then
 
@@ -121,7 +122,7 @@ function GM:HUDAmmoPickedUp(itemname, amount)
 
     local pickup = {}
     pickup.time = CurTime()
-    pickup.name = string.upper(itemname_trans)
+    pickup.name = StringUpper(itemname_trans)
     pickup.holdtime = 5
     pickup.font = "DefaultBold"
     pickup.fadein = 0.04

--- a/gamemodes/terrortown/gamemode/cl_hudpickup.lua
+++ b/gamemodes/terrortown/gamemode/cl_hudpickup.lua
@@ -1,5 +1,11 @@
 include("shared.lua")
 
+local math = math
+local pairs = pairs
+local surface = surface
+local string = string
+local table = table
+
 local TryTranslation = LANG.TryTranslation
 
 GM.PickupHistory = {}

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -1,5 +1,25 @@
 include("shared.lua")
 
+local cam = cam
+local chat = chat
+local concommand = concommand
+local ents = ents
+local hook = hook
+local ipairs = ipairs
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local render = render
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local util = util
+local vgui = vgui
+
+local GetAllPlayers = player.GetAll
+
 -- Define GM12 fonts for compatibility
 surface.CreateFont("DefaultBold", {
     font = "Tahoma",
@@ -134,7 +154,7 @@ local function RoundStateChange(o, n)
         CLSCORE:ClearPanel()
 
         -- people may have died and been searched during prep
-        for _, p in ipairs(player.GetAll()) do
+        for _, p in ipairs(GetAllPlayers()) do
             p.search_result = nil
         end
 
@@ -159,7 +179,7 @@ local function RoundStateChange(o, n)
     end
 
     -- whatever round state we get, clear out the voice flags
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         v.traitor_gvoice = false
     end
 end
@@ -264,7 +284,7 @@ function GM:ClearClientState()
 
     VOICE.InitBattery()
 
-    for _, p in ipairs(player.GetAll()) do
+    for _, p in ipairs(GetAllPlayers()) do
         if IsValid(p) then
             p.sb_tag = nil
             p:SetRole(ROLE_INNOCENT)
@@ -354,7 +374,7 @@ function GM:DrawDeathNotice() end
 
 function GM:Think()
     local client = LocalPlayer()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:Alive() and not v:IsSpec() then
             hook.Run("TTTPlayerAliveClientThink", client, v)
 
@@ -808,7 +828,7 @@ function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies,
     local enemies = {}
     local friends = {}
     local jesters = {}
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= client then
             if showJesters and v:ShouldActLikeJester() then
                 if not onlyShowEnemies then

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -16,6 +16,8 @@ local timer = timer
 local util = util
 local vgui = vgui
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetAllPlayers = player.GetAll
 local MathApproach = math.Approach
 local MathMax = math.max
@@ -179,11 +181,11 @@ local function RoundStateChange(o, n)
     -- players, which hooking code may not expect
     if n == ROUND_PREP then
         -- can enter PREP from any phase due to ttt_roundrestart
-        hook.Call("TTTPrepareRound", GAMEMODE)
+        RunHook("TTTPrepareRound")
     elseif (o == ROUND_PREP) and (n == ROUND_ACTIVE) then
-        hook.Call("TTTBeginRound", GAMEMODE)
+        RunHook("TTTBeginRound")
     elseif (o == ROUND_ACTIVE) and (n == ROUND_POST) then
-        hook.Call("TTTEndRound", GAMEMODE)
+        RunHook("TTTEndRound")
     end
 
     -- whatever round state we get, clear out the voice flags
@@ -384,14 +386,14 @@ function GM:Think()
     local client = LocalPlayer()
     for _, v in pairs(GetAllPlayers()) do
         if v:Alive() and not v:IsSpec() then
-            hook.Call("TTTPlayerAliveClientThink", nil, client, v)
+            CallHook("TTTPlayerAliveClientThink", nil, client, v)
 
             local smokeColor = COLOR_BLACK
             local smokeParticle = "particle/snow.vmt"
             local smokeOffset = Vector(0, 0, 30)
 
             -- Allow other addons to manipulate whether and how players smoke
-            local shouldSmoke, newSmokeColor, newSmokeParticle, newSmokeOffset = hook.Call("TTTShouldPlayerSmoke", nil, v, client, false, smokeColor, smokeParticle, smokeOffset)
+            local shouldSmoke, newSmokeColor, newSmokeParticle, newSmokeOffset = CallHook("TTTShouldPlayerSmoke", nil, v, client, false, smokeColor, smokeParticle, smokeOffset)
             if newSmokeColor then smokeColor = newSmokeColor end
             if newSmokeParticle then smokeParticle = newSmokeParticle end
             if newSmokeOffset then smokeOffset = newSmokeOffset end
@@ -727,7 +729,7 @@ local function SprintFunction()
             sprintTimer = CurTime()
         end
         stamina = stamina - (CurTime() - sprintTimer) * (MathMin(MathMax(consumption, 0.1), 5) * 250)
-        local result = hook.Call("TTTSprintStaminaPost", nil, LocalPlayer(), stamina, sprintTimer, consumption)
+        local result = CallHook("TTTSprintStaminaPost", nil, LocalPlayer(), stamina, sprintTimer, consumption)
         -- Use the overwritten stamina if one is provided
         if result then
             stamina = result
@@ -749,7 +751,7 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
     -- listen for activation
     hook.Add("Think", "TTTSprintThink", function()
         local client = LocalPlayer()
-        local forward_key = hook.Call("TTTSprintKey", nil, client) or IN_FORWARD
+        local forward_key = CallHook("TTTSprintKey", nil, client) or IN_FORWARD
         if client:KeyDown(forward_key) and client:KeyDown(IN_SPEED) then
             -- forward + selected key
             SprintFunction()
@@ -769,7 +771,7 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
                 end
 
                 -- Allow things to change the recovery rate
-                recovery = hook.Call("TTTSprintStaminaRecovery", nil, client, recovery) or recovery
+                recovery = CallHook("TTTSprintStaminaRecovery", nil, client, recovery) or recovery
 
                 stamina = stamina + (CurTime() - recoveryTimer) * recovery * 250
             end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -418,11 +418,9 @@ function GM:Think()
                         particle:SetColor(smokeColor.r, smokeColor.g, smokeColor.b)
                     end
                 end
-            else
-                if v.SmokeEmitter then
-                    v.SmokeEmitter:Finish()
-                    v.SmokeEmitter = nil
-                end
+            elseif v.SmokeEmitter then
+                v.SmokeEmitter:Finish()
+                v.SmokeEmitter = nil
             end
         end
     end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -21,6 +21,8 @@ local GetAllPlayers = player.GetAll
 local StringUpper = string.upper
 local StringLower = string.lower
 local StringExplode = string.Explode
+local TableInsert = table.insert
+local TableHasValue = table.HasValue
 
 -- Define GM12 fonts for compatibility
 surface.CreateFont("DefaultBold", {
@@ -834,15 +836,15 @@ function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies,
         if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= client then
             if showJesters and v:ShouldActLikeJester() then
                 if not onlyShowEnemies then
-                    table.insert(jesters, v)
+                    TableInsert(jesters, v)
                 end
-            elseif table.HasValue(alliedRoles, v:GetRole()) then
+            elseif TableHasValue(alliedRoles, v:GetRole()) then
                 if not onlyShowEnemies then
-                    table.insert(friends, v)
+                    TableInsert(friends, v)
                 end
             -- Don't even track enemies if this role can't see them
             elseif not hideEnemies then
-                table.insert(enemies, v)
+                TableInsert(enemies, v)
             end
         end
     end
@@ -873,7 +875,7 @@ local function EnableTraitorHighlights(client)
         -- Start with the list of traitors
         local allies = GetTeamRoles(TRAITOR_ROLES)
         -- And add the glitch
-        table.insert(allies, ROLE_GLITCH)
+        TableInsert(allies, ROLE_GLITCH)
 
         OnPlayerHighlightEnabled(client, allies, jesters_visible_to_traitors, true, true)
     end)
@@ -961,7 +963,7 @@ function AddFootstep(ply, pos, ang, foot, col, fade_time)
             normal = tr.HitNormal,
             col = col
         }
-        table.insert(footSteps, tbl)
+        TableInsert(footSteps, tbl)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -12,13 +12,15 @@ local pairs = pairs
 local player = player
 local render = render
 local surface = surface
-local string = string
 local table = table
 local timer = timer
 local util = util
 local vgui = vgui
 
 local GetAllPlayers = player.GetAll
+local StringUpper = string.upper
+local StringLower = string.lower
+local StringExplode = string.Explode
 
 -- Define GM12 fonts for compatibility
 surface.CreateFont("DefaultBold", {
@@ -229,7 +231,7 @@ local function ReceiveRole()
 
     if role > ROLE_NONE then
         Msg("You are: ")
-        MsgN(string.upper(client:GetRoleString()))
+        MsgN(StringUpper(client:GetRoleString()))
     end
 end
 net.Receive("TTT_Role", ReceiveRole)
@@ -523,7 +525,7 @@ local hm_CanPlayS = true
 local hm_Alpha = 0
 
 local function GrabColor() -- Used for retrieving the console color
-    local coltable = string.Explode(",", hm_color:GetString())
+    local coltable = StringExplode(",", hm_color:GetString())
     local newcol = {}
 
     for k, v in pairs(coltable) do
@@ -537,7 +539,7 @@ local function GrabColor() -- Used for retrieving the console color
 end
 
 local function GrabCritColor() -- Used for retrieving the console color
-    local coltable = string.Explode(",", hm_critcolor:GetString())
+    local coltable = StringExplode(",", hm_critcolor:GetString())
     local newcol = {}
 
     for k, v in pairs(coltable) do
@@ -631,7 +633,7 @@ hook.Add("HUDPaint", "HitmarkerDrawer", function()
         col.a = hm_Alpha
         surface.SetDrawColor(col)
 
-        local sel = string.lower(hm_type:GetString())
+        local sel = StringLower(hm_type:GetString())
         -- The drawing part of the hitmarkers and the various types you can choose
         if sel == "lines" then
             surface.DrawLine(x - 6, y - 5, x - 11, y - 10)

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -384,14 +384,14 @@ function GM:Think()
     local client = LocalPlayer()
     for _, v in pairs(GetAllPlayers()) do
         if v:Alive() and not v:IsSpec() then
-            hook.Run("TTTPlayerAliveClientThink", client, v)
+            hook.Call("TTTPlayerAliveClientThink", nil, client, v)
 
             local smokeColor = COLOR_BLACK
             local smokeParticle = "particle/snow.vmt"
             local smokeOffset = Vector(0, 0, 30)
 
             -- Allow other addons to manipulate whether and how players smoke
-            local shouldSmoke, newSmokeColor, newSmokeParticle, newSmokeOffset = hook.Run("TTTShouldPlayerSmoke", v, client, false, smokeColor, smokeParticle, smokeOffset)
+            local shouldSmoke, newSmokeColor, newSmokeParticle, newSmokeOffset = hook.Call("TTTShouldPlayerSmoke", nil, v, client, false, smokeColor, smokeParticle, smokeOffset)
             if newSmokeColor then smokeColor = newSmokeColor end
             if newSmokeParticle then smokeParticle = newSmokeParticle end
             if newSmokeOffset then smokeOffset = newSmokeOffset end
@@ -727,7 +727,7 @@ local function SprintFunction()
             sprintTimer = CurTime()
         end
         stamina = stamina - (CurTime() - sprintTimer) * (MathMin(MathMax(consumption, 0.1), 5) * 250)
-        local result = hook.Run("TTTSprintStaminaPost", LocalPlayer(), stamina, sprintTimer, consumption)
+        local result = hook.Call("TTTSprintStaminaPost", nil, LocalPlayer(), stamina, sprintTimer, consumption)
         -- Use the overwritten stamina if one is provided
         if result then
             stamina = result
@@ -749,7 +749,7 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
     -- listen for activation
     hook.Add("Think", "TTTSprintThink", function()
         local client = LocalPlayer()
-        local forward_key = hook.Run("TTTSprintKey", client) or IN_FORWARD
+        local forward_key = hook.Call("TTTSprintKey", nil, client) or IN_FORWARD
         if client:KeyDown(forward_key) and client:KeyDown(IN_SPEED) then
             -- forward + selected key
             SprintFunction()
@@ -769,7 +769,7 @@ hook.Add("TTTPrepareRound", "TTTSprintPrepareRound", function()
                 end
 
                 -- Allow things to change the recovery rate
-                recovery = hook.Run("TTTSprintStaminaRecovery", client, recovery) or recovery
+                recovery = hook.Call("TTTSprintStaminaRecovery", nil, client, recovery) or recovery
 
                 stamina = stamina + (CurTime() - recoveryTimer) * recovery * 250
             end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -6,7 +6,6 @@ local concommand = concommand
 local ents = ents
 local hook = hook
 local ipairs = ipairs
-local math = math
 local net = net
 local pairs = pairs
 local player = player
@@ -18,6 +17,11 @@ local util = util
 local vgui = vgui
 
 local GetAllPlayers = player.GetAll
+local MathApproach = math.Approach
+local MathMax = math.max
+local MathMin = math.min
+local MathRand = math.Rand
+local MathRandom = math.random
 local StringUpper = string.upper
 local StringLower = string.lower
 local StringExplode = string.Explode
@@ -399,14 +403,14 @@ function GM:Think()
                 if v.SmokeNextPart < CurTime() then
                     if client:GetPos():Distance(pos) <= 3000 then
                         v.SmokeEmitter:SetPos(pos)
-                        v.SmokeNextPart = CurTime() + math.Rand(0.003, 0.01)
-                        local vec = Vector(math.Rand(-8, 8), math.Rand(-8, 8), math.Rand(10, 55))
+                        v.SmokeNextPart = CurTime() + MathRand(0.003, 0.01)
+                        local vec = Vector(MathRand(-8, 8), MathRand(-8, 8), MathRand(10, 55))
                         local particle = v.SmokeEmitter:Add(smokeParticle, v:LocalToWorld(vec))
                         particle:SetVelocity(Vector(0, 0, 4) + VectorRand() * 3)
-                        particle:SetDieTime(math.Rand(0.5, 2))
-                        particle:SetStartAlpha(math.random(150, 220))
+                        particle:SetDieTime(MathRand(0.5, 2))
+                        particle:SetStartAlpha(MathRandom(150, 220))
                         particle:SetEndAlpha(0)
-                        local size = math.random(4, 7)
+                        local size = MathRandom(4, 7)
                         particle:SetStartSize(size)
                         particle:SetEndSize(size + 1)
                         particle:SetRoll(0)
@@ -627,7 +631,7 @@ hook.Add("HUDPaint", "HitmarkerDrawer", function()
         local x = ScrW() / 2
         local y = ScrH() / 2
 
-        hm_Alpha = math.Approach(hm_Alpha, 0, 5)
+        hm_Alpha = MathApproach(hm_Alpha, 0, 5)
         local col = GrabColor()
         if hm_LastHitCrit and hm_crit:GetBool() then
             col = GrabCritColor()
@@ -699,7 +703,7 @@ local function SpeedChange(bool)
     local client = LocalPlayer()
     net.Start("TTT_SprintSpeedSet")
     if bool then
-        local mul = math.min(math.max(speedMultiplier, 0.1), 2)
+        local mul = MathMin(MathMax(speedMultiplier, 0.1), 2)
         net.WriteFloat(mul)
         client.mult = 1 + mul
 
@@ -724,7 +728,7 @@ local function SprintFunction()
             sprinting = true
             sprintTimer = CurTime()
         end
-        stamina = stamina - (CurTime() - sprintTimer) * (math.min(math.max(consumption, 0.1), 5) * 250)
+        stamina = stamina - (CurTime() - sprintTimer) * (MathMin(MathMax(consumption, 0.1), 5) * 250)
         local result = hook.Run("TTTSprintStaminaPost", LocalPlayer(), stamina, sprintTimer, consumption)
         -- Use the overwritten stamina if one is provided
         if result then

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -104,7 +104,7 @@ function GM:KeyPress(ply, key)
         timer.Simple(0.05, function()
             -- Use the new permissions system if it exists or otherwise fall back to the old way
             if permissions and permissions.EnableVoiceChat then
-                permissions.EnableVoiceChat(enabled)
+                permissions.EnableVoiceChat(true)
             else
                 RunConsoleCommand("+voicerecord")
             end

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -101,7 +101,14 @@ function GM:KeyPress(ply, key)
     if not IsValid(ply) or ply ~= LocalPlayer() then return end
 
     if key == IN_ZOOM and ply:IsActiveTraitorTeam() then
-        timer.Simple(0.05, function() VOICE.ToggleVoiceChat(true) end)
+        timer.Simple(0.05, function()
+            -- Use the new permissions system if it exists or otherwise fall back to the old way
+            if permissions and permissions.EnableVoiceChat then
+                permissions.EnableVoiceChat(enabled)
+            else
+                RunConsoleCommand("+voicerecord")
+            end
+        end)
     end
 end
 
@@ -110,7 +117,7 @@ function GM:KeyRelease(ply, key)
     if not IsValid(ply) or ply ~= LocalPlayer() then return end
 
     if key == IN_ZOOM and ply:IsActiveTraitorTeam() then
-        timer.Simple(0.05, function() VOICE.ToggleVoiceChat(false) end)
+        timer.Simple(0.05, function() RunConsoleCommand("-voicerecord") end)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -101,7 +101,7 @@ function GM:KeyPress(ply, key)
     if not IsValid(ply) or ply ~= LocalPlayer() then return end
 
     if key == IN_ZOOM and ply:IsActiveTraitorTeam() then
-        timer.Simple(0.05, function() RunConsoleCommand("+voicerecord") end)
+        timer.Simple(0.05, function() VOICE.ToggleVoiceChat(true) end)
     end
 end
 
@@ -110,7 +110,7 @@ function GM:KeyRelease(ply, key)
     if not IsValid(ply) or ply ~= LocalPlayer() then return end
 
     if key == IN_ZOOM and ply:IsActiveTraitorTeam() then
-        timer.Simple(0.05, function() RunConsoleCommand("-voicerecord") end)
+        timer.Simple(0.05, function() VOICE.ToggleVoiceChat(false) end)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -1,5 +1,9 @@
 -- Key overrides for TTT specific keyboard functions
 
+local input = input
+local string = string
+local timer = timer
+
 local function SendWeaponDrop()
     RunConsoleCommand("ttt_dropweapon")
 

--- a/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -4,6 +4,8 @@ local input = input
 local string = string
 local timer = timer
 
+local StringSub = string.sub
+
 local function SendWeaponDrop()
     RunConsoleCommand("ttt_dropweapon")
 
@@ -57,8 +59,8 @@ function GM:PlayerBindPress(ply, bind, pressed)
         elseif TBHUD:PlayerIsFocused() then
             return TBHUD:UseFocused()
         end
-    elseif string.sub(bind, 1, 4) == "slot" and pressed then
-        local idx = tonumber(string.sub(bind, 5, -1)) or 1
+    elseif StringSub(bind, 1, 4) == "slot" and pressed then
+        local idx = tonumber(StringSub(bind, 5, -1)) or 1
 
         -- if radiomenu is open, override weapon select
         if RADIO.Show then

--- a/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -8,6 +8,15 @@
 
 include("shared.lua")
 
+local chat = chat
+local concommand = concommand
+local cvars = cvars
+local hook = hook
+local ipairs = ipairs
+local pairs = pairs
+local string = string
+local table = table
+
 LANG.Strings = {}
 
 CreateConVar("ttt_language", "auto", FCVAR_ARCHIVE)
@@ -239,7 +248,6 @@ LANG.Styles = {
     chat_warn = function(text)
         chat.AddText(COLOR_RED, text)
     end,
-
 
     chat_plain = chat.AddText
 };

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -1,5 +1,15 @@
 -- Some popup window stuff
 
+local concommand = concommand
+local draw = draw
+local hook = hook
+local ipairs = ipairs
+local string = string
+local table = table
+local timer = timer
+local vgui = vgui
+
+local GetAllPlayers = player.GetAll
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 
@@ -52,7 +62,7 @@ local function GetTextForLocalPlayer()
     local roleString = client:GetRoleStringRaw()
     if client:IsMonsterTeam() then
         local allies = {}
-        for _, ply in ipairs(player.GetAll()) do
+        for _, ply in ipairs(GetAllPlayers()) do
             if ply:IsMonsterTeam() then
                 table.insert(allies, ply)
             end
@@ -77,7 +87,7 @@ local function GetTextForLocalPlayer()
     elseif client:IsTraitorTeam() then
         local traitors = {}
         local glitches = {}
-        for _, ply in ipairs(player.GetAll()) do
+        for _, ply in ipairs(GetAllPlayers()) do
             if ply:IsTraitorTeam() then
                 table.insert(traitors, ply)
             elseif ply:IsGlitch() then

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -54,7 +54,7 @@ local function GetTextForLocalPlayer()
     }
 
     -- Allow roles to specify their extra parameters
-    local additionalParams = hook.Run("TTTRolePopupParams", client)
+    local additionalParams = hook.Call("TTTRolePopupParams", nil, client)
     if type(additionalParams) == "table" then params = table.Merge(params, additionalParams) end
 
     local roleString = client:GetRoleStringRaw()

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -8,10 +8,8 @@ local table = table
 local timer = timer
 local vgui = vgui
 
-local GetAllPlayers = player.GetAll
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
-local StringRep = string.rep
 
 ---- Round start
 
@@ -62,7 +60,7 @@ local function GetTextForLocalPlayer()
     local roleString = client:GetRoleStringRaw()
     if client:IsMonsterTeam() then
         local allies = {}
-        for _, ply in ipairs(GetAllPlayers()) do
+        for _, ply in ipairs(player.GetAll()) do
             if ply:IsMonsterTeam() then
                 table.insert(allies, ply)
             end
@@ -87,7 +85,7 @@ local function GetTextForLocalPlayer()
     elseif client:IsTraitorTeam() then
         local traitors = {}
         local glitches = {}
-        for _, ply in ipairs(GetAllPlayers()) do
+        for _, ply in ipairs(player.GetAll()) do
             if ply:IsTraitorTeam() then
                 table.insert(traitors, ply)
             elseif ply:IsGlitch() then

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -72,7 +72,7 @@ local function GetTextForLocalPlayer()
 
             for _, ply in ipairs(allies) do
                 if ply ~= client then
-                    allylist = allylist .. StringRep(" ", 42) .. ply:Nick() .. "\n"
+                    allylist = allylist .. string.rep(" ", 42) .. ply:Nick() .. "\n"
                 end
             end
             comrades = GetPTranslation("info_popup_monster_comrades", table.Merge(params, { allylist = allylist }))
@@ -100,7 +100,7 @@ local function GetTextForLocalPlayer()
 
             for _, ply in ipairs(traitors) do
                 if ply ~= client then
-                    traitorlist = traitorlist .. StringRep(" ", 42) .. ply:Nick() .. "\n"
+                    traitorlist = traitorlist .. string.rep(" ", 42) .. ply:Nick() .. "\n"
                 end
             end
 

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -4,7 +4,6 @@ local concommand = concommand
 local draw = draw
 local hook = hook
 local ipairs = ipairs
-local string = string
 local table = table
 local timer = timer
 local vgui = vgui
@@ -12,6 +11,7 @@ local vgui = vgui
 local GetAllPlayers = player.GetAll
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
+local StringRep = string.rep
 
 ---- Round start
 
@@ -74,7 +74,7 @@ local function GetTextForLocalPlayer()
 
             for _, ply in ipairs(allies) do
                 if ply ~= client then
-                    allylist = allylist .. string.rep(" ", 42) .. ply:Nick() .. "\n"
+                    allylist = allylist .. StringRep(" ", 42) .. ply:Nick() .. "\n"
                 end
             end
             comrades = GetPTranslation("info_popup_monster_comrades", table.Merge(params, { allylist = allylist }))
@@ -102,7 +102,7 @@ local function GetTextForLocalPlayer()
 
             for _, ply in ipairs(traitors) do
                 if ply ~= client then
-                    traitorlist = traitorlist .. string.rep(" ", 42) .. ply:Nick() .. "\n"
+                    traitorlist = traitorlist .. StringRep(" ", 42) .. ply:Nick() .. "\n"
                 end
             end
 

--- a/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -173,7 +173,7 @@ function RADAR:Draw(client)
         end
     end
 
-    hook.Run("TTTRadarRender", client)
+    hook.Call("TTTRadarRender", nil, client)
 
     -- Player radar
     if not self.enable then return end
@@ -231,7 +231,7 @@ function RADAR:Draw(client)
             -- If the target is an active clown but they should be hidden, hide them from the radar
             local hidden = tgt.killer_clown_active and GetGlobalBool("ttt_clown_hide_when_active", false)
 
-            local newColor, newHidden = hook.Run("TTTRadarPlayerRender", client, tgt, color, hidden)
+            local newColor, newHidden = hook.Call("TTTRadarPlayerRender", nil, client, tgt, color, hidden)
             if newColor then color = newColor end
             if type(newHidden) == "boolean" then hidden = newHidden end
 

--- a/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -1,7 +1,14 @@
 -- Traitor radar rendering
 
-local surface = surface
+local hook = hook
 local math = math
+local net = net
+local pairs = pairs
+local surface = surface
+local table = table
+local timer = timer
+local util = util
+local vgui = vgui
 
 RADAR = {}
 RADAR.targets = {}

--- a/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -10,6 +10,8 @@ local timer = timer
 local util = util
 local vgui = vgui
 
+local CallHook = hook.Call
+
 RADAR = {}
 RADAR.targets = {}
 RADAR.enable = false
@@ -173,7 +175,7 @@ function RADAR:Draw(client)
         end
     end
 
-    hook.Call("TTTRadarRender", nil, client)
+    CallHook("TTTRadarRender", nil, client)
 
     -- Player radar
     if not self.enable then return end
@@ -231,7 +233,7 @@ function RADAR:Draw(client)
             -- If the target is an active clown but they should be hidden, hide them from the radar
             local hidden = tgt.killer_clown_active and GetGlobalBool("ttt_clown_hide_when_active", false)
 
-            local newColor, newHidden = hook.Call("TTTRadarPlayerRender", nil, client, tgt, color, hidden)
+            local newColor, newHidden = CallHook("TTTRadarPlayerRender", nil, client, tgt, color, hidden)
             if newColor then color = newColor end
             if type(newHidden) == "boolean" then hidden = newHidden end
 

--- a/gamemodes/terrortown/gamemode/cl_roleweapons.lua
+++ b/gamemodes/terrortown/gamemode/cl_roleweapons.lua
@@ -1,5 +1,14 @@
 include("shared.lua")
 
+local concommand = concommand
+local math = math
+local net = net
+local pairs = pairs
+local string = string
+local table = table
+local timer = timer
+local vgui = vgui
+
 local GetTranslation = LANG.GetTranslation
 local SafeTranslate = LANG.TryTranslation
 
@@ -215,7 +224,7 @@ local function OpenDialog(client)
         local roleitems = GetEquipmentForRole(role, false, true, true, true)
         local filtered = {}
         for _, v in pairs(roleitems) do
-            if v and v["name"] and string.find(SafeTranslate(v["name"]):lower(), value:lower()) then
+            if v and v["name"] and string.find(string.lower(SafeTranslate(v["name"])), string.lower(value)) then
                 table.insert(filtered, v)
             end
         end

--- a/gamemodes/terrortown/gamemode/cl_roleweapons.lua
+++ b/gamemodes/terrortown/gamemode/cl_roleweapons.lua
@@ -4,13 +4,14 @@ local concommand = concommand
 local math = math
 local net = net
 local pairs = pairs
-local string = string
 local table = table
 local timer = timer
 local vgui = vgui
 
 local GetTranslation = LANG.GetTranslation
 local SafeTranslate = LANG.TryTranslation
+local StringFind = string.find
+local StringLower = string.lower
 
 local function ItemIsWeapon(item) return not tonumber(item.id) end
 
@@ -224,7 +225,7 @@ local function OpenDialog(client)
         local roleitems = GetEquipmentForRole(role, false, true, true, true)
         local filtered = {}
         for _, v in pairs(roleitems) do
-            if v and v["name"] and string.find(string.lower(SafeTranslate(v["name"])), string.lower(value)) then
+            if v and v["name"] and StringFind(StringLower(SafeTranslate(v["name"])), StringLower(value)) then
                 table.insert(filtered, v)
             end
         end

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -21,6 +21,8 @@ local util = util
 local vgui = vgui
 local parentPanel, parentTabs, closeButton, saveButton
 
+local StringUpper = string.upper
+
 CLSCORE = {}
 CLSCORE.Events = {}
 CLSCORE.Scores = {}
@@ -249,8 +251,8 @@ end
 
 local function GetWinTitle(wintype)
     local wintitles = {
-        [WIN_INNOCENT] = { txt = "hilite_win_role_plural", params = { role = string.upper(ROLE_STRINGS_PLURAL[ROLE_INNOCENT]) }, c = ROLE_COLORS[ROLE_INNOCENT] },
-        [WIN_TRAITOR] = { txt = "hilite_win_role_plural", params = { role = string.upper(ROLE_STRINGS_PLURAL[ROLE_TRAITOR]) }, c = ROLE_COLORS[ROLE_TRAITOR] },
+        [WIN_INNOCENT] = { txt = "hilite_win_role_plural", params = { role = StringUpper(ROLE_STRINGS_PLURAL[ROLE_INNOCENT]) }, c = ROLE_COLORS[ROLE_INNOCENT] },
+        [WIN_TRAITOR] = { txt = "hilite_win_role_plural", params = { role = StringUpper(ROLE_STRINGS_PLURAL[ROLE_TRAITOR]) }, c = ROLE_COLORS[ROLE_TRAITOR] },
         [WIN_MONSTER] = { txt = "hilite_win_role_plural", params = { role = "MONSTERS" }, c = GetRoleTeamColor(ROLE_TEAM_MONSTER) }
     }
     local title = wintitles[wintype]
@@ -266,7 +268,7 @@ local function GetWinTitle(wintype)
         local monster_role = GetWinningMonsterRole()
         -- If a single support role (zombies or vampires) won as the "monsters team", use their role as the label
         if monster_role then
-            title.params = { role = string.upper(ROLE_STRINGS_PLURAL[monster_role]) }
+            title.params = { role = StringUpper(ROLE_STRINGS_PLURAL[monster_role]) }
         -- Otherwise use the monsters label
         else
             title.params = { role = "MONSTERS" }
@@ -419,7 +421,7 @@ end
 function CLSCORE:AddAward(y, pw, award, dpanel)
     local nick = award.nick
     local text = award.text
-    local title = string.upper(award.title)
+    local title = StringUpper(award.title)
 
     local titlelbl = vgui.Create("DLabel", dpanel)
     titlelbl:SetText(title)
@@ -642,7 +644,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     for i, r in ipairs(secondary_win_roles) do
         local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = string.upper(ROLE_STRINGS[r]) }))
+        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = StringUpper(ROLE_STRINGS[r]) }))
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2
@@ -936,7 +938,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
     for i, r in ipairs(secondary_win_roles) do
         local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = string.upper(ROLE_STRINGS[r]) }))
+        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = StringUpper(ROLE_STRINGS[r]) }))
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -955,7 +955,11 @@ function CLSCORE:BuildHilitePanel(dpanel)
 
     if #secondary_win_roles > 0 then winlbl:SetPos(xwin, ywin - 15) end
 
-    local ysubwin = ywin + winlbl:GetTall() + ((#secondary_win_roles - 1) * 28)
+    local ysubwin = ywin + winlbl:GetTall()
+    -- Add extra space if we have more than one secondary win
+    if #secondary_win_roles > 1 then
+        ysubwin = ysubwin + (#secondary_win_roles - 1) * 28
+    end
     local partlbl = vgui.Create("DLabel", dpanel)
 
     local plytxt = PT(numtr == 1 and "hilite_players2" or "hilite_players1",

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -256,11 +256,11 @@ local function GetWinTitle(wintype)
         [WIN_MONSTER] = { txt = "hilite_win_role_plural", params = { role = "MONSTERS" }, c = GetRoleTeamColor(ROLE_TEAM_MONSTER) }
     }
     local title = wintitles[wintype]
-    local new_title = hook.Run("TTTScoringWinTitle", wintype, wintitles, title)
+    local new_title = hook.Call("TTTScoringWinTitle", nil, wintype, wintitles, title)
     if new_title then title = new_title end
 
     local secondary_wins = {}
-    hook.Run("TTTScoringSecondaryWins", wintype, secondary_wins)
+    hook.Call("TTTScoringSecondaryWins", nil, wintype, secondary_wins)
     secondary_win_roles = secondary_wins
 
     -- If this was a monster win, check that both roles are part of the monsters team still
@@ -538,7 +538,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
                 local groupingRole = finalRole
 
                 -- Allow developers to override role icon, grouping, and color
-                local roleFile, groupRole, iconColor, newName = hook.Run("TTTScoringSummaryRender", ply, roleFileName, groupingRole, roleColor, name, startingRole, finalRole)
+                local roleFile, groupRole, iconColor, newName = hook.Call("TTTScoringSummaryRender", nil, ply, roleFileName, groupingRole, roleColor, name, startingRole, finalRole)
                 if roleFile then roleFileName = roleFile end
                 if groupRole then groupingRole = groupRole end
                 if iconColor then roleColor = iconColor end

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -733,7 +733,7 @@ function CLSCORE:BuildPlayerList(playerList, dpanel, statusX, roleX, initialY, r
         local roleIcon = GetRoleIconElement(v.roleFileName, v.roleColor, v.startingRole, v.finalRole, dpanel)
         local nicklbl = GetNickLabelElement(v.name, dpanel)
         FitNicknameLabel(nicklbl, 275, function(nickname)
-            return string.sub(nickname, 0, #nickname - 4) .. "..."
+            return utf8.sub(nickname, 0, -5) .. "..."
         end)
 
         self:AddPlayerRow(dpanel, statusX, roleX, initialY + rowY * count, roleIcon, nicklbl, v.hasDisconnected, v.hasDied)
@@ -795,9 +795,9 @@ function CLSCORE:BuildRoleLabel(playerList, dpanel, statusX, roleX, rowY)
                 local playerArg = args.player
                 local otherArg = args.other
                 if #playerArg > #otherArg then
-                    playerArg = string.sub(playerArg, 0, #playerArg - 4) .. "..."
+                    playerArg = utf8.sub(playerArg, 0, -5) .. "..."
                 else
-                    otherArg = string.sub(otherArg, 0, #otherArg - 4) .. "..."
+                    otherArg = utf8.sub(otherArg, 0, -5) .. "..."
                 end
 
                 return BuildJesterLabel(playerArg, otherArg, label), {player=playerArg, other=otherArg}
@@ -822,7 +822,7 @@ function CLSCORE:BuildRoleLabel(playerList, dpanel, statusX, roleX, rowY)
     local namesList = string.Implode(", ", names)
     local nickLbl = GetNickLabelElement(namesList, dpanel)
     FitNicknameLabel(nickLbl, maxWidth, function(nickname)
-        return string.sub(nickname, 0, #nickname - 4) .. "..."
+        return utf8.sub(nickname, 0, -5) .. "..."
     end)
 
     -- Show the normal disconnect icon if we have only 1 player and they disconnected

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -2,10 +2,23 @@
 
 include("cl_awards.lua")
 
-local table = table
-local string = string
-local vgui = vgui
+local chat = chat
+local concommand = concommand
+local draw = draw
+local file = file
+local hook = hook
+local input = input
+local ipairs = ipairs
+local math = math
+local net = net
 local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local util = util
+local vgui = vgui
 local parentPanel, parentTabs, closeButton, saveButton
 
 CLSCORE = {}
@@ -236,8 +249,8 @@ end
 
 local function GetWinTitle(wintype)
     local wintitles = {
-        [WIN_INNOCENT] = { txt = "hilite_win_role_plural", params = { role = ROLE_STRINGS_PLURAL[ROLE_INNOCENT]:upper() }, c = ROLE_COLORS[ROLE_INNOCENT] },
-        [WIN_TRAITOR] = { txt = "hilite_win_role_plural", params = { role = ROLE_STRINGS_PLURAL[ROLE_TRAITOR]:upper() }, c = ROLE_COLORS[ROLE_TRAITOR] },
+        [WIN_INNOCENT] = { txt = "hilite_win_role_plural", params = { role = string.upper(ROLE_STRINGS_PLURAL[ROLE_INNOCENT]) }, c = ROLE_COLORS[ROLE_INNOCENT] },
+        [WIN_TRAITOR] = { txt = "hilite_win_role_plural", params = { role = string.upper(ROLE_STRINGS_PLURAL[ROLE_TRAITOR]) }, c = ROLE_COLORS[ROLE_TRAITOR] },
         [WIN_MONSTER] = { txt = "hilite_win_role_plural", params = { role = "MONSTERS" }, c = GetRoleTeamColor(ROLE_TEAM_MONSTER) }
     }
     local title = wintitles[wintype]
@@ -253,7 +266,7 @@ local function GetWinTitle(wintype)
         local monster_role = GetWinningMonsterRole()
         -- If a single support role (zombies or vampires) won as the "monsters team", use their role as the label
         if monster_role then
-            title.params = { role = ROLE_STRINGS_PLURAL[monster_role]:upper() }
+            title.params = { role = string.upper(ROLE_STRINGS_PLURAL[monster_role]) }
         -- Otherwise use the monsters label
         else
             title.params = { role = "MONSTERS" }
@@ -406,7 +419,7 @@ end
 function CLSCORE:AddAward(y, pw, award, dpanel)
     local nick = award.nick
     local text = award.text
-    local title = award.title:upper()
+    local title = string.upper(award.title)
 
     local titlelbl = vgui.Create("DLabel", dpanel)
     titlelbl:SetText(title)
@@ -629,7 +642,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     for i, r in ipairs(secondary_win_roles) do
         local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = ROLE_STRINGS[r]:upper() }))
+        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = string.upper(ROLE_STRINGS[r]) }))
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2
@@ -923,7 +936,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
     for i, r in ipairs(secondary_win_roles) do
         local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = ROLE_STRINGS[r]:upper() }))
+        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = string.upper(ROLE_STRINGS[r]) }))
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2

--- a/gamemodes/terrortown/gamemode/cl_scoring_events.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring_events.lua
@@ -51,7 +51,7 @@ local is_dmg = util.BitSet
 -- Round end event
 Event(EVENT_FINISH,
       { text = function(e)
-                  local result = hook.Run("TTTEventFinishText", e)
+                  local result = hook.Call("TTTEventFinishText", nil, e)
                   if result then return result end
 
                   if e.win == WIN_TRAITOR then
@@ -92,7 +92,7 @@ Event(EVENT_FINISH,
                      win_string = "ev_win_icon_time"
                   end
 
-                  local new_win_string, new_role_string = hook.Run("TTTEventFinishIconText", e, win_string, role_string)
+                  local new_win_string, new_role_string = hook.Call("TTTEventFinishIconText", nil, e, win_string, role_string)
                   if new_win_string then win_string = new_win_string end
                   if new_role_string then role_string = new_role_string end
 

--- a/gamemodes/terrortown/gamemode/cl_scoring_events.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring_events.lua
@@ -20,6 +20,10 @@
 -- Note that custom events don't have to be in this file, just any file that is
 -- loaded on the client.
 
+local hook = hook
+local string = string
+local util = util
+
 -- Translation helpers
 local T  = LANG.GetTranslation
 local PT = LANG.GetParamTranslation
@@ -51,19 +55,19 @@ Event(EVENT_FINISH,
                   if result then return result end
 
                   if e.win == WIN_TRAITOR then
-                     return PT("ev_win_traitor", { role = ROLE_STRINGS_PLURAL[ROLE_TRAITOR]:lower() })
+                     return PT("ev_win_traitor", { role = string.lower(ROLE_STRINGS_PLURAL[ROLE_TRAITOR]) })
                   elseif e.win == WIN_INNOCENT then
-                     return PT("ev_win_inno", { role = ROLE_STRINGS_PLURAL[ROLE_INNOCENT]:lower() })
+                     return PT("ev_win_inno", { role = string.lower(ROLE_STRINGS_PLURAL[ROLE_INNOCENT]) })
                   elseif e.win == WIN_MONSTER then
                      local monster_role = GetWinningMonsterRole()
                      if monster_role == ROLE_VAMPIRE then
-                        return PT("ev_win_vampire", { role = ROLE_STRINGS_PLURAL[ROLE_VAMPIRE]:lower() })
+                        return PT("ev_win_vampire", { role = string.lower(ROLE_STRINGS_PLURAL[ROLE_VAMPIRE]) })
                      elseif monster_role == ROLE_ZOMBIE then
-                        return PT("ev_win_zombie", { role = ROLE_STRINGS[ROLE_ZOMBIE]:lower() })
+                        return PT("ev_win_zombie", { role = string.lower(ROLE_STRINGS[ROLE_ZOMBIE]) })
                      end
                      return T("ev_win_monster")
                   elseif e.win == WIN_TIMELIMIT then
-                     return PT("ev_win_time", { role = ROLE_STRINGS_PLURAL[ROLE_TRAITOR]:lower() })
+                     return PT("ev_win_time", { role = string.lower(ROLE_STRINGS_PLURAL[ROLE_TRAITOR]) })
                   end
 
                   return PT("ev_win_unknown", { id = e.win })

--- a/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/cl_search.lua
@@ -1,5 +1,14 @@
 -- Body search popup
 
+local file = file
+local hook = hook
+local net = net
+local pairs = pairs
+local string = string
+local table = table
+local util = util
+local vgui = vgui
+
 local T = LANG.GetTranslation
 local PT = LANG.GetParamTranslation
 

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -14,6 +14,7 @@ local util = util
 local GetAllPlayers = player.GetAll
 local GetPTranslation = LANG.GetParamTranslation
 local GetRaw = LANG.GetRawTranslation
+local StringUpper = string.upper
 
 local key_params = { usekey = Key("+use", "USE"), walkkey = Key("+walk", "WALK") }
 
@@ -589,34 +590,34 @@ function GM:HUDDrawTargetID()
     text = nil
     local secondary_text = nil
     if target_traitor then
-        text = string.upper(ROLE_STRINGS[ROLE_TRAITOR])
+        text = StringUpper(ROLE_STRINGS[ROLE_TRAITOR])
         col = ROLE_COLORS_RADAR[ROLE_TRAITOR]
     elseif target_special_traitor then
         local role = ent:GetRole()
-        text = string.upper(ROLE_STRINGS[role])
+        text = StringUpper(ROLE_STRINGS[role])
         col = ROLE_COLORS_RADAR[role]
     elseif target_glitch then
         local bluff = ent:GetNWInt("GlitchBluff", ROLE_TRAITOR)
         if client:IsZombie() and client:IsTraitorTeam() then
             bluff = ROLE_ZOMBIE
         end
-        text = string.upper(ROLE_STRINGS[bluff])
+        text = StringUpper(ROLE_STRINGS[bluff])
         col = ROLE_COLORS_RADAR[bluff]
     elseif target_detective then
-        text = string.upper(ROLE_STRINGS[ROLE_DETECTIVE])
+        text = StringUpper(ROLE_STRINGS[ROLE_DETECTIVE])
         col = ROLE_COLORS_RADAR[ROLE_DETECTIVE]
     elseif target_special_detective then
         local role = ent:GetRole()
-        text = string.upper(ROLE_STRINGS[role])
+        text = StringUpper(ROLE_STRINGS[role])
         col = ROLE_COLORS_RADAR[role]
     elseif target_jester then
-        text = string.upper(ROLE_STRINGS[ROLE_JESTER])
+        text = StringUpper(ROLE_STRINGS[ROLE_JESTER])
         col = ROLE_COLORS_RADAR[ROLE_JESTER]
     elseif target_monster then
-        text = string.upper(ROLE_STRINGS[target_monster])
+        text = StringUpper(ROLE_STRINGS[target_monster])
         col = GetRoleTeamColor(ROLE_TEAM_MONSTER, "radar")
     elseif target_independent then
-        text = string.upper(ROLE_STRINGS[target_independent])
+        text = StringUpper(ROLE_STRINGS[target_independent])
         col = GetRoleTeamColor(ROLE_TEAM_INDEPENDENT, "radar")
     elseif ent.sb_tag and ent.sb_tag.txt ~= nil then
         text = L[ent.sb_tag.txt]

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -225,7 +225,7 @@ local function DrawPropSpecLabels(cli)
     local text = nil
     local w = 0
     tgt = nil
-    for _, p in ipairs(GetPlayers()) do
+    for _, p in ipairs(GetAllPlayers()) do
         if p:IsSpec() then
             surface.SetTextColor(220, 200, 0, 120)
 

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -101,7 +101,7 @@ function GM:PostDrawTranslucentRenderables()
     for _, v in pairs(plys) do
         -- Compatibility with the disguises, Dead Ringer (810154456), and Prop Disguiser (310403737 and 2127939503)
         local hidden = v:GetNWBool("disguised", false) or (v.IsFakeDead and v:IsFakeDead()) or v:GetNWBool("PD_Disguised", false)
-        if v:IsActive() and v ~= client and not hidden and not hook.Run("TTTTargetIDPlayerBlockIcon", v, client) then
+        if v:IsActive() and v ~= client and not hidden and not hook.Call("TTTTargetIDPlayerBlockIcon", nil, v, client) then
             pos = v:GetPos()
             pos.z = pos.z + v:GetHeight() + 15
 
@@ -112,7 +112,7 @@ function GM:PostDrawTranslucentRenderables()
 
             -- Allow other addons (and external roles) to determine if the "KILL" icon should show
             -- NOTE: Leave the permanent 'false' parameter to make sure we don't break external hook usage
-            local showKillIcon = hook.Run("TTTTargetIDPlayerKillIcon", v, client, false, showJester)
+            local showKillIcon = hook.Call("TTTTargetIDPlayerKillIcon", nil, v, client, false, showJester)
             if showKillIcon and not client:IsSameTeam(v) then -- If we are showing the "KILL" icon this should take priority over role icons
                 render.SetMaterial(indicator_mat_roleback_noz)
                 render.DrawQuadEasy(pos, dir, 8, 8, ROLE_COLORS_SPRITE[client:GetRole()], 180) -- Use the colour of whatever role the player currently is for the "KILL" icon
@@ -179,7 +179,7 @@ function GM:PostDrawTranslucentRenderables()
                     end
                 end
 
-                local newRole, newNoZ, newColorRole = hook.Run("TTTTargetIDPlayerRoleIcon", v, client, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
+                local newRole, newNoZ, newColorRole = hook.Call("TTTTargetIDPlayerRoleIcon", nil, v, client, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
                 if newRole or (type(newRole) == "boolean" and not newRole) then role = newRole end
                 if type(newNoZ) == "boolean" then noz = newNoZ end
                 if newColorRole then color_role = newColorRole end
@@ -299,7 +299,7 @@ function GM:HUDDrawTargetID()
     local ent = trace.Entity
     if (not IsValid(ent)) or ent.NoTarget then return end
 
-    if IsPlayer(ent) and hook.Run("TTTTargetIDPlayerBlockInfo", ent, client) then return end
+    if IsPlayer(ent) and hook.Call("TTTTargetIDPlayerBlockInfo", nil, ent, client) then return end
 
     -- some bools for caching what kind of ent we are looking at
     local target_traitor = false
@@ -406,7 +406,7 @@ function GM:HUDDrawTargetID()
         target_special_detective = GetRoundState() > ROUND_PREP and ent:IsDetectiveTeam() and not target_detective
 
         -- Allow external roles to override or block showing player name
-        local new_text, new_col = hook.Run("TTTTargetIDPlayerName", ent, client, text, color)
+        local new_text, new_col = hook.Call("TTTTargetIDPlayerName", nil, ent, client, text, color)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then color = new_col end
@@ -424,7 +424,7 @@ function GM:HUDDrawTargetID()
         end
 
         -- Allow external roles to override or block showing a ragdoll's name
-        local new_text, new_col = hook.Run("TTTTargetIDRagdollName", ent, client, text, color)
+        local new_text, new_col = hook.Call("TTTTargetIDRagdollName", nil, ent, client, text, color)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then color = new_col end
@@ -441,7 +441,7 @@ function GM:HUDDrawTargetID()
 
     local ring_visible = target_traitor or target_special_traitor or target_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
 
-    local new_visible, color_override = hook.Run("TTTTargetIDPlayerRing", ent, client, ring_visible)
+    local new_visible, color_override = hook.Call("TTTTargetIDPlayerRing", nil, ent, client, ring_visible)
     if type(new_visible) == "boolean" then ring_visible = new_visible end
 
     if ring_visible then
@@ -512,7 +512,7 @@ function GM:HUDDrawTargetID()
         text = L[text]
 
         -- Allow external roles to override or block showing health
-        local new_text, new_col = hook.Run("TTTTargetIDPlayerHealth", ent, client, text, col)
+        local new_text, new_col = hook.Call("TTTTargetIDPlayerHealth", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -520,7 +520,7 @@ function GM:HUDDrawTargetID()
         text = GetRaw(hint.name) or hint.name
 
         -- Allow external roles to override or block showing the hint label
-        local new_text, new_col = hook.Run("TTTTargetIDEntityHintLabel", ent, client, text, col)
+        local new_text, new_col = hook.Call("TTTTargetIDEntityHintLabel", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -548,7 +548,7 @@ function GM:HUDDrawTargetID()
         text = L[text]
 
         -- Allow external roles to override or block showing karma
-        local new_text, new_col = hook.Run("TTTTargetIDPlayerKarma", ent, client, text, col)
+        local new_text, new_col = hook.Call("TTTTargetIDPlayerKarma", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -573,7 +573,7 @@ function GM:HUDDrawTargetID()
         end
 
         -- Allow external roles to override or block showing karma
-        local new_text, new_col = hook.Run("TTTTargetIDPlayerHintText", ent, client, text, col)
+        local new_text, new_col = hook.Call("TTTTargetIDPlayerHintText", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -627,7 +627,7 @@ function GM:HUDDrawTargetID()
         col = COLOR_YELLOW
     end
 
-    local new_text, new_color, new_secondary = hook.Run("TTTTargetIDPlayerText", ent, client, text, col, secondary_text)
+    local new_text, new_color, new_secondary = hook.Call("TTTTargetIDPlayerText", nil, ent, client, text, col, secondary_text)
     -- If either text return value is a boolean and it's "false" then save that so we know to skip rendering the text
     if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
     if new_color then col = new_color end

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -1,7 +1,6 @@
 local cam = cam
 local draw = draw
 local file = file
-local hook = hook
 local ipairs = ipairs
 local math = math
 local pairs = pairs
@@ -11,6 +10,8 @@ local string = string
 local table = table
 local util = util
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetAllPlayers = player.GetAll
 local GetPTranslation = LANG.GetParamTranslation
 local GetRaw = LANG.GetRawTranslation
@@ -101,7 +102,7 @@ function GM:PostDrawTranslucentRenderables()
     for _, v in pairs(plys) do
         -- Compatibility with the disguises, Dead Ringer (810154456), and Prop Disguiser (310403737 and 2127939503)
         local hidden = v:GetNWBool("disguised", false) or (v.IsFakeDead and v:IsFakeDead()) or v:GetNWBool("PD_Disguised", false)
-        if v:IsActive() and v ~= client and not hidden and not hook.Call("TTTTargetIDPlayerBlockIcon", nil, v, client) then
+        if v:IsActive() and v ~= client and not hidden and not CallHook("TTTTargetIDPlayerBlockIcon", nil, v, client) then
             pos = v:GetPos()
             pos.z = pos.z + v:GetHeight() + 15
 
@@ -112,7 +113,7 @@ function GM:PostDrawTranslucentRenderables()
 
             -- Allow other addons (and external roles) to determine if the "KILL" icon should show
             -- NOTE: Leave the permanent 'false' parameter to make sure we don't break external hook usage
-            local showKillIcon = hook.Call("TTTTargetIDPlayerKillIcon", nil, v, client, false, showJester)
+            local showKillIcon = CallHook("TTTTargetIDPlayerKillIcon", nil, v, client, false, showJester)
             if showKillIcon and not client:IsSameTeam(v) then -- If we are showing the "KILL" icon this should take priority over role icons
                 render.SetMaterial(indicator_mat_roleback_noz)
                 render.DrawQuadEasy(pos, dir, 8, 8, ROLE_COLORS_SPRITE[client:GetRole()], 180) -- Use the colour of whatever role the player currently is for the "KILL" icon
@@ -179,7 +180,7 @@ function GM:PostDrawTranslucentRenderables()
                     end
                 end
 
-                local newRole, newNoZ, newColorRole = hook.Call("TTTTargetIDPlayerRoleIcon", nil, v, client, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
+                local newRole, newNoZ, newColorRole = CallHook("TTTTargetIDPlayerRoleIcon", nil, v, client, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
                 if newRole or (type(newRole) == "boolean" and not newRole) then role = newRole end
                 if type(newNoZ) == "boolean" then noz = newNoZ end
                 if newColorRole then color_role = newColorRole end
@@ -281,7 +282,7 @@ function GM:HUDDrawTargetID()
 
     local L = GetLang()
 
-    if hook.Call("HUDShouldDraw", GAMEMODE, "TTTPropSpec") then
+    if RunHook("HUDShouldDraw", "TTTPropSpec") then
         DrawPropSpecLabels(client)
     end
 
@@ -299,7 +300,7 @@ function GM:HUDDrawTargetID()
     local ent = trace.Entity
     if (not IsValid(ent)) or ent.NoTarget then return end
 
-    if IsPlayer(ent) and hook.Call("TTTTargetIDPlayerBlockInfo", nil, ent, client) then return end
+    if IsPlayer(ent) and CallHook("TTTTargetIDPlayerBlockInfo", nil, ent, client) then return end
 
     -- some bools for caching what kind of ent we are looking at
     local target_traitor = false
@@ -406,7 +407,7 @@ function GM:HUDDrawTargetID()
         target_special_detective = GetRoundState() > ROUND_PREP and ent:IsDetectiveTeam() and not target_detective
 
         -- Allow external roles to override or block showing player name
-        local new_text, new_col = hook.Call("TTTTargetIDPlayerName", nil, ent, client, text, color)
+        local new_text, new_col = CallHook("TTTTargetIDPlayerName", nil, ent, client, text, color)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then color = new_col end
@@ -424,7 +425,7 @@ function GM:HUDDrawTargetID()
         end
 
         -- Allow external roles to override or block showing a ragdoll's name
-        local new_text, new_col = hook.Call("TTTTargetIDRagdollName", nil, ent, client, text, color)
+        local new_text, new_col = CallHook("TTTTargetIDRagdollName", nil, ent, client, text, color)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then color = new_col end
@@ -441,7 +442,7 @@ function GM:HUDDrawTargetID()
 
     local ring_visible = target_traitor or target_special_traitor or target_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
 
-    local new_visible, color_override = hook.Call("TTTTargetIDPlayerRing", nil, ent, client, ring_visible)
+    local new_visible, color_override = CallHook("TTTTargetIDPlayerRing", nil, ent, client, ring_visible)
     if type(new_visible) == "boolean" then ring_visible = new_visible end
 
     if ring_visible then
@@ -512,7 +513,7 @@ function GM:HUDDrawTargetID()
         text = L[text]
 
         -- Allow external roles to override or block showing health
-        local new_text, new_col = hook.Call("TTTTargetIDPlayerHealth", nil, ent, client, text, col)
+        local new_text, new_col = CallHook("TTTTargetIDPlayerHealth", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -520,7 +521,7 @@ function GM:HUDDrawTargetID()
         text = GetRaw(hint.name) or hint.name
 
         -- Allow external roles to override or block showing the hint label
-        local new_text, new_col = hook.Call("TTTTargetIDEntityHintLabel", nil, ent, client, text, col)
+        local new_text, new_col = CallHook("TTTTargetIDEntityHintLabel", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -548,7 +549,7 @@ function GM:HUDDrawTargetID()
         text = L[text]
 
         -- Allow external roles to override or block showing karma
-        local new_text, new_col = hook.Call("TTTTargetIDPlayerKarma", nil, ent, client, text, col)
+        local new_text, new_col = CallHook("TTTTargetIDPlayerKarma", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -573,7 +574,7 @@ function GM:HUDDrawTargetID()
         end
 
         -- Allow external roles to override or block showing karma
-        local new_text, new_col = hook.Call("TTTTargetIDPlayerHintText", nil, ent, client, text, col)
+        local new_text, new_col = CallHook("TTTTargetIDPlayerHintText", nil, ent, client, text, col)
         -- If the first return value is a boolean and it's "false" then save that so we know to skip rendering the text
         if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
         if new_col then col = new_col end
@@ -627,7 +628,7 @@ function GM:HUDDrawTargetID()
         col = COLOR_YELLOW
     end
 
-    local new_text, new_color, new_secondary = hook.Call("TTTTargetIDPlayerText", nil, ent, client, text, col, secondary_text)
+    local new_text, new_color, new_secondary = CallHook("TTTTargetIDPlayerText", nil, ent, client, text, col, secondary_text)
     -- If either text return value is a boolean and it's "false" then save that so we know to skip rendering the text
     if new_text or (type(new_text) == "boolean" and not new_text) then text = new_text end
     if new_color then col = new_color end

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -1,7 +1,17 @@
-local util = util
-local surface = surface
+local cam = cam
 local draw = draw
+local file = file
+local hook = hook
+local ipairs = ipairs
+local math = math
+local pairs = pairs
+local render = render
+local surface = surface
+local string = string
+local table = table
+local util = util
 
+local GetAllPlayers = player.GetAll
 local GetPTranslation = LANG.GetParamTranslation
 local GetRaw = LANG.GetRawTranslation
 
@@ -59,7 +69,6 @@ local function DrawRoleIcon(role, noz, pos, dir, color_role)
 end
 
 local client, plys, ply, pos, dir, tgt
-local GetPlayers = player.GetAll
 
 local propspec_outline = Material("models/props_combine/portalball001_sheet")
 
@@ -79,7 +88,7 @@ end
 -- happen before certain entities are drawn, which then clip over the sprite
 function GM:PostDrawTranslucentRenderables()
     client = LocalPlayer()
-    plys = GetPlayers()
+    plys = GetAllPlayers()
 
     dir = client:GetForward() * -1
 
@@ -88,7 +97,7 @@ function GM:PostDrawTranslucentRenderables()
         hide_roles = GetConVar("ttt_hide_role"):GetBool()
     end
 
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(plys) do
         -- Compatibility with the disguises, Dead Ringer (810154456), and Prop Disguiser (310403737 and 2127939503)
         local hidden = v:GetNWBool("disguised", false) or (v.IsFakeDead and v:IsFakeDead()) or v:GetNWBool("PD_Disguised", false)
         if v:IsActive() and v ~= client and not hidden and not hook.Run("TTTTargetIDPlayerBlockIcon", v, client) then

--- a/gamemodes/terrortown/gamemode/cl_tbuttons.lua
+++ b/gamemodes/terrortown/gamemode/cl_tbuttons.lua
@@ -1,7 +1,11 @@
 --- Display of and interaction with ttt_traitor_button
-local surface = surface
-local pairs = pairs
+local ents = ents
+local ipairs = ipairs
 local math = math
+local net = net
+local pairs = pairs
+local surface = surface
+local table = table
 local abs = math.abs
 
 TBHUD = {}

--- a/gamemodes/terrortown/gamemode/cl_tips.lua
+++ b/gamemodes/terrortown/gamemode/cl_tips.lua
@@ -2,7 +2,15 @@
 
 CreateConVar("ttt_tips_enable", "1", FCVAR_ARCHIVE)
 
+local concommand = concommand
+local cvars = cvars
 local draw = draw
+local math = math
+local pairs = pairs
+local surface = surface
+local table = table
+local timer = timer
+local vgui = vgui
 
 TIPS = {}
 

--- a/gamemodes/terrortown/gamemode/cl_transfer.lua
+++ b/gamemodes/terrortown/gamemode/cl_transfer.lua
@@ -1,3 +1,9 @@
+local ipairs = ipairs
+local player = player
+local vgui = vgui
+
+local GetAllPlayers = player.GetAll
+
 --- Credit transfer tab for equipment menu
 local GetTranslation = LANG.GetTranslation
 function CreateTransferMenu(parent)
@@ -32,7 +38,7 @@ function CreateTransferMenu(parent)
 
     -- fill combobox
     local r = client:GetRole()
-    for _, p in ipairs(player.GetAll()) do
+    for _, p in ipairs(GetAllPlayers()) do
         if (IsValid(p) and p:IsActiveRole(r) and p ~= client) or
                 (client:IsActiveTraitorTeam() and (p:IsActiveTraitorTeam() or p:IsActiveGlitch())) or
                 (client:IsActiveMonsterTeam() and p:IsActiveMonsterTeam()) then

--- a/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -2,9 +2,24 @@
 
 DEFINE_BASECLASS("gamemode_base")
 
+local chat = chat
+local concommand = concommand
+local draw = draw
+local hook = hook
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local surface = surface
+local string = string
+local table = table
+local timer = timer
+local util = util
+local vgui = vgui
+
+local GetAllPlayers = GetAllPlayers
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
-local string = string
 
 local function GetPlayerName(ply)
     local name = ply:GetNWString("PlayerName", nil)
@@ -76,7 +91,7 @@ local function AddDetectiveText(ply, text)
 end
 
 -- Use this instead of the base class so we can control the colors and name of the player
-local function OnPlayerChat(player, strText, bTeamOnly, bPlayerIsDead)
+local function OnPlayerChat(ply, strText, bTeamOnly, bPlayerIsDead)
     local tab = {}
     if bPlayerIsDead then
         table.insert(tab, Color(255, 30, 40))
@@ -90,8 +105,8 @@ local function OnPlayerChat(player, strText, bTeamOnly, bPlayerIsDead)
         table.insert(tab, Color(0, 201, 0))
     end
 
-    if IsValid(player) then
-        table.insert(tab, GetPlayerName(player))
+    if IsValid(ply) then
+        table.insert(tab, GetPlayerName(ply))
     else
         table.insert(tab, "Console")
     end
@@ -510,7 +525,7 @@ function GM:PlayerStartVoice(ply)
             end
 
             local hasGlitch = false
-            for _, v in pairs(player.GetAll()) do
+            for _, v in pairs(GetAllPlayers()) do
                 if v:IsGlitch() then hasGlitch = true end
             end
 

--- a/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -696,7 +696,7 @@ function VOICE.Tick()
 
         if not VOICE.CanSpeak() then
             client.voice_battery = 0
-            RunConsoleCommand("-voicerecord")
+            VOICE.ToggleVoiceChat(false)
         end
     elseif client.voice_battery < battery_max then
         client.voice_battery = client.voice_battery + GetRechargeRate()
@@ -707,6 +707,21 @@ end
 function VOICE.IsSpeaking() return LocalPlayer().speaking end
 
 function VOICE.SetSpeaking(state) LocalPlayer().speaking = state end
+
+function VOICE.ToggleVoiceChat(enabled)
+    -- Use the new permissions system if it exists or otherwise fall back to the old way
+    if permissions and permissions.EnableVoiceChat then
+        permissions.EnableVoiceChat(enabled)
+    else
+        local command = "voicerecord"
+        if enabled then
+            command = "+" .. command
+        else
+            command = "-" .. command
+        end
+        RunConsoleCommand(command)
+    end
+end
 
 function VOICE.CanSpeak()
     if not GetGlobalBool("ttt_voice_drain", false) then return true end

--- a/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -696,7 +696,7 @@ function VOICE.Tick()
 
         if not VOICE.CanSpeak() then
             client.voice_battery = 0
-            VOICE.ToggleVoiceChat(false)
+            RunConsoleCommand("-voicerecord")
         end
     elseif client.voice_battery < battery_max then
         client.voice_battery = client.voice_battery + GetRechargeRate()
@@ -707,21 +707,6 @@ end
 function VOICE.IsSpeaking() return LocalPlayer().speaking end
 
 function VOICE.SetSpeaking(state) LocalPlayer().speaking = state end
-
-function VOICE.ToggleVoiceChat(enabled)
-    -- Use the new permissions system if it exists or otherwise fall back to the old way
-    if permissions and permissions.EnableVoiceChat then
-        permissions.EnableVoiceChat(enabled)
-    else
-        local command = "voicerecord"
-        if enabled then
-            command = "+" .. command
-        else
-            command = "-" .. command
-        end
-        RunConsoleCommand(command)
-    end
-end
 
 function VOICE.CanSpeak()
     if not GetGlobalBool("ttt_voice_drain", false) then return true end

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -2,8 +2,11 @@
 
 include("shared.lua")
 
-local math = math
+local concommand = concommand
 local draw = draw
+local input = input
+local math = math
+local pairs = pairs
 local surface = surface
 local table = table
 

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -5,6 +5,18 @@ CORPSE = {}
 
 include("corpse_shd.lua")
 
+local concommand = concommand
+local hook = hook
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local table = table
+local timer = timer
+local util = util
+
+local CreateEntity = ents.Create
+
 --- networked data abstraction layer
 local dti = CORPSE.dti
 
@@ -401,7 +413,7 @@ local rag_collide = CreateConVar("ttt_ragdoll_collide", "0")
 function CORPSE.Create(ply, attacker, dmginfo)
     if not IsValid(ply) then return end
 
-    local rag = ents.Create("prop_ragdoll")
+    local rag = CreateEntity("prop_ragdoll")
     if not IsValid(rag) then return nil end
 
     rag:SetPos(ply:GetPos())

--- a/gamemodes/terrortown/gamemode/equip_items_shd.lua
+++ b/gamemodes/terrortown/gamemode/equip_items_shd.lua
@@ -1,3 +1,8 @@
+local ipairs = ipairs
+local pairs = pairs
+local string = string
+local table = table
+
 -- This table is used by the client to show items in the equipment menu, and by
 -- the server to check if a certain role is allowed to buy a certain item.
 

--- a/gamemodes/terrortown/gamemode/equip_items_shd.lua
+++ b/gamemodes/terrortown/gamemode/equip_items_shd.lua
@@ -3,6 +3,8 @@ local pairs = pairs
 local string = string
 local table = table
 
+local StringLower = string.lower
+
 -- This table is used by the client to show items in the equipment menu, and by
 -- the server to check if a certain role is allowed to buy a certain item.
 
@@ -144,7 +146,7 @@ function GetEquipmentItemByName(name)
     PopulateEquipmentCache()
 
     for _, equip in pairs(EquipmentCache) do
-        if string.lower(equip.name) == string.lower(name) then
+        if StringLower(equip.name) == StringLower(name) then
             return equip
         end
     end

--- a/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -3,7 +3,6 @@
 local concommand = concommand
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -1,10 +1,17 @@
 ---- Communicating game state to players
 
+local concommand = concommand
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
 local net = net
+local pairs = pairs
 local string = string
 local table = table
-local ipairs = ipairs
-local IsValid = IsValid
+
+local GetAllPlayers = player.GetAll
 
 -- NOTE: most uses of the Msg functions here have been moved to the LANG
 -- functions. These functions are essentially deprecated, though they won't be
@@ -70,7 +77,7 @@ end
 
 -- Round start info popup
 function ShowRoundStartPopup()
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if IsValid(v) and v:Team() == TEAM_TERROR and v:Alive() then
             v:ConCommand("ttt_cl_startpopup")
         end
@@ -79,7 +86,7 @@ end
 
 function GetPlayerFilter(pred)
     local filter = {}
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if IsValid(v) and pred(v) then
             table.insert(filter, v)
         end
@@ -204,7 +211,7 @@ function GM:PlayerSay(ply, text, team_only)
             return table.concat(filtered, " ")
         elseif team_only and not team and (ply:IsTraitorTeam() or ply:IsDetectiveLike() or ply:IsMonsterTeam()) then
             local hasGlitch = false
-            for _, v in pairs(player.GetAll()) do
+            for _, v in pairs(GetAllPlayers()) do
                 if v:IsGlitch() then hasGlitch = true end
             end
             if ply:IsTraitorTeam() and hasGlitch then
@@ -267,7 +274,7 @@ function GM:PlayerCanHearPlayersVoice(listener, speaker)
     -- Traitors "team" chat by default, non-locationally
     if speaker:IsActiveTraitorTeam() then
         local hasGlitch = false
-        for _, v in pairs(player.GetAll()) do
+        for _, v in pairs(GetAllPlayers()) do
             if v:IsGlitch() then hasGlitch = true end
         end
 
@@ -315,7 +322,7 @@ local function TraitorGlobalVoice(ply, cmd, args)
     ply.traitor_gvoice = (state == 1)
 
     local hasGlitch = false
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:IsGlitch() then hasGlitch = true end
     end
 

--- a/gamemodes/terrortown/gamemode/incompatible_addons.lua
+++ b/gamemodes/terrortown/gamemode/incompatible_addons.lua
@@ -1,3 +1,5 @@
+local pairs = pairs
+
 local incompatible = {
     -- Outdated Custom Roles for TTT Versions
     ["1215502383"] = { reason = "Outdated version of Custom Roles for TTT." }, -- Custom Roles for TTT by Noxx

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -447,7 +447,7 @@ end
 -- I don't like it any more than you do, dear reader.
 function GM:SyncGlobals()
     -- For some reason hooking "SyncGlobals" directly is unreliable so... here we go
-    hook.Run("TTTSyncGlobals")
+    hook.Call("TTTSyncGlobals", nil)
 
     SetGlobalBool("ttt_detective", ttt_detective:GetBool())
     SetGlobalBool("ttt_haste", ttt_haste:GetBool())
@@ -1119,7 +1119,7 @@ local function HandleWinCondition(win)
     if win ~= WIN_TIMELIMIT then
         -- Handle role-specific checks
         local win_blocks = {}
-        hook.Run("TTTWinCheckBlocks", win_blocks)
+        hook.Call("TTTWinCheckBlocks", nil, win_blocks)
 
         for _, win_block in ipairs(win_blocks) do
             win = win_block(win)
@@ -1128,7 +1128,7 @@ local function HandleWinCondition(win)
 
     -- If, after all that, we have a win condition then end the round
     if win ~= WIN_NONE then
-        hook.Run("TTTWinCheckComplete", win)
+        hook.Call("TTTWinCheckComplete", nil, win)
 
         timer.Simple(0.5, function() EndRound(win) end) -- Slight delay to make sure alternate winners go through before scoring
     end
@@ -1351,7 +1351,7 @@ function SelectRoles()
     local choices_copy = table.Copy(choices)
     local prev_roles_copy = table.Copy(prev_roles)
 
-    hook.Run("TTTSelectRoles", choices_copy, prev_roles_copy)
+    hook.Call("TTTSelectRoles", nil, choices_copy, prev_roles_copy)
 
     local forcedTraitorCount = 0
     local forcedSpecialTraitorCount = 0
@@ -1569,7 +1569,7 @@ function SelectRoles()
     -- pick special detectives
     if max_special_detective_count > 0 then
         -- Allow external addons to modify available roles and their weights
-        hook.Run("TTTSelectRolesDetectiveOptions", specialDetectiveRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+        hook.Call("TTTSelectRolesDetectiveOptions", nil, specialDetectiveRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
 
         for _ = 1, max_special_detective_count do
             if #specialDetectiveRoles ~= 0 and math.random() <= GetConVar("ttt_special_detective_chance"):GetFloat() and #detectives > 0 then
@@ -1623,7 +1623,7 @@ function SelectRoles()
         -- pick special traitors
         if max_special_traitor_count > 0 then
             -- Allow external addons to modify available roles and their weights
-            hook.Run("TTTSelectRolesTraitorOptions", specialTraitorRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+            hook.Call("TTTSelectRolesTraitorOptions", nil, specialTraitorRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
 
             for _ = 1, max_special_traitor_count do
                 if #specialTraitorRoles ~= 0 and math.random() <= GetConVar("ttt_special_traitor_chance"):GetFloat() and #traitors > 0 then
@@ -1652,9 +1652,9 @@ function SelectRoles()
     -- pick independent
     if forcedIndependentCount == 0 and independent_count > 0 and #choices > 0 then
         -- Allow external addons to modify available roles and their weights
-        hook.Run("TTTSelectRolesIndependentOptions", independentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+        hook.Call("TTTSelectRolesIndependentOptions", nil, independentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
         if singleJesterIndependent then
-            hook.Run("TTTSelectRolesJesterOptions", independentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+            hook.Call("TTTSelectRolesJesterOptions", nil, independentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
         end
 
         if #independentRoles ~= 0 then
@@ -1674,7 +1674,7 @@ function SelectRoles()
 
     -- pick jester
     if not singleJesterIndependent and forcedJesterCount == 0 and jester_count > 0 and #choices > 0 then
-        hook.Run("TTTSelectRolesJesterOptions", jesterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+        hook.Call("TTTSelectRolesJesterOptions", nil, jesterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
 
         if #jesterRoles ~= 0 then
             local plyPick = math.random(1, #choices)
@@ -1703,7 +1703,7 @@ function SelectRoles()
         end
 
         -- Allow external addons to modify available roles and their weights
-        hook.Run("TTTSelectRolesInnocentOptions", specialInnocentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+        hook.Call("TTTSelectRolesInnocentOptions", nil, specialInnocentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
 
         for _ = 1, max_special_innocent_count do
             if #specialInnocentRoles ~= 0 and math.random() <= GetConVar("ttt_special_innocent_chance"):GetFloat() and #choices > 0 then
@@ -1734,7 +1734,7 @@ function SelectRoles()
         local monster_chosen = false
         for _ = 1, monster_count do
             -- Allow external addons to modify available roles and their weights
-            hook.Run("TTTSelectRolesMonsterOptions", monsterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+            hook.Call("TTTSelectRolesMonsterOptions", nil, monsterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
 
             if #monsterRoles ~= 0 and math.random() <= GetConVar("ttt_monster_chance"):GetFloat() and #choices > 0 and not monster_chosen then
                 local plyPick = math.random(1, #choices)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -798,7 +798,7 @@ function TellTraitorsAboutTraitors()
                         names = names .. name .. ", "
                     end
                 end
-                names = string.sub(names, 1, -3)
+                names = utf8.sub(names, 1, -3)
                 LANG.Msg(v, "round_traitors_more", { role = ROLE_STRINGS[ROLE_TRAITOR], names = names })
             end
         end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -77,6 +77,10 @@ local timer = timer
 local util = util
 
 local GetAllPlayers = player.GetAll
+local StringLower = string.lower
+local StringUpper = string.upper
+local StringSub = string.sub
+local StringStartsWith = string.StartWith
 
 -- Round times
 CreateConVar("ttt_roundtime_minutes", "10", FCVAR_NOTIFY)
@@ -1024,7 +1028,7 @@ function PrintResultMessage(type)
             ServerLog("Result: Monsters win.\n")
         else
             local plural = ROLE_STRINGS_PLURAL[monster_role]
-            LANG.Msg("win_" .. string.lower(plural), { role = plural })
+            LANG.Msg("win_" .. StringLower(plural), { role = plural })
             ServerLog("Result: " .. plural .. " win.\n")
         end
     else
@@ -1039,7 +1043,7 @@ function CheckForMapSwitch()
 
     local time_left = math.max(0, (GetConVar("ttt_time_limit_minutes"):GetInt() * 60) - CurTime())
     local switchmap = false
-    local nextmap = string.upper(game.GetMapNext())
+    local nextmap = StringUpper(game.GetMapNext())
 
     if rounds_left <= 0 then
         LANG.Msg("limit_round", { mapname = nextmap })
@@ -1834,13 +1838,13 @@ hook.Add("ScaleNPCDamage", "HitmarkerPlayerCritDetector", function(npc, hitgroup
 end)
 
 hook.Add("PlayerSay", "ColorMixerOpen", function(ply, text, team_only)
-    text = string.lower(text)
-    if (string.sub(text, 1, 12) == "!hmcritcolor") then
+    text = StringLower(text)
+    if (StringSub(text, 1, 12) == "!hmcritcolor") then
         net.Start("TTT_OpenMixer")
         net.WriteBool(true)
         net.Send(ply)
         return false
-    elseif (string.sub(text, 1, 8) == "!hmcolor") then
+    elseif (StringSub(text, 1, 8) == "!hmcolor") then
         net.Start("TTT_OpenMixer")
         net.WriteBool(false)
         net.Send(ply)
@@ -1860,7 +1864,7 @@ hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, entity, killer
         elseif killer == victim then
             reason = "suicide"
         elseif IsValid(entity) then
-            if victim:IsPlayer() and (string.StartWith(entity:GetClass(), "prop_physics") or entity:GetClass() == "prop_dynamic") then
+            if victim:IsPlayer() and (StringStartsWith(entity:GetClass(), "prop_physics") or entity:GetClass() == "prop_dynamic") then
                 -- If the killer is also a prop
                 reason = "prop"
             elseif IsValid(killer) then
@@ -1934,18 +1938,18 @@ function HandleRoleEquipment()
             local norandom = false
             -- Extract the weapon name from the file name
             local lastdotpos = v:find("%.")
-            local weaponname = string.sub(v, 0, lastdotpos - 1)
+            local weaponname = StringSub(v, 0, lastdotpos - 1)
 
             -- Check that there isn't a two-part extension (e.g. "something.exclude.txt")
-            local extension = string.sub(v, lastdotpos + 1, #v)
+            local extension = StringSub(v, lastdotpos + 1, #v)
             lastdotpos = extension:find("%.")
 
             -- If there is, check if it equals "exclude"
             if lastdotpos ~= nil then
-                extension = string.sub(extension, 0, lastdotpos - 1)
-                if string.lower(extension) == "exclude" then
+                extension = StringSub(extension, 0, lastdotpos - 1)
+                if StringLower(extension) == "exclude" then
                     exclude = true
-                elseif string.lower(extension) == "norandom" then
+                elseif StringLower(extension) == "norandom" then
                     norandom = true
                 end
             end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -65,7 +65,6 @@ local ents = ents
 local file = file
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/karma.lua
+++ b/gamemodes/terrortown/gamemode/karma.lua
@@ -3,7 +3,6 @@
 local cvars = cvars
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 

--- a/gamemodes/terrortown/gamemode/karma.lua
+++ b/gamemodes/terrortown/gamemode/karma.lua
@@ -1,5 +1,14 @@
 ---- Karma system stuff
 
+local cvars = cvars
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+
+local GetAllPlayers = player.GetAll
+
 KARMA = {}
 
 -- ply steamid -> karma table for disconnected players who might reconnect
@@ -35,8 +44,6 @@ KARMA.cv.bantime = CreateConVar("ttt_karma_low_ban_minutes", "60")
 local config = KARMA.cv
 
 local function IsDebug() return config.debug:GetBool() end
-
-local math = math
 
 cvars.AddChangeCallback("ttt_karma_max", function(cvar, old, new)
     SetGlobalInt("ttt_karma_max", new)
@@ -238,7 +245,7 @@ function KARMA.RoundIncrement()
     local healbonus = config.roundheal:GetFloat()
     local cleanbonus = config.clean:GetFloat()
 
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         if ply:IsDeadTerror() and ply.death_type ~= KILL_SUICIDE or not ply:IsSpec() then
             local bonus = healbonus + (ply:GetCleanRound() and math.Clamp(math.floor(cleanbonus * config.cleanmult:GetFloat() ^ (ply:GetCleanRounds() - 1)), 0, config.cleanmax:GetFloat()) or 0)
             KARMA.GiveReward(ply, bonus)
@@ -254,7 +261,7 @@ end
 
 -- When a new round starts, Live karma becomes Base karma
 function KARMA.Rebase()
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         if IsDebug() then
             print(ply, "rebased from", ply:GetBaseKarma(), "to", ply:GetLiveKarma())
         end
@@ -265,7 +272,7 @@ end
 
 -- Apply karma to damage factor for all players
 function KARMA.ApplyKarmaAll()
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         KARMA.ApplyKarma(ply)
     end
 end
@@ -304,7 +311,7 @@ function KARMA.RoundBegin()
     KARMA.InitState()
 
     if KARMA.IsEnabled() then
-        for _, ply in ipairs(player.GetAll()) do
+        for _, ply in ipairs(GetAllPlayers()) do
             KARMA.ApplyKarma(ply)
 
             KARMA.NotifyPlayer(ply)
@@ -363,7 +370,7 @@ function KARMA.LateRecallAndSet(ply)
 end
 
 function KARMA.RememberAll()
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         KARMA.Remember(ply)
     end
 end
@@ -395,13 +402,13 @@ function KARMA.CheckAutoKick(ply)
 end
 
 function KARMA.CheckAutoKickAll()
-   for _, ply in ipairs(player.GetAll()) do
+   for _, ply in ipairs(GetAllPlayers()) do
       KARMA.CheckAutoKick(ply)
    end
 end
 
 function KARMA.PrintAll(printfn)
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         printfn(Format("%s : Live = %f -- Base = %f -- Dmg = %f\n",
                 ply:Nick(),
                 ply:GetLiveKarma(), ply:GetBaseKarma(),

--- a/gamemodes/terrortown/gamemode/karma.lua
+++ b/gamemodes/terrortown/gamemode/karma.lua
@@ -1,11 +1,12 @@
 ---- Karma system stuff
 
 local cvars = cvars
-local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
 local math = math
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetAllPlayers = player.GetAll
 
 KARMA = {}
@@ -80,7 +81,7 @@ function KARMA.GetKillReward()
 end
 
 function KARMA.GivePenalty(ply, penalty, victim)
-    if not hook.Call("TTTKarmaGivePenalty", nil, ply, penalty, victim) then
+    if not CallHook("TTTKarmaGivePenalty", nil, ply, penalty, victim) then
         ply:SetLiveKarma(math.max(ply:GetLiveKarma() - penalty, 0))
         ply:SetCleanRound(false)
         ply:SetCleanRounds(0)
@@ -90,7 +91,7 @@ function KARMA.GivePenalty(ply, penalty, victim)
 end
 
 function KARMA.GiveReward(ply, reward, victim)
-    if not hook.Call("TTTKarmaGiveReward", nil, ply, reward, victim) then
+    if not CallHook("TTTKarmaGiveReward", nil, ply, reward, victim) then
         reward = KARMA.DecayedMultiplier(ply) * reward
         ply:SetLiveKarma(math.min(ply:GetLiveKarma() + reward, config.max:GetFloat()))
         return reward
@@ -133,7 +134,7 @@ local function WasAvoidable(attacker, victim, dmginfo)
 end
 
 local function ShouldReduceKarma(attacker, victim)
-    local result = hook.Call("TTTKarmaShouldGivePenalty", nil, attacker, victim)
+    local result = CallHook("TTTKarmaShouldGivePenalty", nil, attacker, victim)
     if type(result) == "boolean" then
         return result
     end
@@ -377,7 +378,7 @@ end
 local reason = "Karma too low"
 function KARMA.CheckAutoKick(ply)
     if ply:GetBaseKarma() <= config.kicklevel:GetInt() then
-        if hook.Call("TTTKarmaLow", GAMEMODE, ply) == false then
+        if RunHook("TTTKarmaLow", ply) == false then
             return
         end
         ServerLog(ply:Nick() .. " autokicked/banned for low karma.\n")

--- a/gamemodes/terrortown/gamemode/karma.lua
+++ b/gamemodes/terrortown/gamemode/karma.lua
@@ -133,7 +133,7 @@ local function WasAvoidable(attacker, victim, dmginfo)
 end
 
 local function ShouldReduceKarma(attacker, victim)
-    local result = hook.Run("TTTKarmaShouldGivePenalty", attacker, victim)
+    local result = hook.Call("TTTKarmaShouldGivePenalty", nil, attacker, victim)
     if type(result) == "boolean" then
         return result
     end

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -1339,8 +1339,9 @@ function GM:PlayerShouldTaunt(ply, actid)
 end
 
 local function GetTargetPlayerByName(ply, name)
+    name = string.lower(name)
     for _, v in RandomPairs(GetAllPlayers()) do
-        if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= ply and v:Nick() == name then
+        if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= ply and string.lower(v:Nick()) == name then
             return v
         end
     end

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -1,7 +1,6 @@
 ---- Player spawning/dying
 
 local concommand = concommand
-local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
 local math = math
@@ -12,6 +11,8 @@ local table = table
 local timer = timer
 local util = util
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetAllPlayers = player.GetAll
 local CreateEntity = ents.Create
 local FindEntsInBox = ents.FindInBox
@@ -104,12 +105,12 @@ function GM:PlayerSpawn(ply)
             end
         end
     else
-        hook.Call("PlayerLoadout", GAMEMODE, ply)
+        RunHook("PlayerLoadout", ply)
     end
 
     -- ye olde hooks
-    hook.Call("PlayerSetModel", GAMEMODE, ply)
-    hook.Call("TTTPlayerSetColor", GAMEMODE, ply)
+    RunHook("PlayerSetModel", ply)
+    RunHook("TTTPlayerSetColor", ply)
 
     ply:SetupHands()
 
@@ -358,7 +359,7 @@ function GM:KeyPress(ply, key)
         if ply:ShouldShowSpectatorHUD() then
             local tgt = ply:GetObserverTarget()
             local powers = {}
-            local skip, power_property = hook.Call("TTTSpectatorHUDKeyPress", nil, ply, tgt, powers)
+            local skip, power_property = CallHook("TTTSpectatorHUDKeyPress", nil, ply, tgt, powers)
             if power_property then
                 -- Get the player's current power and make sure they can do something with the key the pressed
                 local current_power = ply:GetNWInt(power_property, 0)
@@ -1286,7 +1287,7 @@ function GM:Tick()
                 ply.scanner_weapon:Think()
             end
 
-            hook.Call("TTTPlayerAliveThink", nil, ply)
+            CallHook("TTTPlayerAliveThink", nil, ply)
         elseif tm == TEAM_SPEC then
             if ply.propspec then
                 PROPSPEC.Recharge(ply)

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -1,10 +1,22 @@
 ---- Player spawning/dying
 
+local concommand = concommand
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
 local math = math
-local table = table
-local player = player
-local timer = timer
+local net = net
 local pairs = pairs
+local string = string
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+local CreateEntity = ents.Create
+local FindEntsInBox = ents.FindInBox
+local FindEntsByClass = ents.FindByClass
 
 CreateConVar("ttt_bots_are_spectators", "0", FCVAR_ARCHIVE)
 CreateConVar("ttt_dyingshot", "0")
@@ -41,7 +53,7 @@ end
 
 function GM:NetworkIDValidated(name, steamid)
     -- edge case where player authed after initspawn
-    for _, p in ipairs(player.GetAll()) do
+    for _, p in ipairs(GetAllPlayers()) do
         if IsValid(p) and p:SteamID() == steamid and p.delay_karma_recall then
             KARMA.LateRecallAndSet(p)
             return
@@ -131,7 +143,7 @@ function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
 
     if not util.IsInWorld(pos) then return false end
 
-    local blocking = ents.FindInBox(pos + Vector(-16, -16, 0), pos + Vector(16, 16, 64))
+    local blocking = FindEntsInBox(pos + Vector(-16, -16, 0), pos + Vector(16, 16, 64))
 
     for _, p in ipairs(blocking) do
         if IsPlayer(p) and p:IsTerror() and p:Alive() then
@@ -154,7 +166,7 @@ local SpawnTypes = { "info_player_deathmatch", "info_player_combine",
 function GetSpawnEnts(shuffled, force_all)
     local tbl = {}
     for k, classname in ipairs(SpawnTypes) do
-        for _, e in ipairs(ents.FindByClass(classname)) do
+        for _, e in ipairs(FindEntsByClass(classname)) do
             if IsValid(e) and (not e.BeingRemoved) then
                 table.insert(tbl, e)
             end
@@ -165,7 +177,7 @@ function GetSpawnEnts(shuffled, force_all)
     -- uses it for observer starts that are in places where players cannot really
     -- spawn well. At all.
     if force_all or #tbl == 0 then
-        for _, e in ipairs(ents.FindByClass("info_player_start")) do
+        for _, e in ipairs(FindEntsByClass("info_player_start")) do
             if IsValid(e) and (not e.BeingRemoved) then
                 table.insert(tbl, e)
             end
@@ -241,7 +253,7 @@ function GM:PlayerSelectSpawn(ply)
         local rigged = PointsAroundSpawn(spwn)
         for _, rig in pairs(rigged) do
             if self:IsSpawnpointSuitable(ply, rig, false, true) then
-                local rig_spwn = ents.Create("info_player_terrorist")
+                local rig_spwn = CreateEntity("info_player_terrorist")
                 if IsValid(rig_spwn) then
                     rig_spwn:SetPos(rig)
                     rig_spwn:Spawn()
@@ -563,7 +575,7 @@ local function CheckCreditAward(victim, attacker)
 
         -- If size is 0, awards are off
         if amt > 0 then
-            for _, ply in ipairs(player.GetAll()) do
+            for _, ply in ipairs(GetAllPlayers()) do
                 if ply:IsActiveDetectiveTeam() or (ply:IsActiveDeputy() and ply:IsRoleActive()) then
                     ply:AddCredits(amt)
                 end
@@ -579,7 +591,7 @@ local function CheckCreditAward(victim, attacker)
         local inno_dead = 0
         local inno_total = 0
 
-        for _, ply in ipairs(player.GetAll()) do
+        for _, ply in ipairs(GetAllPlayers()) do
             if not ply:IsTraitorTeam() then
                 if ply:IsTerror() then
                     inno_alive = inno_alive + 1
@@ -616,7 +628,7 @@ local function CheckCreditAward(victim, attacker)
                 end
                 LANG.Msg(GetPlayerFilter(predicate), "credit_all", { role = ROLE_STRINGS_PLURAL[ROLE_TRAITOR], num = amt })
 
-                for _, ply in ipairs(player.GetAll()) do
+                for _, ply in ipairs(GetAllPlayers()) do
                     if predicate(ply) then
                         ply:AddCredits(amt)
                     end
@@ -827,7 +839,7 @@ function GM:SpectatorThink(ply)
             ply:Spectate(OBS_MODE_ROAMING)
 
             -- move to spectator spawn if mapper defined any
-            local spec_spawns = ents.FindByClass("ttt_spectator_spawn")
+            local spec_spawns = FindEntsByClass("ttt_spectator_spawn")
             if spec_spawns and #spec_spawns > 0 then
                 local spawn = table.Random(spec_spawns)
                 ply:SetPos(spawn:GetPos())
@@ -1235,7 +1247,7 @@ function GM:OnNPCKilled() end
 -- Drowning and such
 function GM:Tick()
     -- three cheers for micro-optimizations
-    local plys = player.GetAll()
+    local plys = GetAllPlayers()
     local tm = nil
     local ply = nil
     for i = 1, #plys do
@@ -1328,7 +1340,7 @@ function GM:PlayerShouldTaunt(ply, actid)
 end
 
 local function GetTargetPlayerByName(ply, name)
-    for _, v in RandomPairs(player.GetAll()) do
+    for _, v in RandomPairs(GetAllPlayers()) do
         if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= ply and v:Nick() == name then
             return v
         end
@@ -1336,7 +1348,7 @@ local function GetTargetPlayerByName(ply, name)
 end
 
 local function GetRandomTargetPlayer(ply)
-    for _, v in RandomPairs(player.GetAll()) do
+    for _, v in RandomPairs(GetAllPlayers()) do
         if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= ply and not v:ShouldActLikeJester() then
             return v
         end
@@ -1365,7 +1377,7 @@ local function PlayerAutoComplete(cmd, args)
 
     -- Find player options that match the given value (or all if there is no given value)
     local options = {}
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if #name == 0 or string.find(string.lower(v:Nick()), name) then
             table.insert(options, cmd .. other_args .. " \"" .. v:Nick() .. "\"")
         end

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -3,7 +3,6 @@
 local concommand = concommand
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -358,7 +358,7 @@ function GM:KeyPress(ply, key)
         if ply:ShouldShowSpectatorHUD() then
             local tgt = ply:GetObserverTarget()
             local powers = {}
-            local skip, power_property = hook.Run("TTTSpectatorHUDKeyPress", ply, tgt, powers)
+            local skip, power_property = hook.Call("TTTSpectatorHUDKeyPress", nil, ply, tgt, powers)
             if power_property then
                 -- Get the player's current power and make sure they can do something with the key the pressed
                 local current_power = ply:GetNWInt(power_property, 0)
@@ -1286,7 +1286,7 @@ function GM:Tick()
                 ply.scanner_weapon:Think()
             end
 
-            hook.Run("TTTPlayerAliveThink", ply)
+            hook.Call("TTTPlayerAliveThink", nil, ply)
         elseif tm == TEAM_SPEC then
             if ply.propspec then
                 PROPSPEC.Recharge(ply)

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -12,6 +12,18 @@ if not entmeta then
     return
 end
 
+local concommand = concommand
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local table = table
+local timer = timer
+local weapons = weapons
+
 function plymeta:SetRagdollSpec(s)
     if s then
         self.spec_ragdoll_start = CurTime()

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -15,7 +15,6 @@ end
 local concommand = concommand
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -25,7 +25,7 @@ local oldSetRole = plymeta.SetRole
 function plymeta:SetRole(role)
     local oldRole = self:GetRole()
     oldSetRole(self, role)
-    hook.Run("TTTPlayerRoleChanged", self, oldRole, role)
+    hook.Call("TTTPlayerRoleChanged", nil, self, oldRole, role)
 end
 
 -- Player is alive and in an active round

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -3,7 +3,18 @@
 local plymeta = FindMetaTable("Player")
 if not plymeta then return end
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
 local math = math
+local net = net
+local string = string
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
 
 function plymeta:IsTerror() return self:Team() == TEAM_TERROR end
 function plymeta:IsSpec() return self:Team() == TEAM_SPEC end
@@ -519,7 +530,7 @@ function player.GetRoleTeam(role, detectivesAreInnocent)
 end
 
 function player.GetLivingRole(role)
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:Alive() and v:IsTerror() and v:IsRole(role) then
             return v
         end
@@ -534,7 +545,7 @@ function player.TeamLivingCount(ignorePassiveWinners)
     local indep_alive = 0
     local monster_alive = 0
     local jester_alive = 0
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         -- If the player is alive
         if v:Alive() and v:IsTerror() then
             -- If we're either not ignoring passive winners or this isn't a passive winning role
@@ -570,7 +581,7 @@ function player.AreTeamsLiving(ignorePassiveWinners)
 end
 
 function player.ExecuteAgainstTeamPlayers(roleTeam, detectivesAreInnocent, aliveOnly, callback)
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if not aliveOnly or (v:Alive() and v:IsTerror()) then
             local playerTeam = player.GetRoleTeam(v:GetRole(), detectivesAreInnocent)
             if playerTeam == roleTeam then
@@ -590,7 +601,7 @@ end
 
 function player.LivingCount(ignorePassiveWinners)
     local players_alive = 0
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         -- If the player is alive and we're either not ignoring passive winners or this isn't a passive winning role
         if (v:Alive() and v:IsTerror() and (not ignorePassiveWinners or not ROLE_HAS_PASSIVE_WIN[v:GetRole()])) or
             -- Handle zombification differently because the player's original role should have no impact on this

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -5,7 +5,6 @@ if not plymeta then return end
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -3,7 +3,6 @@
 local plymeta = FindMetaTable("Player")
 if not plymeta then return end
 
-local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
 local math = math
@@ -13,6 +12,7 @@ local table = table
 local timer = timer
 local util = util
 
+local CallHook = hook.Call
 local GetAllPlayers = player.GetAll
 local MathAbs = math.abs
 
@@ -25,7 +25,7 @@ local oldSetRole = plymeta.SetRole
 function plymeta:SetRole(role)
     local oldRole = self:GetRole()
     oldSetRole(self, role)
-    hook.Call("TTTPlayerRoleChanged", nil, self, oldRole, role)
+    CallHook("TTTPlayerRoleChanged", nil, self, oldRole, role)
 end
 
 -- Player is alive and in an active round

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -14,6 +14,7 @@ local timer = timer
 local util = util
 
 local GetAllPlayers = player.GetAll
+local MathAbs = math.abs
 
 function plymeta:IsTerror() return self:Team() == TEAM_TERROR end
 function plymeta:IsSpec() return self:Team() == TEAM_SPEC end
@@ -328,7 +329,7 @@ if CLIENT then
                 local matrix = self:GetBoneMatrix(headId)
                 if matrix then
                     local translation = matrix:GetTranslation()
-                    local diff = math.abs(max_bone_z - translation.z)
+                    local diff = MathAbs(max_bone_z - translation.z)
                     -- Scale the difference by the head scale
                     max_bone_z = max_bone_z + (diff * headScale.z)
                 end

--- a/gamemodes/terrortown/gamemode/radar.lua
+++ b/gamemodes/terrortown/gamemode/radar.lua
@@ -3,7 +3,16 @@
 -- should mirror client
 local chargetime = 30
 
+local concommand = concommand
+local ipairs = ipairs
+local IsValid = IsValid
 local math = math
+local net = net
+local player = player
+local table = table
+
+local GetAllPlayers = player.GetAll
+local FindEntsByClass = ents.FindByClass
 
 local function RadarScan(ply, cmd, args)
     if IsValid(ply) and ply:IsTerror() then
@@ -16,8 +25,8 @@ local function RadarScan(ply, cmd, args)
 
             ply.radar_charge = CurTime() + chargetime
 
-            local scan_ents = player.GetAll()
-            table.Add(scan_ents, ents.FindByClass("ttt_decoy"))
+            local scan_ents = GetAllPlayers()
+            table.Add(scan_ents, FindEntsByClass("ttt_decoy"))
 
             local targets = {}
             for _, p in ipairs(scan_ents) do

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -1,5 +1,15 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local table = table
+local timer = timer
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -59,7 +69,7 @@ function AssignAssassinTarget(ply, start, delay)
         end
     end
 
-    for _, p in pairs(player.GetAll()) do
+    for _, p in pairs(GetAllPlayers()) do
         if p:Alive() and not p:IsSpec() then
             -- Include all non-traitor detective-like players
             if p:IsDetectiveLike() and not p:IsTraitorTeam() then
@@ -151,7 +161,7 @@ hook.Add("DoPlayerDeath", "Assassin_DoPlayerDeath", function(ply, attacker, dmgi
         attacker:SetNWBool("AssassinFailed", true)
     end
 
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         local assassintarget = v:GetNWString("AssassinTarget", "")
         if v:IsAssassin() and ply:Nick() == assassintarget then
             -- Reset the target to clear the target overlay from the scoreboard
@@ -182,7 +192,7 @@ end)
 
 -- Clear the assassin target information when the next round starts
 hook.Add("TTTPrepareRound", "Assassin_Smoke_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWString("AssassinTarget", "")
         v:SetNWBool("AssassinFailed", false)
         v:SetNWBool("AssassinComplete", false)

--- a/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
@@ -1,3 +1,12 @@
+local halo = halo
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local pairs = pairs
+local string = string
+
+local GetAllPlayers = player.GetAll
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -75,10 +84,10 @@ local client = nil
 local function EnableAssassinTargetHighlights()
     hook.Add("PreDrawHalos", "Assassin_Highlight_PreDrawHalos", function()
         local target_nick = client:GetNWString("AssassinTarget", "")
-        if not target_nick or target_nick:len() == 0 then return end
+        if not target_nick or #target_nick == 0 then return end
 
         local target = nil
-        for _, v in pairs(player.GetAll()) do
+        for _, v in pairs(GetAllPlayers()) do
             if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= client and v:Nick() == target_nick then
                 target = v
                 break

--- a/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
@@ -1,6 +1,5 @@
 local halo = halo
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local pairs = pairs
 local string = string

--- a/gamemodes/terrortown/gamemode/roles/assassin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 ROLE_SHOULD_DELAY_ANNOUNCEMENTS[ROLE_ASSASSIN] = true
 

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -1,5 +1,16 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_BeggarConverted")
 util.AddNetworkString("TTT_BeggarKilled")
 
@@ -51,7 +62,7 @@ hook.Add("WeaponEquip", "Beggar_WeaponEquip", function(wep, ply)
         ply:PrintMessage(HUD_PRINTCENTER, "You have joined the " .. ROLE_STRINGS[role] .. " team")
         timer.Simple(0.5, function() SendFullStateUpdate() end) -- Slight delay to avoid flickering from beggar to the new role and back to beggar
 
-        for _, v in ipairs(player.GetAll()) do
+        for _, v in ipairs(GetAllPlayers()) do
             if beggarMode == BEGGAR_REVEAL_ALL or (v:IsActiveTraitorTeam() and beggarMode == BEGGAR_REVEAL_TRAITORS) or (not v:IsActiveTraitorTeam() and beggarMode == BEGGAR_REVEAL_INNOCENTS) then
                 v:PrintMessage(HUD_PRINTTALK, "The beggar has joined the " .. ROLE_STRINGS[role] .. " team")
                 v:PrintMessage(HUD_PRINTCENTER, "The beggar has joined the " .. ROLE_STRINGS[role] .. " team")
@@ -69,7 +80,7 @@ end)
 
 -- Disable tracking that this player was a beggar at the start of a new round or if their role changes again (e.g. if they go beggar -> innocent -> dead -> hypnotist res to traitor)
 hook.Add("TTTPrepareRound", "Beggar_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("WasBeggar", false)
         timer.Remove(v:Nick() .. "BeggarRespawn")
     end

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/beggar/cl_beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/cl_beggar.lua
@@ -1,3 +1,8 @@
+local hook = hook
+local net = net
+local surface = surface
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -118,15 +123,15 @@ end)
 --------------
 
 local function GetRevealModeString(roleColor, revealMode, teamName, teamColor)
-    local modeString = "When joining the <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>" .. teamName:lower() .. "</span> team, the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_BEGGAR] .. "</span>'s new role will be revealed to "
+    local modeString = "When joining the <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>" .. string.lower(teamName) .. "</span> team, the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_BEGGAR] .. "</span>'s new role will be revealed to "
     if revealMode == BEGGAR_REVEAL_ALL then
         modeString = modeString .. "everyone"
     elseif revealMode == BEGGAR_REVEAL_TRAITORS then
         local revealColor = ROLE_COLORS[ROLE_TRAITOR]
-        modeString = modeString .. "only <span style='color: rgb(" .. revealColor.r .. ", " .. revealColor.g .. ", " .. revealColor.b .. ")'>" .. LANG.GetTranslation("traitors"):lower() .. "</span>"
+        modeString = modeString .. "only <span style='color: rgb(" .. revealColor.r .. ", " .. revealColor.g .. ", " .. revealColor.b .. ")'>" .. string.lower(LANG.GetTranslation("traitors")) .. "</span>"
     elseif revealMode == BEGGAR_REVEAL_INNOCENTS then
         local revealColor = ROLE_COLORS[ROLE_TRAITOR]
-        modeString = modeString .. "only <span style='color: rgb(" .. revealColor.r .. ", " .. revealColor.g .. ", " .. revealColor.b .. ")'>" .. LANG.GetTranslation("innocents"):lower() .. "</span>"
+        modeString = modeString .. "only <span style='color: rgb(" .. revealColor.r .. ", " .. revealColor.g .. ", " .. revealColor.b .. ")'>" .. string.lower(LANG.GetTranslation("innocents")) .. "</span>"
     else
         modeString = modeString .. "nobody"
     end

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
@@ -1,5 +1,15 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_BodysnatcherKilled")
 
 -------------
@@ -37,7 +47,7 @@ end)
 
 -- Disable tracking that this player was a bodysnatcher at the start of a new round or if their role changes again (e.g. if they go bodysnatcher -> innocent -> dead -> hypnotist res to traitor)
 hook.Add("TTTPrepareRound", "Bodysnatcher_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("WasBodysnatcher", false)
         timer.Remove(v:Nick() .. "BodysnatcherRespawn")
     end

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/cl_bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/cl_bodysnatcher.lua
@@ -1,3 +1,8 @@
+local hook = hook
+local net = net
+local surface = surface
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -118,7 +123,7 @@ end)
 --------------
 
 local function GetRevealModeString(roleColor, revealMode, teamName, teamColor)
-    local modeString = "When joining the <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>" .. teamName:lower() .. "</span> team, the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_BODYSNATCHER] .. "</span>'s new role will be revealed to "
+    local modeString = "When joining the <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>" .. string.lower(teamName) .. "</span> team, the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_BODYSNATCHER] .. "</span>'s new role will be revealed to "
     if revealMode == BODYSNATCHER_REVEAL_ALL then
         modeString = modeString .. "everyone"
     elseif revealMode == BODYSNATCHER_REVEAL_TEAM then

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Bodysnatcher reveal modes
 BODYSNATCHER_REVEAL_NONE = 0
 BODYSNATCHER_REVEAL_ALL = 1

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -1,3 +1,8 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local net = net
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -52,7 +57,7 @@ hook.Add("TTTTargetIDPlayerText", "Clown_TTTTargetIDPlayerText", function(ent, c
     if GetRoundState() < ROUND_ACTIVE then return end
 
     if IsClownVisible(ent) then
-        return ROLE_STRINGS[ROLE_CLOWN]:upper(), ROLE_COLORS_RADAR[ROLE_CLOWN]
+        return string.upper(ROLE_STRINGS[ROLE_CLOWN]), ROLE_COLORS_RADAR[ROLE_CLOWN]
     end
 end)
 
@@ -105,7 +110,7 @@ end)
 
 hook.Add("TTTScoringWinTitle", "Clown_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
     if wintype == WIN_CLOWN then
-        return { txt = "hilite_win_role_singular", params = { role = ROLE_STRINGS[ROLE_CLOWN]:upper() }, c = ROLE_COLORS[ROLE_JESTER] }
+        return { txt = "hilite_win_role_singular", params = { role = string.upper(ROLE_STRINGS[ROLE_CLOWN]) }, c = ROLE_COLORS[ROLE_JESTER] }
     end
 end)
 
@@ -115,7 +120,7 @@ end)
 
 hook.Add("TTTEventFinishText", "Clown_TTTEventFinishText", function(e)
     if e.win == WIN_CLOWN then
-        return LANG.GetParamTranslation("ev_win_clown", { role = ROLE_STRINGS[ROLE_CLOWN]:lower() })
+        return LANG.GetParamTranslation("ev_win_clown", { role = string.lower(ROLE_STRINGS[ROLE_CLOWN]) })
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -2,6 +2,8 @@ local hook = hook
 local net = net
 local string = string
 
+local StringUpper = string.upper
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -56,7 +58,7 @@ hook.Add("TTTTargetIDPlayerText", "Clown_TTTTargetIDPlayerText", function(ent, c
     if GetRoundState() < ROUND_ACTIVE then return end
 
     if IsClownVisible(ent) then
-        return string.upper(ROLE_STRINGS[ROLE_CLOWN]), ROLE_COLORS_RADAR[ROLE_CLOWN]
+        return StringUpper(ROLE_STRINGS[ROLE_CLOWN]), ROLE_COLORS_RADAR[ROLE_CLOWN]
     end
 end)
 
@@ -109,7 +111,7 @@ end)
 
 hook.Add("TTTScoringWinTitle", "Clown_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
     if wintype == WIN_CLOWN then
-        return { txt = "hilite_win_role_singular", params = { role = string.upper(ROLE_STRINGS[ROLE_CLOWN]) }, c = ROLE_COLORS[ROLE_JESTER] }
+        return { txt = "hilite_win_role_singular", params = { role = StringUpper(ROLE_STRINGS[ROLE_CLOWN]) }, c = ROLE_COLORS[ROLE_JESTER] }
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local net = net
 local string = string
 

--- a/gamemodes/terrortown/gamemode/roles/clown/clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/clown.lua
@@ -1,5 +1,16 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local net = net
+local pairs = pairs
+local player = player
+local resource = resource
+local table = table
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_ClownActivate")
 
 resource.AddSingleFile("sound/clown.wav")
@@ -99,7 +110,7 @@ end)
 
 -- Disable tracking that this player was is the active clown at the start of a new round or if their role changes
 hook.Add("TTTPrepareRound", "Clown_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("KillerClownActive", false)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/clown/clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/clown.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local net = net
 local pairs = pairs
 local player = player

--- a/gamemodes/terrortown/gamemode/roles/deputy/cl_deputy.lua
+++ b/gamemodes/terrortown/gamemode/roles/deputy/cl_deputy.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/deputy/deputy.lua
+++ b/gamemodes/terrortown/gamemode/roles/deputy/deputy.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -------------
 -- CONVARS --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/deputy/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/deputy/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 
 -- HandleDetectiveLikePromotion and ROLE_MOVE_ROLE_STATE are defined in detectivelike/shared.lua

--- a/gamemodes/terrortown/gamemode/roles/detective/cl_detective.lua
+++ b/gamemodes/terrortown/gamemode/roles/detective/cl_detective.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/detective/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/detective/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_DETECTIVE] = {

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
@@ -1,3 +1,7 @@
+local hook = hook
+local net = net
+local surface = surface
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
@@ -1,5 +1,12 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local pairs = pairs
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_Promotion")
 
 -- Server-side functions shared by detective-like roles (Deputy, Impersonator)
@@ -10,7 +17,7 @@ util.AddNetworkString("TTT_Promotion")
 
 function ShouldPromoteDetectiveLike()
     local alive, dead = 0, 0
-    for _, p in ipairs(player.GetAll()) do
+    for _, p in ipairs(GetAllPlayers()) do
         if p:IsDetectiveTeam() then
             if not p:IsSpec() and p:Alive() then
                 alive = alive + 1
@@ -42,14 +49,14 @@ ROLE_ON_ROLE_ASSIGNED[ROLE_DEPUTY] = BeginRoleChecks
 ROLE_ON_ROLE_ASSIGNED[ROLE_IMPERSONATOR] = BeginRoleChecks
 
 hook.Add("TTTPrepareRound", "DetectiveLike_RoleState_TTTPrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("HasPromotion", false)
     end
 end)
 
 hook.Add("PlayerDeath", "DetectiveLike_RoleState_PlayerDeath", function(victim, infl, attacker)
     if victim:IsDetectiveTeam() and GetRoundState() == ROUND_ACTIVE and ShouldPromoteDetectiveLike() then
-        for _, ply in pairs(player.GetAll()) do
+        for _, ply in pairs(GetAllPlayers()) do
             if ply:IsDetectiveLikePromotable() then
                 local alive = ply:Alive()
                 if alive then
@@ -59,7 +66,7 @@ hook.Add("PlayerDeath", "DetectiveLike_RoleState_PlayerDeath", function(victim, 
 
                 -- If the player is an Impersonator, tell all their team members when they get promoted
                 if ply:IsImpersonator() then
-                    for _, v in pairs(player.GetAll()) do
+                    for _, v in pairs(GetAllPlayers()) do
                         if v ~= ply and v:IsTraitorTeam() and v:Alive() and not v:IsSpec() then
                             local message = "The " .. ROLE_STRINGS[ROLE_IMPERSONATOR] .. " has been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!"
                             if not alive then

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local net = net
+
 -- Role features shared by detective-like roles (Deputy, Impersonator)
 local function MoveRoleState(ply, target, keep_on_source)
     if ply:IsRoleActive() then

--- a/gamemodes/terrortown/gamemode/roles/doctor/cl_doctor.lua
+++ b/gamemodes/terrortown/gamemode/roles/doctor/cl_doctor.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -19,7 +22,7 @@ hook.Add("TTTTutorialRoleText", "Doctor_TTTTutorialRoleText", function(role, tit
         local roleColor = ROLE_COLORS[ROLE_INNOCENT]
         local html = "The " .. ROLE_STRINGS[ROLE_DOCTOR] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose goal is to heal their patients."
 
-        html = html .. "<span style='display: block; margin-top: 10px;'>Use the equipment shop to buy <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>a health station</span> or <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_PARASITE]:lower() .. " cure</span> to help administer treatments.</span>"
+        html = html .. "<span style='display: block; margin-top: 10px;'>Use the equipment shop to buy <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>a health station</span> or <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. string.lower(ROLE_STRINGS[ROLE_PARASITE]) .. " cure</span> to help administer treatments.</span>"
 
         return html
     end

--- a/gamemodes/terrortown/gamemode/roles/doctor/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/doctor/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 ROLE_STARTING_CREDITS[ROLE_DOCTOR] = 1
 local function InitializeEquipment()

--- a/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
@@ -1,3 +1,10 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local math = math
+local net = net
+local surface = surface
+local util = util
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local math = math
 local net = net
 local surface = surface

--- a/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
@@ -1,8 +1,9 @@
 local hook = hook
-local math = math
 local net = net
 local surface = surface
 local util = util
+
+local MathMax = math.max
 
 ------------------
 -- TRANSLATIONS --
@@ -77,7 +78,7 @@ hook.Add("TTTHUDInfoPaint", "Drunk_TTTHUDInfoPaint", function(client, label_left
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)
 
-        local remaining = math.max(0, GetGlobalFloat("ttt_drunk_remember", 0) - CurTime())
+        local remaining = MathMax(0, GetGlobalFloat("ttt_drunk_remember", 0) - CurTime())
 
         text = LANG.GetParamTranslation("drunk_hud", { time = util.SimpleTime(remaining, "%02i:%02i") })
         local _, h = surface.GetTextSize(text)

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -4,7 +4,6 @@ local plymeta = FindMetaTable("Player")
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local math = math
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -2,6 +2,19 @@ AddCSLuaFile()
 
 local plymeta = FindMetaTable("Player")
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_DrunkSober")
 
 -------------
@@ -146,7 +159,7 @@ function plymeta:SoberDrunk(team)
         -- If there are role options, remove any that shouldn't be used
         if #role_options > 0 then
             -- Remove any used roles
-            for _, p in ipairs(player.GetAll()) do
+            for _, p in ipairs(GetAllPlayers()) do
                 if p:IsCustom() then
                     table.RemoveByValue(role_options, p:GetRole())
                 end
@@ -200,7 +213,7 @@ function plymeta:DrunkRememberRole(role, hidecenter)
 
     local mode = drunk_notify_mode:GetInt()
     if mode > 0 then
-        for _, v in pairs(player.GetAll()) do
+        for _, v in pairs(GetAllPlayers()) do
             if self ~= v then
                 if (v:IsTraitorTeam() and (mode == JESTER_NOTIFY_DETECTIVE_AND_TRAITOR or mode == JESTER_NOTIFY_TRAITOR)) or -- the enums here are the same as for the jester notifications so we can just use those
                         (v:IsDetectiveLike() and (mode == JESTER_NOTIFY_DETECTIVE_AND_TRAITOR or mode == JESTER_NOTIFY_DETECTIVE)) or
@@ -235,13 +248,13 @@ end
 ROLE_ON_ROLE_ASSIGNED[ROLE_DRUNK] = function(ply)
     SetGlobalFloat("ttt_drunk_remember", CurTime() + drunk_sober_time:GetInt())
     timer.Create("drunkremember", drunk_sober_time:GetInt(), 1, function()
-        for _, p in pairs(player.GetAll()) do
+        for _, p in pairs(GetAllPlayers()) do
             if p:IsActiveDrunk() then
                 p:SoberDrunk()
             elseif p:IsDrunk() and not p:Alive() and not timer.Exists("waitfordrunkrespawn") then
                 timer.Create("waitfordrunkrespawn", 0.1, 0, function()
                     local dead_drunk = false
-                    for _, p2 in pairs(player.GetAll()) do
+                    for _, p2 in pairs(GetAllPlayers()) do
                         if p2:IsActiveDrunk() then
                             p2:SoberDrunk()
                         elseif p2:IsDrunk() and not p2:Alive() then
@@ -291,7 +304,7 @@ hook.Add("TTTWinCheckBlocks", "Drunk_TTTWinCheckBlocks", function(win_blocks)
 end)
 
 hook.Add("TTTPrepareRound", "Drunk_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("WasDrunk", false)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/glitch/cl_glitch.lua
+++ b/gamemodes/terrortown/gamemode/roles/glitch/cl_glitch.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/glitch/glitch.lua
+++ b/gamemodes/terrortown/gamemode/roles/glitch/glitch.lua
@@ -1,5 +1,11 @@
 AddCSLuaFile()
 
+local hook = hook
+local pairs = pairs
+local player = player
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -25,7 +31,7 @@ hook.Add("Initialize", "Glitch_RoleFeatures_Initialize", function()
 end)
 
 hook.Add("TTTPrepareRound", "Glitch_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWInt("GlitchBluff", ROLE_TRAITOR)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/glitch/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/glitch/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 GLITCH_SHOW_AS_TRAITOR = 0
 GLITCH_SHOW_AS_SPECIAL_TRAITOR = 1

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/cl_hypnotist.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/cl_hypnotist.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local net = net
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/hypnotist.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/hypnotist.lua
@@ -1,5 +1,11 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local pairs = pairs
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -33,7 +39,7 @@ end)
 ----------------
 
 hook.Add("TTTPrepareRound", "Hypnotist_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("WasHypnotised", false)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local table = table
+local weapons = weapons
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_HYPNOTIST] = {

--- a/gamemodes/terrortown/gamemode/roles/impersonator/cl_impersonator.lua
+++ b/gamemodes/terrortown/gamemode/roles/impersonator/cl_impersonator.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
+++ b/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
@@ -1,5 +1,8 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+
 -------------
 -- CONVARS --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
+++ b/gamemodes/terrortown/gamemode/roles/impersonator/impersonator.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 
 -------------
 -- CONVARS --

--- a/gamemodes/terrortown/gamemode/roles/impersonator/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/impersonator/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 
 -- HandleDetectiveLikePromotion and ROLE_MOVE_ROLE_STATE are defined in detectivelike/shared.lua

--- a/gamemodes/terrortown/gamemode/roles/innocent/cl_innocent.lua
+++ b/gamemodes/terrortown/gamemode/roles/innocent/cl_innocent.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/innocent/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/innocent/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_INNOCENT] = {

--- a/gamemodes/terrortown/gamemode/roles/jester/cl_jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/cl_jester.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -18,7 +21,7 @@ end)
 
 hook.Add("TTTScoringWinTitle", "Jester_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
     if wintype == WIN_JESTER then
-        return { txt = "hilite_win_role_singular", params = { role = ROLE_STRINGS[ROLE_JESTER]:upper() }, c = ROLE_COLORS[ROLE_JESTER] }
+        return { txt = "hilite_win_role_singular", params = { role = string.upper(ROLE_STRINGS[ROLE_JESTER]) }, c = ROLE_COLORS[ROLE_JESTER] }
     end
 end)
 
@@ -28,7 +31,7 @@ end)
 
 hook.Add("TTTEventFinishText", "Jester_TTTEventFinishText", function(e)
     if e.win == WIN_JESTER then
-        return LANG.GetParamTranslation("ev_win_jester", { role = ROLE_STRINGS[ROLE_JESTER]:lower() })
+        return LANG.GetParamTranslation("ev_win_jester", { role = string.lower(ROLE_STRINGS[ROLE_JESTER]) })
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/jester/jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/jester.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local pairs = pairs
 local timer = timer
 

--- a/gamemodes/terrortown/gamemode/roles/jester/jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/jester.lua
@@ -1,5 +1,12 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local pairs = pairs
+local timer = timer
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -57,7 +64,7 @@ hook.Add("TTTPrintResultMessage", "Killer_TTTPrintResultMessage", function(type)
 end)
 
 hook.Add("TTTPrepareRound", "Jester_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWString("JesterKiller", "")
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -1,3 +1,7 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -95,7 +99,7 @@ end)
 
 hook.Add("TTTScoringWinTitle", "Killer_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
     if wintype == WIN_KILLER then
-        return { txt = "hilite_win_role_singular", params = { role = ROLE_STRINGS[ROLE_KILLER]:upper() }, c = ROLE_COLORS[ROLE_KILLER] }
+        return { txt = "hilite_win_role_singular", params = { role = string.upper(ROLE_STRINGS[ROLE_KILLER]) }, c = ROLE_COLORS[ROLE_KILLER] }
     end
 end)
 
@@ -105,7 +109,7 @@ end)
 
 hook.Add("TTTEventFinishText", "Killer_TTTEventFinishText", function(e)
     if e.win == WIN_KILLER then
-        return LANG.GetParamTranslation("ev_win_killer", { role = ROLE_STRINGS[ROLE_KILLER]:lower() })
+        return LANG.GetParamTranslation("ev_win_killer", { role = string.lower(ROLE_STRINGS[ROLE_KILLER]) })
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local string = string
 
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -1,5 +1,16 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local player = player
+local timer = timer
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -60,7 +71,7 @@ local function HandleKillerSmokeTick()
     timer.Create("KillerTick", 0.1, 0, function()
         if GetRoundState() == ROUND_ACTIVE then
             if killerSmokeTime >= killer_smoke_timer:GetInt() then
-                for _, v in pairs(player.GetAll()) do
+                for _, v in pairs(GetAllPlayers()) do
                     if not IsValid(v) then return end
                     if v:IsKiller() and v:Alive() and not v:GetNWBool("KillerSmoke", false) then
                         v:SetNWBool("KillerSmoke", true)
@@ -115,7 +126,7 @@ end)
 
 -- Disable the smoke when the round ends, the player respawns, or they have their role changed
 hook.Add("TTTPrepareRound", "Killer_Smoke_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("KillerSmoke", false)
     end
 end)
@@ -158,7 +169,7 @@ hook.Add("DoPlayerDeath", "Killer_Credits_DoPlayerDeath", function(victim, attac
         local ply_dead = 0
         local ply_total = 0
 
-        for _, ply in pairs(player.GetAll()) do
+        for _, ply in pairs(GetAllPlayers()) do
             if not ply:IsKiller() then
                 if ply:IsTerror() then
                     ply_alive = ply_alive + 1
@@ -188,7 +199,7 @@ hook.Add("DoPlayerDeath", "Killer_Credits_DoPlayerDeath", function(victim, attac
             if amt > 0 then
                 LANG.Msg(GetKillerFilter(true), "credit_all", { role = ROLE_STRINGS[ROLE_KILLER], num = amt })
 
-                for _, ply in pairs(player.GetAll()) do
+                for _, ply in pairs(GetAllPlayers()) do
                     if ply:IsActiveKiller() then
                         ply:AddCredits(amt)
                     end
@@ -280,7 +291,7 @@ end)
 -- Warn other players that there is a killer
 hook.Add("TTTBeginRound", "Killer_Announce_TTTBeginRound", function()
     timer.Simple(1.5, function()
-        local plys = player.GetAll()
+        local plys = GetAllPlayers()
 
         local hasGlitch = false
         local hasKiller = false
@@ -320,7 +331,7 @@ end)
 hook.Add("TTTCheckForWin", "Killer_TTTCheckForWin", function()
     local killer_alive = false
     local other_alive = false
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:Alive() and v:IsTerror() then
             if v:IsKiller() then
                 killer_alive = true

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/killer/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 ROLE_STARTING_HEALTH[ROLE_KILLER] = 150
 ROLE_MAX_HEALTH[ROLE_KILLER] = 150

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -1,3 +1,12 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local math = math
+local net = net
+local surface = surface
+local string = string
+local table = table
+local util = util
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -85,7 +94,7 @@ end)
 
 hook.Add("TTTEventFinishText", "LootGoblin_TTTEventFinishText", function(e)
     if e.win == WIN_LOOTGOBLIN then
-        return LANG.GetParamTranslation("ev_win_lootgoblin", { role = ROLE_STRINGS[ROLE_LOOTGOBLIN]:lower() })
+        return LANG.GetParamTranslation("ev_win_lootgoblin", { role = string.lower(ROLE_STRINGS[ROLE_LOOTGOBLIN]) })
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local math = math
 local net = net
 local surface = surface

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -6,6 +6,8 @@ local string = string
 local table = table
 local util = util
 
+local StringUpper = string.upper
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -42,7 +44,7 @@ end)
 
 hook.Add("TTTTargetIDPlayerText", "LootGoblin_TTTTargetIDPlayerText", function(ent, client, text, clr, secondaryText)
     if IsPlayer(ent) and ent:IsActiveLootGoblin() and ent:IsRoleActive() then
-        return string.upper(ROLE_STRINGS[ROLE_LOOTGOBLIN]), ROLE_COLORS_RADAR[ROLE_LOOTGOBLIN]
+        return StringUpper(ROLE_STRINGS[ROLE_LOOTGOBLIN]), ROLE_COLORS_RADAR[ROLE_LOOTGOBLIN]
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -1,11 +1,11 @@
 local hook = hook
-local math = math
 local net = net
 local surface = surface
 local string = string
 local table = table
 local util = util
 
+local MathMax = math.max
 local StringUpper = string.upper
 
 ------------------
@@ -114,7 +114,7 @@ hook.Add("TTTHUDInfoPaint", "LootGoblin_TTTHUDInfoPaint", function(client, label
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)
 
-        local remaining = math.max(0, GetGlobalFloat("ttt_lootgoblin_activate", 0) - CurTime())
+        local remaining = MathMax(0, GetGlobalFloat("ttt_lootgoblin_activate", 0) - CurTime())
 
         text = LANG.GetParamTranslation("lootgoblin_hud", { time = util.SimpleTime(remaining, "%02i:%02i") })
         local _, h = surface.GetTextSize(text)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -1,5 +1,21 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local resource = resource
+local table = table
+local timer = timer
+local util = util
+local weapons = weapons
+
+local GetAllPlayers = player.GetAll
+local CreateEntity = ents.Create
+
 util.AddNetworkString("TTT_UpdateLootGoblinWins")
 
 resource.AddSingleFile("lootgoblin/cackle1.wav")
@@ -67,7 +83,7 @@ local lootGoblinActive = false
 local function StartGoblinTimers()
     local goblinTime = lootgoblin_activation_timer:GetInt()
     SetGlobalFloat("ttt_lootgoblin_activate", CurTime() + goblinTime)
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:IsActiveLootGoblin() then
             v:PrintMessage(HUD_PRINTTALK, "You will transform into a goblin in " .. tostring(goblinTime) .. " seconds!")
         end
@@ -75,7 +91,7 @@ local function StartGoblinTimers()
     timer.Create("LootGoblinActivate", goblinTime, 1, function()
         lootGoblinActive = true
         local revealMode = lootgoblin_announce:GetInt()
-        for _, v in ipairs(player.GetAll()) do
+        for _, v in ipairs(GetAllPlayers()) do
             if v:IsActiveLootGoblin() then
                 v:SetNWBool("LootGoblinActive", true)
                 v:PrintMessage(HUD_PRINTTALK, "You have transformed into a goblin!")
@@ -105,7 +121,7 @@ local function StartGoblinTimers()
             local min = lootgoblin_cackle_timer_min:GetInt()
             local max = lootgoblin_cackle_timer_max:GetInt()
             timer.Create("LootGoblinCackle", math.random(min, max), 0, function()
-                for _, v in ipairs(player.GetAll()) do
+                for _, v in ipairs(GetAllPlayers()) do
                     if v:IsActiveLootGoblin() and not v:GetNWBool("LootGoblinKilled", false) then
                         local idx = math.random(1, #cackles)
                         local chosen_sound = cackles[idx]
@@ -126,7 +142,7 @@ local function HandleLootGoblinWinChecks(win_type)
     if win_type == WIN_NONE then return end
 
     local hasLootGoblin = false
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:IsActiveLootGoblin() and not v:GetNWBool("LootGoblinKilled", false) then
             hasLootGoblin = true
         end
@@ -209,7 +225,7 @@ hook.Add("PlayerDeath", "LootGoblin_PlayerDeath", function(victim, infl, attacke
                 local idx = math.random(1, #lootTable)
                 local wep = lootTable[idx]
                 table.remove(lootTable, idx)
-                local ent = ents.Create(wep)
+                local ent = CreateEntity(wep)
                 ent:SetPos(pos)
                 ent:Spawn()
 
@@ -234,7 +250,7 @@ local function ResetPlayer(ply)
 end
 
 hook.Add("TTTPrepareRound", "LootGoblin_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("LootGoblinKilled", false)
         ResetPlayer(v)
     end

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local math = math
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local table = table
 
 -- Initialize role features

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
@@ -3,6 +3,8 @@ AddCSLuaFile()
 local hook = hook
 local table = table
 
+local TableInsert = table.insert
+
 -- Initialize role features
 ROLE_STARTING_HEALTH[ROLE_LOOTGOBLIN] = 50
 ROLE_MAX_HEALTH[ROLE_LOOTGOBLIN] = 50
@@ -14,6 +16,6 @@ end
 
 hook.Add("TTTSpeedMultiplier", "LootGoblin_TTTSpeedMultiplier", function(ply, mults)
     if IsPlayer(ply) and ply:IsActiveLootGoblin() and ply:IsRoleActive() then
-        table.insert(mults, GetGlobalFloat("ttt_lootgoblin_speed_mult", 1.2))
+        TableInsert(mults, GetGlobalFloat("ttt_lootgoblin_speed_mult", 1.2))
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local table = table
+
 -- Initialize role features
 ROLE_STARTING_HEALTH[ROLE_LOOTGOBLIN] = 50
 ROLE_MAX_HEALTH[ROLE_LOOTGOBLIN] = 50

--- a/gamemodes/terrortown/gamemode/roles/madscientist/cl_madscientist.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/cl_madscientist.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/medium/cl_medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/cl_medium.lua
@@ -1,3 +1,9 @@
+local hook = hook
+local math = math
+local pairs = pairs
+
+local GetAllEnts = ents.GetAll
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -19,7 +25,7 @@ hook.Add("Think", "Medium_RoleFeature_Think", function()
     local client = LocalPlayer()
     if not client:IsActiveMedium() then return end
 
-    for _, ent in pairs(ents.GetAll()) do
+    for _, ent in pairs(GetAllEnts()) do
         if ent:GetNWBool("MediumSpirit", false) then
             ent:SetNoDraw(true)
             ent:SetRenderMode(RENDERMODE_NONE)

--- a/gamemodes/terrortown/gamemode/roles/medium/cl_medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/cl_medium.lua
@@ -3,6 +3,8 @@ local math = math
 local pairs = pairs
 
 local GetAllEnts = ents.GetAll
+local MathRand = math.Rand
+local MathRandom = math.random
 
 ------------------
 -- TRANSLATIONS --
@@ -37,16 +39,16 @@ hook.Add("Think", "Medium_RoleFeature_Think", function()
             if ent.WispNextPart < CurTime() then
                 if client:GetPos():Distance(pos) <= 3000 then
                     ent.WispEmitter:SetPos(pos)
-                    ent.WispNextPart = CurTime() + math.Rand(0.003, 0.01)
+                    ent.WispNextPart = CurTime() + MathRand(0.003, 0.01)
                     local particle = ent.WispEmitter:Add("particle/wisp.vmt", pos)
                     particle:SetVelocity(Vector(0, 0, 30))
                     particle:SetDieTime(1)
-                    particle:SetStartAlpha(math.random(150, 220))
+                    particle:SetStartAlpha(MathRandom(150, 220))
                     particle:SetEndAlpha(0)
-                    local size = math.random(4, 7)
+                    local size = MathRandom(4, 7)
                     particle:SetStartSize(size)
                     particle:SetEndSize(1)
-                    particle:SetRoll(math.Rand(0, math.pi))
+                    particle:SetRoll(MathRand(0, math.pi))
                     particle:SetRollDelta(0)
                     local col = ent:GetNWVector("SpiritColor", Vector(1, 1, 1))
                     particle:SetColor(col.x * 255, col.y * 255, col.z * 255)

--- a/gamemodes/terrortown/gamemode/roles/medium/medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/medium.lua
@@ -1,5 +1,14 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local pairs = pairs
+local player = player
+local table = table
+
+local GetAllPlayers = player.GetAll
+local CreateEntity = ents.Create
+
 -------------
 -- CONVARS --
 -------------
@@ -50,11 +59,11 @@ end)
 hook.Add("PlayerDeath", "Medium_Spirits_PlayerDeath", function(victim, infl, attacker)
     -- Create spirit for the medium
     local mediums = {}
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:IsMedium() then table.insert(mediums, v) end
     end
     if #mediums > 0 then
-        local spirit = ents.Create("npc_kleiner")
+        local spirit = CreateEntity("npc_kleiner")
         spirit:SetPos(victim:GetPos())
         spirit:SetRenderMode(RENDERMODE_NONE)
         spirit:SetNotSolid(true)

--- a/gamemodes/terrortown/gamemode/roles/medium/medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/medium.lua
@@ -14,10 +14,12 @@ local CreateEntity = ents.Create
 -------------
 
 local medium_spirit_color = CreateConVar("ttt_medium_spirit_color", "1")
+local medium_spirit_vision = CreateConVar("ttt_medium_spirit_vision", "1")
 local medium_dead_notify = CreateConVar("ttt_medium_dead_notify", "1")
 
 hook.Add("TTTSyncGlobals", "Medium_TTTSyncGlobals", function()
     SetGlobalBool("ttt_medium_spirit_color", medium_spirit_color:GetBool())
+    SetGlobalBool("ttt_medium_spirit_vision", medium_spirit_vision:GetBool())
 end)
 
 -------------------
@@ -77,8 +79,8 @@ hook.Add("PlayerDeath", "Medium_Spirits_PlayerDeath", function(victim, infl, att
         spirit:Spawn()
         spirits[victim:SteamID64()] = spirit
 
-        -- Let the player who died know there is a medium
-        if medium_dead_notify:GetBool() then
+        -- Let the player who died know there is a medium and this player isn't the only medium
+        if medium_dead_notify:GetBool() and (#mediums > 1 or not victim:IsMedium()) then
             victim:PrintMessage(HUD_PRINTTALK, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
             victim:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
         end

--- a/gamemodes/terrortown/gamemode/roles/medium/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_MEDIUM] = {

--- a/gamemodes/terrortown/gamemode/roles/mercenary/cl_mercenary.lua
+++ b/gamemodes/terrortown/gamemode/roles/mercenary/cl_mercenary.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/mercenary/mercenary.lua
+++ b/gamemodes/terrortown/gamemode/roles/mercenary/mercenary.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -------------
 -- CONVARS --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/mercenary/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/mercenary/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -- Initialize role features
 ROLE_STARTING_CREDITS[ROLE_MERCENARY] = 1
 local function InitializeEquipment()

--- a/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
@@ -3,6 +3,8 @@ local net = net
 local string = string
 local table = table
 
+local StringUpper = string.upper
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -92,7 +94,7 @@ hook.Add("TTTTargetIDPlayerText", "OldMan_TTTTargetIDPlayerText", function(ent, 
     if GetRoundState() < ROUND_ACTIVE then return end
 
     if IsOldManVisible(ent) then
-        return string.upper(ROLE_STRINGS[ROLE_OLDMAN]), ROLE_COLORS_RADAR[ROLE_OLDMAN]
+        return StringUpper(ROLE_STRINGS[ROLE_OLDMAN]), ROLE_COLORS_RADAR[ROLE_OLDMAN]
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
@@ -1,3 +1,8 @@
+local hook = hook
+local net = net
+local string = string
+local table = table
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -49,7 +54,7 @@ end)
 
 hook.Add("TTTEventFinishText", "OldMan_TTTEventFinishText", function(e)
     if e.win == WIN_OLDMAN then
-        return LANG.GetParamTranslation("ev_win_oldman", { role = ROLE_STRINGS[ROLE_OLDMAN]:lower() })
+        return LANG.GetParamTranslation("ev_win_oldman", { role = string.lower(ROLE_STRINGS[ROLE_OLDMAN]) })
     end
 end)
 
@@ -87,7 +92,7 @@ hook.Add("TTTTargetIDPlayerText", "OldMan_TTTTargetIDPlayerText", function(ent, 
     if GetRoundState() < ROUND_ACTIVE then return end
 
     if IsOldManVisible(ent) then
-        return ROLE_STRINGS[ROLE_OLDMAN]:upper(), ROLE_COLORS_RADAR[ROLE_OLDMAN]
+        return string.upper(ROLE_STRINGS[ROLE_OLDMAN]), ROLE_COLORS_RADAR[ROLE_OLDMAN]
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
@@ -1,5 +1,18 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local player = player
+local resource = resource
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_UpdateOldManWins")
 
 resource.AddSingleFile("sound/oldmanramble.wav")
@@ -48,7 +61,7 @@ ROLE_ON_ROLE_ASSIGNED[ROLE_OLDMAN] = function(ply)
     local oldman_drain_health = oldman_drain_health_to:GetInt()
     if oldman_drain_health > 0 then
         timer.Create("oldmanhealthdrain", 3, 0, function()
-            for _, p in pairs(player.GetAll()) do
+            for _, p in pairs(GetAllPlayers()) do
                 if p:IsActiveOldMan() then
                     local hp = p:Health()
                     if hp > oldman_drain_health then
@@ -129,7 +142,7 @@ hook.Add("EntityTakeDamage", "OldMan_EntityTakeDamage", function(ent, dmginfo)
 end)
 
 hook.Add("TTTPrepareRound", "OldMan_Adrenaline_TTTPrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("AdrenalineRush", false)
         v:SetNWBool("AdrenalineRushed", false)
         timer.Remove(v:Nick() .. "AdrenalineRush")

--- a/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local math = math
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
@@ -45,11 +45,9 @@ hook.Add("TTTPlayerAliveClientThink", "Paladin_RoleFeatures_TTTPlayerAliveClient
                 particle:SetColor(ROLE_COLORS[ROLE_PALADIN].r, ROLE_COLORS[ROLE_PALADIN].g, ROLE_COLORS[ROLE_PALADIN].b)
             end
         end
-    else
-        if ply.AuraEmitter then
-            ply.AuraEmitter:Finish()
-            ply.AuraEmitter = nil
-        end
+    elseif ply.AuraEmitter then
+        ply.AuraEmitter:Finish()
+        ply.AuraEmitter = nil
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
@@ -1,5 +1,7 @@
 local hook = hook
-local math = math
+
+local MathCos = math.cos
+local MathSin = math.sin
 
 ------------------
 -- TRANSLATIONS --
@@ -30,7 +32,7 @@ hook.Add("TTTPlayerAliveClientThink", "Paladin_RoleFeatures_TTTPlayerAliveClient
                 ply.AuraNextPart = CurTime() + 0.02
                 ply.AuraDir = ply.AuraDir + 0.05
                 local radius = GetGlobalFloat("ttt_paladin_aura_radius", 262.45)
-                local vec = Vector(math.sin(ply.AuraDir) * radius, math.cos(ply.AuraDir) * radius, 10)
+                local vec = Vector(MathSin(ply.AuraDir) * radius, MathCos(ply.AuraDir) * radius, 10)
                 local particle = ply.AuraEmitter:Add("particle/shield.vmt", ply:GetPos() + vec)
                 particle:SetVelocity(Vector(0, 0, 20))
                 particle:SetDieTime(1)

--- a/gamemodes/terrortown/gamemode/roles/paladin/paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/paladin.lua
@@ -1,5 +1,13 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local math = math
+local pairs = pairs
+local timer = timer
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -25,9 +33,9 @@ hook.Add("TTTBeginRound", "Paladin_RoleFeatures_TTTBeginRound", function()
     local paladinHealSelf = paladin_heal_self:GetBool()
     local paladinRadius = GetGlobalFloat("ttt_paladin_aura_radius", 262.45)
     timer.Create("paladinheal", 1, 0, function()
-        for _, p in pairs(player.GetAll()) do
+        for _, p in pairs(GetAllPlayers()) do
             if p:IsActivePaladin() then
-                for _, v in pairs(player.GetAll()) do
+                for _, v in pairs(GetAllPlayers()) do
                     if v:IsActive() and (not v:IsPaladin() or paladinHealSelf) and v:GetPos():Distance(p:GetPos()) <= paladinRadius and v:Health() < v:GetMaxHealth() then
                         local health = math.min(v:GetMaxHealth(), v:Health() + paladinHeal)
                         v:SetHealth(health)
@@ -52,7 +60,7 @@ hook.Add("ScalePlayerDamage", "Paladin_ScalePlayerDamage", function(ply, hitgrou
         if not ply:IsPaladin() or paladin_protect_self:GetBool() then
             local withPaladin = false
             local radius = GetGlobalFloat("ttt_paladin_aura_radius", 262.45)
-            for _, v in pairs(player.GetAll()) do
+            for _, v in pairs(GetAllPlayers()) do
                 if v:IsPaladin() and v:GetPos():Distance(ply:GetPos()) <= radius then
                     withPaladin = true
                     break

--- a/gamemodes/terrortown/gamemode/roles/paladin/paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/paladin.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local math = math
 local pairs = pairs
 local timer = timer

--- a/gamemodes/terrortown/gamemode/roles/paladin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_PALADIN] = {

--- a/gamemodes/terrortown/gamemode/roles/paramedic/cl_paramedic.lua
+++ b/gamemodes/terrortown/gamemode/roles/paramedic/cl_paramedic.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/paramedic/paramedic.lua
+++ b/gamemodes/terrortown/gamemode/roles/paramedic/paramedic.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -------------
 -- CONVARS --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/paramedic/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/paramedic/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local table = table
+local weapons = weapons
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_PARAMEDIC] = {

--- a/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local net = net
 local pairs = pairs
 

--- a/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
@@ -1,3 +1,10 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local net = net
+local pairs = pairs
+
+local GetAllPlayers = player.GetAll
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -84,7 +91,7 @@ hook.Add("TTTScoreboardPlayerName", "Parasite_TTTScoreboardPlayerName", function
 
     -- Show Assassin + Parasite logic if that applies
     local infected = ply:GetNWBool("Infected", false)
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if ply:Nick() == v:GetNWString("AssassinTarget", "") then
             local newText = " ("
             if infected then

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -1,5 +1,18 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local player = player
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_ParasiteInfect")
 
 -------------
@@ -25,7 +38,7 @@ end)
 
 local deadParasites = {}
 hook.Add("TTTPrepareRound", "Parasite_TTTPrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("Infected", false)
         v:SetNWBool("Infecting", false)
         v:SetNWString("InfectingTarget", nil)

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/parasite/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local table = table
+local weapons = weapons
+
 -- Parasite respawn modes
 PARASITE_RESPAWN_HOST = 0
 PARASITE_RESPAWN_BODY = 1

--- a/gamemodes/terrortown/gamemode/roles/phantom/cl_phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/cl_phantom.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local net = net
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
@@ -1,5 +1,18 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_PhantomHaunt")
 
 -------------
@@ -43,7 +56,7 @@ end)
 
 local deadPhantoms = {}
 hook.Add("TTTPrepareRound", "Phantom_TTTPrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("Haunted", false)
         v:SetNWBool("Haunting", false)
         v:SetNWString("HauntingTarget", nil)
@@ -119,7 +132,7 @@ hook.Add("PlayerDeath", "Phantom_PlayerDeath", function(victim, infl, attacker)
         end
         victim:PrintMessage(HUD_PRINTCENTER, "Your attacker has been haunted.")
         if phantom_announce_death:GetBool() then
-            for _, v in pairs(player.GetAll()) do
+            for _, v in pairs(GetAllPlayers()) do
                 if v ~= attacker and v:IsDetectiveLike() and v:Alive() and not v:IsSpec() then
                     v:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_PHANTOM] .. " has been killed.")
                 end
@@ -239,7 +252,7 @@ hook.Add("DoPlayerDeath", "Phantom_DoPlayerDeath", function(ply, attacker, dmgin
         end
 
         if respawn and phantom_announce_death:GetBool() then
-            for _, v in pairs(player.GetAll()) do
+            for _, v in pairs(GetAllPlayers()) do
                 if v:IsDetectiveLike() and v:Alive() and not v:IsSpec() then
                     v:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_PHANTOM] .. " has been respawned.")
                 end

--- a/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/roles/quack/cl_quack.lua
+++ b/gamemodes/terrortown/gamemode/roles/quack/cl_quack.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -40,7 +43,7 @@ hook.Add("TTTTutorialRoleText", "Quack_TTTTutorialRoleText", function(role, titl
         local roleColor = ROLE_COLORS[ROLE_TRAITOR]
         local html = "The " .. ROLE_STRINGS[ROLE_QUACK] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>traitor team</span> whose goal is imitate the " .. ROLE_STRINGS[ROLE_DOCTOR] .. " and \"heal\" their patients... <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>to death</span>."
 
-        html = html .. "<span style='display: block; margin-top: 10px;'>Use the equipment shop to buy <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>a bomb station</span> or <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>fake " .. ROLE_STRINGS[ROLE_PARASITE]:lower() .. " cure</span> to help administer \"treatments\".</span>"
+        html = html .. "<span style='display: block; margin-top: 10px;'>Use the equipment shop to buy <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>a bomb station</span> or <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>fake " .. string.lower(ROLE_STRINGS[ROLE_PARASITE]) .. " cure</span> to help administer \"treatments\".</span>"
 
         if GetGlobalBool("ttt_quack_phantom_cure", false) then
             html = html .. "<span style='display: block; margin-top: 10px;'>The " .. ROLE_STRINGS[ROLE_QUACK] .. " can also <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>buy an Exorcism Device</span> which can be used to remove a haunting " .. ROLE_STRINGS[ROLE_PHANTOM] .. ".</span>"

--- a/gamemodes/terrortown/gamemode/roles/quack/quack.lua
+++ b/gamemodes/terrortown/gamemode/roles/quack/quack.lua
@@ -1,5 +1,8 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+
 -------------
 -- CONVARS --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/quack/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/quack/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local table = table
+local weapons = weapons
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_QUACK] = {

--- a/gamemodes/terrortown/gamemode/roles/revenger/cl_revenger.lua
+++ b/gamemodes/terrortown/gamemode/roles/revenger/cl_revenger.lua
@@ -1,3 +1,11 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local net = net
+local pairs = pairs
+local player = player
+local surface = surface
+local timer = timer
+
 local function IsLover(cli, ply)
     return ply:SteamID64() == cli:GetNWString("RevengerLover", "")
 end

--- a/gamemodes/terrortown/gamemode/roles/revenger/cl_revenger.lua
+++ b/gamemodes/terrortown/gamemode/roles/revenger/cl_revenger.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local net = net
 local pairs = pairs
 local player = player

--- a/gamemodes/terrortown/gamemode/roles/revenger/revenger.lua
+++ b/gamemodes/terrortown/gamemode/roles/revenger/revenger.lua
@@ -1,5 +1,18 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_RevengerLoverKillerRadar")
 
 -------------
@@ -31,7 +44,7 @@ end)
 
 -- Clear out the revenger data when the round starts
 hook.Add("TTTPrepareRound", "Revenger_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWString("RevengerLover", "")
         v:SetNWString("RevengerKiller", "")
     end
@@ -48,7 +61,7 @@ end)
 -- Handle revenger lover death
 hook.Add("PlayerDeath", "Revenger_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:IsRevenger() and v:GetNWString("RevengerLover", "") == victim:SteamID64() then
             local message
             if v == attacker then
@@ -124,7 +137,7 @@ end
 
 ROLE_ON_ROLE_ASSIGNED[ROLE_REVENGER] = function(ply)
     local potentialSoulmates = {}
-    for _, p in pairs(player.GetAll()) do
+    for _, p in pairs(GetAllPlayers()) do
         if p:Alive() and not p:IsSpec() and p ~= ply then
             table.insert(potentialSoulmates, p)
         end
@@ -139,7 +152,7 @@ ROLE_ON_ROLE_ASSIGNED[ROLE_REVENGER] = function(ply)
     local drain_health = revenger_drain_health_to:GetInt()
     if drain_health >= 0 then
         timer.Create("revengerhealthdrain", 3, 0, function()
-            for _, p in pairs(player.GetAll()) do
+            for _, p in pairs(GetAllPlayers()) do
                 local lover_sid = p:GetNWString("RevengerLover", "")
                 if p:IsActiveRevenger() and lover_sid ~= "" then
                     local lover = player.GetBySteamID64(lover_sid)

--- a/gamemodes/terrortown/gamemode/roles/revenger/revenger.lua
+++ b/gamemodes/terrortown/gamemode/roles/revenger/revenger.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/roles/swapper/cl_swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/cl_swapper.lua
@@ -1,3 +1,6 @@
+local hook = hook
+local net = net
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
@@ -1,5 +1,17 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local table = table
+local timer = timer
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_SwapperSwapped")
 
 -------------
@@ -172,7 +184,7 @@ hook.Add("PlayerDeath", "Swapper_KillCheck_PlayerDeath", function(victim, infl, 
 end)
 
 hook.Add("TTTPrepareRound", "Swapper_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWString("SwappedWith", "")
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/roles/tracker/cl_tracker.lua
+++ b/gamemodes/terrortown/gamemode/roles/tracker/cl_tracker.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/tracker/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/tracker/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_TRACKER] = {

--- a/gamemodes/terrortown/gamemode/roles/tracker/tracker.lua
+++ b/gamemodes/terrortown/gamemode/roles/tracker/tracker.lua
@@ -1,5 +1,13 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local table = table
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -37,7 +45,7 @@ hook.Add("PlayerFootstep", "Tracker_PlayerFootstep", function(ply, pos, foot, so
     net.WriteTable(Color(col.x * 255, col.y * 255, col.z * 255))
     net.WriteUInt(footstep_time, 8)
     local tab = {}
-    for k, p in pairs(player.GetAll()) do
+    for k, p in pairs(GetAllPlayers()) do
         if p:IsActiveTracker() then
             table.insert(tab, p)
         end

--- a/gamemodes/terrortown/gamemode/roles/traitor/cl_traitor.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/cl_traitor.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/traitor/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local table = table
+local weapons = weapons
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_TRAITOR] = {

--- a/gamemodes/terrortown/gamemode/roles/traitor/traitor.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/traitor.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 -------------
 -- CONVARS --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/trickster/cl_trickster.lua
+++ b/gamemodes/terrortown/gamemode/roles/trickster/cl_trickster.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/trickster/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/trickster/shared.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+local hook = hook
+
 local function InitializeEquipment()
     if DefaultEquipment then
         DefaultEquipment[ROLE_TRICKSTER] = {

--- a/gamemodes/terrortown/gamemode/roles/trickster/trickster.lua
+++ b/gamemodes/terrortown/gamemode/roles/trickster/trickster.lua
@@ -1,1 +1,3 @@
-ROLE_SELECTION_PREDICATE[ROLE_TRICKSTER] = function() return #ents.FindByClass("ttt_traitor_button") > 0 end
+local FindEntsByClass = ents.FindByClass
+
+ROLE_SELECTION_PREDICATE[ROLE_TRICKSTER] = function() return #FindEntsByClass("ttt_traitor_button") > 0 end

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local player = player

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -1,3 +1,10 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local player = player
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -106,7 +113,7 @@ end)
 
 hook.Add("TTTScoringWinTitle", "Vampire_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
     if wintype == WIN_VAMPIRE then
-        return { txt = "hilite_win_role_plural", params = { role = ROLE_STRINGS_PLURAL[ROLE_VAMPIRE]:upper() }, c = ROLE_COLORS[ROLE_VAMPIRE] }
+        return { txt = "hilite_win_role_plural", params = { role = string.upper(ROLE_STRINGS_PLURAL[ROLE_VAMPIRE]) }, c = ROLE_COLORS[ROLE_VAMPIRE] }
     end
 end)
 
@@ -116,7 +123,7 @@ end)
 
 hook.Add("TTTEventFinishText", "Vampire_TTTEventFinishText", function(e)
     if e.win == WIN_VAMPIRE then
-        return LANG.GetParamTranslation("ev_win_vampire", { role = ROLE_STRINGS[ROLE_VAMPIRE]:lower() })
+        return LANG.GetParamTranslation("ev_win_vampire", { role = string.lower(ROLE_STRINGS[ROLE_VAMPIRE]) })
     end
 end)
 
@@ -209,7 +216,7 @@ hook.Add("TTTTutorialRoleText", "Vampire_TTTTutorialRoleText", function(role, ti
         local roleTeam = player.GetRoleTeam(ROLE_VAMPIRE, true)
         local roleTeamString, roleTeamColor = GetRoleTeamInfo(roleTeam, true)
 
-        local html = "The " .. ROLE_STRINGS[ROLE_VAMPIRE] .. " is a member of the <span style='color: rgb(" .. roleTeamColor.r .. ", " .. roleTeamColor.g .. ", " .. roleTeamColor.b .. ")'>" .. roleTeamString:lower() .. " team</span>."
+        local html = "The " .. ROLE_STRINGS[ROLE_VAMPIRE] .. " is a member of the <span style='color: rgb(" .. roleTeamColor.r .. ", " .. roleTeamColor.g .. ", " .. roleTeamColor.b .. ")'>" .. string.lower(roleTeamString) .. " team</span>."
 
         -- Draining
         html = html .. "<span style='display: block; margin-top: 10px;'>They can heal themselves by <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>draining blood</span> from "

--- a/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local table = table
+
 -- Vampire prime death modes
 VAMPIRE_DEATH_NONE = 0
 VAMPIRE_DEATH_KILL_CONVERTED = 1

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -4,7 +4,6 @@ local plymeta = FindMetaTable("Player")
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -2,6 +2,19 @@ AddCSLuaFile()
 
 local plymeta = FindMetaTable("Player")
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local resource = resource
+local table = table
+local util = util
+
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_VampirePrimeDeath")
 
 resource.AddSingleFile("sound/weapons/ttt/fade.wav")
@@ -59,7 +72,7 @@ hook.Add("DoPlayerDeath", "Vampire_Credits_DoPlayerDeath", function(victim, atta
         local ply_dead = 0
         local ply_total = 0
 
-        for _, ply in pairs(player.GetAll()) do
+        for _, ply in pairs(GetAllPlayers()) do
             if not ply:IsVampireAlly() then
                 if ply:IsTerror() then
                     ply_alive = ply_alive + 1
@@ -89,7 +102,7 @@ hook.Add("DoPlayerDeath", "Vampire_Credits_DoPlayerDeath", function(victim, atta
             if amt > 0 then
                 LANG.Msg(GetVampireFilter(true), "credit_all", { role = ROLE_STRINGS[ROLE_VAMPIRE], num = amt })
 
-                for _, ply in pairs(player.GetAll()) do
+                for _, ply in pairs(GetAllPlayers()) do
                     if ply:IsActiveVampire() then
                         ply:AddCredits(amt)
                     end
@@ -114,7 +127,7 @@ hook.Add("PlayerDeath", "Vampire_PrimeDeath_PlayerDeath", function(victim, infl,
         local living_vampire_primes = 0
         local vampires = {}
         -- Find all the living vampires anmd count the primes
-        for _, v in pairs(player.GetAll()) do
+        for _, v in pairs(GetAllPlayers()) do
             if v:Alive() and v:IsTerror() and v:IsVampire() then
                 if v:IsVampirePrime() then
                     living_vampire_primes = living_vampire_primes + 1
@@ -169,7 +182,7 @@ function plymeta:SetVampirePreviousRole(r) self:SetNWInt("vampire_previous_role"
 -----------------
 
 hook.Add("TTTBeginRound", "Vampire_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:IsVampire() then
             v:SetVampirePrime(true)
         end
@@ -177,7 +190,7 @@ hook.Add("TTTBeginRound", "Vampire_RoleFeatures_PrepareRound", function()
 end)
 
 hook.Add("TTTPrepareRound", "Vampire_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWInt("VampireFreezeCount", 0)
         -- Keep previous naming scheme for backwards compatibility
         v:SetNWBool("vampire_prime", false)
@@ -202,7 +215,7 @@ hook.Add("TTTCheckForWin", "Vampire_TTTCheckForWin", function()
 
     local vampire_alive = false
     local other_alive = false
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:Alive() and v:IsTerror() then
             if v:IsVampire() then
                 vampire_alive = true

--- a/gamemodes/terrortown/gamemode/roles/veteran/cl_veteran.lua
+++ b/gamemodes/terrortown/gamemode/roles/veteran/cl_veteran.lua
@@ -1,3 +1,5 @@
+local hook = hook
+
 ------------------
 -- TRANSLATIONS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
+++ b/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
@@ -1,5 +1,14 @@
 AddCSLuaFile()
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local math = math
+local pairs = pairs
+local table = table
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -21,7 +30,7 @@ end)
 hook.Add("PlayerDeath", "Veteran_RoleFeatures_PlayerDeath", function(victim, infl, attacker)
     local innocents_alive = 0
     local veterans = {}
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:IsActiveInnocentTeam() then innocents_alive = innocents_alive + 1 end
         if v:IsActiveVeteran() then table.insert(veterans, v) end
     end
@@ -34,7 +43,7 @@ hook.Add("PlayerDeath", "Veteran_RoleFeatures_PlayerDeath", function(victim, inf
                 v:PrintMessage(HUD_PRINTTALK, "You are the last " .. ROLE_STRINGS[ROLE_INNOCENT] .. " alive!")
                 v:PrintMessage(HUD_PRINTCENTER, "You are the last " .. ROLE_STRINGS[ROLE_INNOCENT] .. " alive!")
                 if veteran_announce:GetBool() then
-                    for _, p in ipairs(player.GetAll()) do
+                    for _, p in ipairs(GetAllPlayers()) do
                         if p ~= v and p:Alive() and not p:IsSpec() then
                             p:PrintMessage(HUD_PRINTTALK, "The last " .. ROLE_STRINGS[ROLE_INNOCENT] .. " alive is " .. ROLE_STRINGS_EXT[ROLE_VETERAN] .. "!")
                             p:PrintMessage(HUD_PRINTCENTER, "The last " .. ROLE_STRINGS[ROLE_INNOCENT] .. " alive is " .. ROLE_STRINGS_EXT[ROLE_VETERAN] .. "!")
@@ -75,7 +84,7 @@ hook.Add("ScalePlayerDamage", "Veteran_ScalePlayerDamage", function(ply, hitgrou
 end)
 
 hook.Add("TTTPrepareRound", "Veteran_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("VeteranActive", false)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
+++ b/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local math = math
 local pairs = pairs
 local table = table

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -1,5 +1,4 @@
 local hook = hook
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local player = player

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -1,3 +1,10 @@
+local hook = hook
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local player = player
+local string = string
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -81,7 +88,7 @@ end)
 
 hook.Add("TTTScoringWinTitle", "Zombie_TTTScoringWinTitle", function(wintype, wintitles, title, secondary_win_role)
     if wintype == WIN_ZOMBIE then
-        return { txt = "hilite_win_role_plural", params = { role = ROLE_STRINGS_PLURAL[ROLE_ZOMBIE]:upper() }, c = ROLE_COLORS[ROLE_ZOMBIE] }
+        return { txt = "hilite_win_role_plural", params = { role = string.upper(ROLE_STRINGS_PLURAL[ROLE_ZOMBIE]) }, c = ROLE_COLORS[ROLE_ZOMBIE] }
     end
 end)
 
@@ -91,7 +98,7 @@ end)
 
 hook.Add("TTTEventFinishText", "Zombie_TTTEventFinishText", function(e)
     if e.win == WIN_ZOMBIE then
-        return LANG.GetParamTranslation("ev_win_zombie", { role = ROLE_STRINGS[ROLE_ZOMBIE]:lower() })
+        return LANG.GetParamTranslation("ev_win_zombie", { role = string.lower(ROLE_STRINGS[ROLE_ZOMBIE]) })
     end
 end)
 
@@ -191,7 +198,7 @@ hook.Add("TTTTutorialRoleText", "Zombie_TTTTutorialRoleText", function(role, tit
         local roleTeam = player.GetRoleTeam(ROLE_ZOMBIE, true)
         local roleTeamString, roleTeamColor = GetRoleTeamInfo(roleTeam, true)
 
-        local html = "The " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " is a member of the <span style='color: rgb(" .. roleTeamColor.r .. ", " .. roleTeamColor.g .. ", " .. roleTeamColor.b .. ")'>" .. roleTeamString:lower() .. " team</span> that uses their claws to attack their enemies."
+        local html = "The " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " is a member of the <span style='color: rgb(" .. roleTeamColor.r .. ", " .. roleTeamColor.g .. ", " .. roleTeamColor.b .. ")'>" .. string.lower(roleTeamString) .. " team</span> that uses their claws to attack their enemies."
 
         -- Convert
         html = html .. "<span style='display: block; margin-top: 10px;'>Killing a player with their claws will <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>turn the target</span> into a " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " thrall.</span>"

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -1,5 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
+local IsValid = IsValid
+local table = table
+
 local function InitializeEquipment()
     if EquipmentItems then
         local mat_dir = "vgui/ttt/"

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -4,7 +4,6 @@ local plymeta = FindMetaTable("Player")
 
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local pairs = pairs
 

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -2,6 +2,14 @@ AddCSLuaFile()
 
 local plymeta = FindMetaTable("Player")
 
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local pairs = pairs
+
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -37,7 +45,7 @@ function plymeta:SetZombiePrime(p) self:SetNWBool("zombie_prime", p) end
 -----------------
 
 hook.Add("TTTBeginRound", "Zombie_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if v:IsZombie() then
             v:SetZombiePrime(true)
         end
@@ -45,7 +53,7 @@ hook.Add("TTTBeginRound", "Zombie_RoleFeatures_PrepareRound", function()
 end)
 
 hook.Add("TTTPrepareRound", "Zombie_RoleFeatures_PrepareRound", function()
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         v:SetNWBool("IsZombifying", false)
         -- Keep previous naming scheme for backwards compatibility
         v:SetNWBool("zombie_prime", false)
@@ -69,7 +77,7 @@ hook.Add("TTTCheckForWin", "Zombie_TTTCheckForWin", function()
 
     local zombie_alive = false
     local other_alive = false
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:Alive() and v:IsTerror() then
             if v:IsZombie() or v:IsMadScientist() then
                 zombie_alive = true

--- a/gamemodes/terrortown/gamemode/scoring.lua
+++ b/gamemodes/terrortown/gamemode/scoring.lua
@@ -85,7 +85,7 @@ function SCORE:HandleKill(victim, attacker, dmginfo)
         e.att.jes = attacker:IsJesterTeam()
         e.att.ind = attacker:IsIndependentTeam()
         e.att.mon = attacker:IsMonsterTeam()
-        e.tk = (e.att.tr and e.vic.tr) or (e.att.inno and e.vic.inno) or (e.att.mon and e.vic.mon) or e.vic.jes
+        e.tk = (e.att.tr and e.vic.tr) or (e.att.inno and e.vic.inno) or (e.att.mon and e.vic.mon)
 
         -- If a traitor gets himself killed by another traitor's C4, it's his own
         -- damn fault for ignoring the indicator.

--- a/gamemodes/terrortown/gamemode/scoring.lua
+++ b/gamemodes/terrortown/gamemode/scoring.lua
@@ -10,6 +10,7 @@ local table = table
 local util = util
 
 local GetAllPlayers = player.GetAll
+local StringSub = string.sub
 
 SCORE = SCORE or {}
 SCORE.Events = SCORE.Events or {}
@@ -252,7 +253,7 @@ function SCORE:StreamToClients()
 
         repeat
             net.Start("TTT_ReportStream_Part")
-            net.WriteData(string.sub(events, curpos + 1, curpos + MaxStreamLength + 1), MaxStreamLength)
+            net.WriteData(StringSub(events, curpos + 1, curpos + MaxStreamLength + 1), MaxStreamLength)
             net.Broadcast()
 
             curpos = curpos + MaxStreamLength + 1
@@ -260,7 +261,7 @@ function SCORE:StreamToClients()
 
         net.Start("TTT_ReportStream")
         net.WriteUInt(len, 16)
-        net.WriteData(string.sub(events, curpos + 1, len), len - curpos)
+        net.WriteData(StringSub(events, curpos + 1, len), len - curpos)
         net.Broadcast()
     end
 end

--- a/gamemodes/terrortown/gamemode/scoring.lua
+++ b/gamemodes/terrortown/gamemode/scoring.lua
@@ -1,8 +1,16 @@
 ---- Customized scoring
 
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local net = net
+local pairs = pairs
+local player = player
 local string = string
 local table = table
-local pairs = pairs
+local util = util
+
+local GetAllPlayers = player.GetAll
 
 SCORE = SCORE or {}
 SCORE.Events = SCORE.Events or {}
@@ -100,7 +108,7 @@ end
 
 function SCORE:HandleSelection()
     local roles = {}
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         -- Prefix the ID value with a string to force the key to stay as a string when it gets transferred
         -- Without this, the key gets converted to a floating-point number which loses precision and causes errors during data lookup
         roles[GetRoleId(ply:SteamID64())] = ply:GetRole()
@@ -149,7 +157,7 @@ function SCORE:ApplyEventLogScores(wintype)
     local roles = {}
     local bonus = {}
 
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         local sid64 = ply:SteamID64()
         scores[sid64] = {}
         roles[sid64] = ply:GetRole()

--- a/gamemodes/terrortown/gamemode/scoring.lua
+++ b/gamemodes/terrortown/gamemode/scoring.lua
@@ -1,7 +1,6 @@
 ---- Customized scoring
 
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local net = net
 local pairs = pairs

--- a/gamemodes/terrortown/gamemode/scoring_shd.lua
+++ b/gamemodes/terrortown/gamemode/scoring_shd.lua
@@ -3,6 +3,13 @@
 -- 2^16 bytes - 4 (header) - 2 (UInt length in TTT_ReportStream) - 1 (terminanting byte)
 (SERVER and SCORE or CLSCORE).MaxStreamLength = 65529
 
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local scripted_ents = scripted_ents
+local util = util
+local weapons = weapons
+
 function GetRoleId(id)
     return "ID_" .. id
 end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -914,7 +914,7 @@ EVENTS_BY_ROLE = {}
 function GenerateNewEventID(role)
     if not role or role < ROLE_NONE or role > ROLE_MAX then
         -- Print message telling the server owners that the role dev needs to update
-        ErrorNoHalt("WARNING: Role is missing 'role' parameter when generating unique event ID. Contact developer of role and reference: GenerateNewEventID\n")
+        ErrorNoHaltWithStack("WARNING: Role is missing 'role' parameter when generating unique event ID. Contact developer of role and reference: GenerateNewEventID\n")
         role = GetRoleFromStackTrace()
     end
 
@@ -950,7 +950,7 @@ WINS_BY_ROLE = {}
 function GenerateNewWinID(role)
     if not role or role < ROLE_NONE or role > ROLE_MAX then
         -- Print message telling the server owners that the role dev needs to update
-        ErrorNoHalt("WARNING: Role is missing 'role' parameter when generating unique win ID. Contact developer of role and reference: GenerateNewWinID\n")
+        ErrorNoHaltWithStack("WARNING: Role is missing 'role' parameter when generating unique win ID. Contact developer of role and reference: GenerateNewWinID\n")
         role = GetRoleFromStackTrace()
     end
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1117,7 +1117,7 @@ function GM:PlayerFootstep(ply, pos, foot, sound, volume, rf)
         return true
     end
 
-    if hook.Run("TTTBlockPlayerFootstepSound", ply) then
+    if hook.Call("TTTBlockPlayerFootstepSound", nil, ply) then
         return true
     end
 end
@@ -1144,7 +1144,7 @@ function GetSprintMultiplier(ply, sprinting)
     local mult = 1
     if IsValid(ply) then
         local mults = {}
-        hook.Run("TTTSpeedMultiplier", ply, mults)
+        hook.Call("TTTSpeedMultiplier", nil, ply, mults)
         for _, m in pairs(mults) do
             mult = mult * m
         end
@@ -1168,7 +1168,7 @@ function GetSprintMultiplier(ply, sprinting)
 end
 
 function UpdateRoleWeaponState()
-    hook.Run("TTTUpdateRoleState")
+    hook.Call("TTTUpdateRoleState", nil)
 
     if SERVER then
         net.Start("TTT_ResetBuyableWeaponsCache")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,3 +1,14 @@
+local file = file
+local hook = hook
+local ipairs = ipairs
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local string = string
+local table = table
+
+local GetAllPlayers = player.GetAll
 local StringUpper = string.upper
 local StringLower = string.lower
 local StringFind = string.find
@@ -44,18 +55,6 @@ GM.Website = "ttt.badking.net"
 GM.Version = "Custom Roles for TTT v" .. CR_VERSION
 
 GM.Customized = false
-
-local file = file
-local hook = hook
-local ipairs = ipairs
-local IsValid = IsValid
-local math = math
-local net = net
-local pairs = pairs
-local string = string
-local table = table
-
-local GetAllPlayers = player.GetAll
 
 -- Round status consts
 ROUND_WAIT = 1

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,4 @@
 local file = file
-local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
 local math = math
@@ -8,6 +7,8 @@ local pairs = pairs
 local string = string
 local table = table
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetAllPlayers = player.GetAll
 local StringUpper = string.upper
 local StringLower = string.lower
@@ -1117,7 +1118,7 @@ function GM:PlayerFootstep(ply, pos, foot, sound, volume, rf)
         return true
     end
 
-    if hook.Call("TTTBlockPlayerFootstepSound", nil, ply) then
+    if CallHook("TTTBlockPlayerFootstepSound", nil, ply) then
         return true
     end
 end
@@ -1133,7 +1134,7 @@ function GM:Move(ply, mv)
             basemul = 120 / 220
             slowed = true
         end
-        local mul = hook.Call("TTTPlayerSpeedModifier", GAMEMODE, ply, slowed, mv) or 1
+        local mul = RunHook("TTTPlayerSpeedModifier", ply, slowed, mv) or 1
         mul = basemul * mul
         mv:SetMaxClientSpeed(mv:GetMaxClientSpeed() * mul)
         mv:SetMaxSpeed(mv:GetMaxSpeed() * mul)
@@ -1144,7 +1145,7 @@ function GetSprintMultiplier(ply, sprinting)
     local mult = 1
     if IsValid(ply) then
         local mults = {}
-        hook.Call("TTTSpeedMultiplier", nil, ply, mults)
+        CallHook("TTTSpeedMultiplier", nil, ply, mults)
         for _, m in pairs(mults) do
             mult = mult * m
         end
@@ -1168,7 +1169,7 @@ function GetSprintMultiplier(ply, sprinting)
 end
 
 function UpdateRoleWeaponState()
-    hook.Call("TTTUpdateRoleState", nil)
+    CallHook("TTTUpdateRoleState", nil)
 
     if SERVER then
         net.Start("TTT_ResetBuyableWeaponsCache")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -39,6 +39,19 @@ GM.Version = "Custom Roles for TTT v" .. CR_VERSION
 
 GM.Customized = false
 
+local file = file
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local string = string
+local table = table
+
+local GetAllPlayers = player.GetAll
+
 -- Round status consts
 ROUND_WAIT = 1
 ROUND_PREP = 2
@@ -613,11 +626,11 @@ function UpdateRoleStrings()
 
             local plural = GetGlobalString("ttt_" .. ROLE_STRINGS_RAW[role] .. "_name_plural", "")
             if plural == "" then -- Fallback if no plural is given. Does NOT handle all cases properly
-                local lastChar = string.sub(name, name:len(), name:len()):lower()
+                local lastChar = string.lower(string.sub(name, #name, #name))
                 if lastChar == "s" then
                     ROLE_STRINGS_PLURAL[role] = name .. "es"
                 elseif lastChar == "y" then
-                    ROLE_STRINGS_PLURAL[role] = string.sub(name, 1, name:len() - 1) .. "ies"
+                    ROLE_STRINGS_PLURAL[role] = string.sub(name, 1, #name - 1) .. "ies"
                 else
                     ROLE_STRINGS_PLURAL[role] = name .. "s"
                 end
@@ -855,11 +868,11 @@ local function GetRoleFromStackTrace()
             -- Get the file path
             local source = info.short_src
             -- Extract the file name from the path and drop the extension
-            local role_name = string.StripExtension(string.GetFileFromFilename(source)):lower()
+            local role_name = string.lower(string.StripExtension(string.GetFileFromFilename(source)))
 
             -- Find the role whose raw string matches the file name
             for r, str in pairs(ROLE_STRINGS_RAW) do
-                if str:lower() == role_name then
+                if string.lower(str) == role_name then
                     role = r
                     break
                 end
@@ -1253,7 +1266,7 @@ if SERVER then
         local mode = GetConVar("ttt_" .. cvar_role .. "_notify_mode"):GetInt()
         local play_sound = GetConVar("ttt_" .. cvar_role .. "_notify_sound"):GetBool()
         local show_confetti = GetConVar("ttt_" .. cvar_role .. "_notify_confetti"):GetBool()
-        for _, ply in pairs(player.GetAll()) do
+        for _, ply in pairs(GetAllPlayers()) do
             if ply == attacker then
                 local role_string = ROLE_STRINGS[role]
                 ply:PrintMessage(HUD_PRINTCENTER, "You killed the " .. role_string .. "!")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,5 +1,5 @@
 -- Version string for display and function for version checks
-CR_VERSION = "1.4.1"
+CR_VERSION = "1.4.2"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1,16 +1,22 @@
+local StringUpper = string.upper
+local StringLower = string.lower
+local StringFind = string.find
+local StringSplit = string.Split
+local StringSub = string.sub
+
 -- Version string for display and function for version checks
 CR_VERSION = "1.4.2"
 CR_BETA = true
 
 function CRVersion(version)
-    local installedVersionRaw = string.Split(CR_VERSION, ".")
+    local installedVersionRaw = StringSplit(CR_VERSION, ".")
     local installedVersion = {
         major = tonumber(installedVersionRaw[1]),
         minor = tonumber(installedVersionRaw[2]),
         patch = tonumber(installedVersionRaw[3])
     }
 
-    local neededVersionRaw = string.Split(version, ".")
+    local neededVersionRaw = StringSplit(version, ".")
     local neededVersion = {
         major = tonumber(neededVersionRaw[1]),
         minor = tonumber(neededVersionRaw[2]),
@@ -609,7 +615,7 @@ ROLE_STRINGS_SHORT = {
 }
 
 function StartsWithVowel(word)
-    local firstletter = string.sub(word, 1, 1)
+    local firstletter = StringSub(word, 1, 1)
     return firstletter == "a" or
         firstletter == "e" or
         firstletter == "i" or
@@ -625,11 +631,11 @@ function UpdateRoleStrings()
 
             local plural = GetGlobalString("ttt_" .. ROLE_STRINGS_RAW[role] .. "_name_plural", "")
             if plural == "" then -- Fallback if no plural is given. Does NOT handle all cases properly
-                local lastChar = string.lower(string.sub(name, #name, #name))
+                local lastChar = StringLower(StringSub(name, #name, #name))
                 if lastChar == "s" then
                     ROLE_STRINGS_PLURAL[role] = name .. "es"
                 elseif lastChar == "y" then
-                    ROLE_STRINGS_PLURAL[role] = string.sub(name, 1, #name - 1) .. "ies"
+                    ROLE_STRINGS_PLURAL[role] = StringSub(name, 1, #name - 1) .. "ies"
                 else
                     ROLE_STRINGS_PLURAL[role] = name .. "s"
                 end
@@ -698,7 +704,7 @@ function RegisterRole(tbl)
     end
 
     local roleID = ROLE_MAX + 1
-    _G["ROLE_" .. string.upper(tbl.nameraw)] = roleID
+    _G["ROLE_" .. StringUpper(tbl.nameraw)] = roleID
     ROLE_MAX = roleID
 
     ROLE_STRINGS_RAW[roleID] = tbl.nameraw
@@ -831,8 +837,8 @@ local function AddInternalRoles()
     for _, dir in ipairs(dirs) do
         local files, _ = file.Find(root .. dir .. "/*.lua", "LUA")
         for _, fil in ipairs(files) do
-            local isClientFile = string.find(fil, "cl_")
-            local isSharedFile = fil == "shared.lua" or string.find(fil, "sh_")
+            local isClientFile = StringFind(fil, "cl_")
+            local isSharedFile = fil == "shared.lua" or StringFind(fil, "sh_")
 
             if SERVER then
                 -- Send client and shared files to clients
@@ -867,11 +873,11 @@ local function GetRoleFromStackTrace()
             -- Get the file path
             local source = info.short_src
             -- Extract the file name from the path and drop the extension
-            local role_name = string.lower(string.StripExtension(string.GetFileFromFilename(source)))
+            local role_name = StringLower(string.StripExtension(string.GetFileFromFilename(source)))
 
             -- Find the role whose raw string matches the file name
             for r, str in pairs(ROLE_STRINGS_RAW) do
-                if string.lower(str) == role_name then
+                if StringLower(str) == role_name then
                     role = r
                     break
                 end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -912,7 +912,7 @@ end
 
 EVENTS_BY_ROLE = {}
 function GenerateNewEventID(role)
-    if not role or role <= ROLE_NONE or role > ROLE_MAX then
+    if not role or role < ROLE_NONE or role > ROLE_MAX then
         -- Print message telling the server owners that the role dev needs to update
         ErrorNoHalt("WARNING: Role is missing 'role' parameter when generating unique event ID. Contact developer of role and reference: GenerateNewEventID\n")
         role = GetRoleFromStackTrace()
@@ -948,7 +948,7 @@ end
 
 WINS_BY_ROLE = {}
 function GenerateNewWinID(role)
-    if not role or role <= ROLE_NONE or role > ROLE_MAX then
+    if not role or role < ROLE_NONE or role > ROLE_MAX then
         -- Print message telling the server owners that the role dev needs to update
         ErrorNoHalt("WARNING: Role is missing 'role' parameter when generating unique win ID. Contact developer of role and reference: GenerateNewWinID\n")
         role = GetRoleFromStackTrace()

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -872,11 +872,11 @@ EVENT_VAMPPRIME_DEATH = 24
 EVENT_BEGGARCONVERTED = 25
 EVENT_BEGGARKILLED = 26
 EVENT_INFECT = 27
-EVENT_BODYSNATCHERKILLED = 26
+EVENT_BODYSNATCHERKILLED = 28
 
 -- Don't redefine this every time we load this file
 if not EVENT_MAX then
-    EVENT_MAX = 27
+    EVENT_MAX = 28
 end
 
 function GenerateNewEventID()

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -42,7 +42,6 @@ GM.Customized = false
 local file = file
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -1,6 +1,15 @@
+local concommand = concommand
+local hook = hook
+local ipairs = ipairs
+local IsValid = IsValid
+local net = net
+local table = table
+
+local GetAllPlayers = player.GetAll
+
 function GetTraitors()
     local trs = {}
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:IsTraitorTeam() then table.insert(trs, v) end
     end
 
@@ -13,7 +22,7 @@ function CountTraitors() return #GetTraitors() end
 
 -- Send every player their role
 local function SendPlayerRoles()
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         net.Start("TTT_Role")
         net.WriteInt(v:GetRole(), 8)
         net.Send(v)
@@ -37,7 +46,7 @@ end
 
 function SendRoleList(role, ply_or_rf, pred)
     local role_ids = {}
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in ipairs(GetAllPlayers()) do
         if v:IsRole(role) then
             if not pred or (pred and pred(v)) then
                 table.insert(role_ids, v:EntIndex())
@@ -70,7 +79,7 @@ function SendFullStateUpdate()
 end
 
 function SendRoleReset(ply_or_rf)
-    local plys = player.GetAll()
+    local plys = GetAllPlayers()
 
     net.Start("TTT_RoleList")
     net.WriteInt(ROLE_INNOCENT, 8)

--- a/gamemodes/terrortown/gamemode/util.lua
+++ b/gamemodes/terrortown/gamemode/util.lua
@@ -15,6 +15,9 @@ local timer = timer
 local weapons = weapons
 
 local GetAllPlayers = player.GetAll
+local StringUpper = string.upper
+local StringFormat = string.format
+local StringSub = string.sub
 
 -- attempts to get the weapon used from a DamageInfo instance needed because the
 -- GetAmmoType value is useless and inflictor isn't properly set (yet)
@@ -98,7 +101,7 @@ end
 
 -- Uppercases the first character only
 function string.Capitalize(str)
-    return string.upper(string.sub(str, 1, 1)) .. string.sub(str, 2)
+    return StringUpper(StringSub(str, 1, 1)) .. StringSub(str, 2)
 end
 util.Capitalize = string.Capitalize
 
@@ -337,7 +340,7 @@ function Key(binding, default)
     local b = input.LookupBinding(binding)
     if not b then return default end
 
-    return string.upper(b)
+    return StringUpper(b)
 end
 
 local exp = math.exp
@@ -442,5 +445,5 @@ function util.SimpleTime(seconds, fmt)
     seconds = (seconds - s) / 60
     local m = seconds % 60
 
-    return string.format(fmt, m, s, ms)
+    return StringFormat(fmt, m, s, ms)
 end

--- a/gamemodes/terrortown/gamemode/util.lua
+++ b/gamemodes/terrortown/gamemode/util.lua
@@ -2,10 +2,19 @@
 
 if not util then return end
 
+local cvars = cvars
+local input = input
+local ipairs = ipairs
+local IsValid = IsValid
 local math = math
+local pairs = pairs
+local scripted_ents = scripted_ents
 local string = string
 local table = table
-local pairs = pairs
+local timer = timer
+local weapons = weapons
+
+local GetAllPlayers = player.GetAll
 
 -- attempts to get the weapon used from a DamageInfo instance needed because the
 -- GetAmmoType value is useless and inflictor isn't properly set (yet)
@@ -53,7 +62,7 @@ end
 
 function util.GetAlivePlayers()
     local alive = {}
-    for _, p in ipairs(player.GetAll()) do
+    for _, p in ipairs(GetAllPlayers()) do
         if IsValid(p) and p:Alive() and p:IsTerror() then
             table.insert(alive, p)
         end

--- a/gamemodes/terrortown/gamemode/vgui/sb_info.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_info.lua
@@ -1,6 +1,10 @@
 
 ---- Player info panel, based on sandbox scoreboard's infocard
 
+local ipairs = ipairs
+local IsValid = IsValid
+local pairs = pairs
+local surface = surface
 local vgui = vgui
 
 local GetTranslation = LANG.GetTranslation

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -1,12 +1,19 @@
 ---- VGUI panel version of the scoreboard, based on TEAM GARRY's sandbox mode
 ---- scoreboard.
 
-local surface = surface
 local draw = draw
+local hook = hook
+local ipairs = ipairs
+local IsValid = IsValid
 local math = math
+local pairs = pairs
+local surface = surface
 local string = string
+local table = table
+local timer = timer
 local vgui = vgui
 
+local GetAllPlayers = player.GetAll
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 
@@ -412,7 +419,7 @@ function PANEL:UpdateScoreboard(force)
 
     -- Put players where they belong. Groups will dump them as soon as they don't
     -- anymore.
-    for k, p in ipairs(player.GetAll()) do
+    for k, p in ipairs(GetAllPlayers()) do
         if IsValid(p) then
             local group = ScoreGroup(p)
             if self.ply_groups[group] and not self.ply_groups[group]:HasPlayerRow(p) then

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -16,6 +16,8 @@ local vgui = vgui
 local GetAllPlayers = player.GetAll
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
+local StringFormat = string.format
+local StringSub = string.sub
 
 include("sb_team.lua")
 
@@ -54,7 +56,7 @@ local function UntilMapChange()
     time_left = time_left - floor(m * 60)
     local s = floor(time_left)
 
-    return rounds_left, string.format("%02i:%02i:%02i", h, m, s)
+    return rounds_left, StringFormat("%02i:%02i:%02i", h, m, s)
 end
 
 GROUP_TERROR = 1
@@ -350,7 +352,7 @@ function PANEL:PerformLayout()
     local hname = self.hostname:GetValue()
     local tw, _ = surface.GetTextSize(hname)
     while tw > hw do
-        hname = string.sub(hname, 1, -6) .. "..."
+        hname = StringSub(hname, 1, -6) .. "..."
         tw, _ = surface.GetTextSize(hname)
     end
 

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -5,7 +5,6 @@ local draw = draw
 local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
-local math = math
 local pairs = pairs
 local surface = surface
 local string = string
@@ -18,6 +17,11 @@ local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 local StringFormat = string.format
 local StringSub = string.sub
+
+local clamp = math.Clamp
+local max = math.max
+local min = math.min
+local floor = math.floor
 
 include("sb_team.lua")
 
@@ -44,8 +48,6 @@ local logo = surface.GetTextureID("vgui/ttt/score_logo")
 
 local PANEL = {}
 
-local max = math.max
-local floor = math.floor
 local function UntilMapChange()
     local rounds_left = max(0, GetGlobalInt("ttt_rounds_left", 6))
     local time_left = floor(max(0, ((GetGlobalInt("ttt_time_limit_minutes") or 60) * 60) - CurTime()))
@@ -330,12 +332,12 @@ function PANEL:PerformLayout()
     --   gui.EnableScreenClicker(scrolling)
     self.ply_frame:SetScroll(scrolling)
 
-    h = math.Clamp(h, 110 + y_logo_off, ScrH() * 0.95)
+    h = clamp(h, 110 + y_logo_off, ScrH() * 0.95)
 
-    local w = math.max(ScrW() * 0.6, 640)
+    local w = max(ScrW() * 0.6, 640)
 
     self:SetSize(w, h)
-    self:SetPos((ScrW() - w) / 2, math.min(72, (ScrH() - h) / 4))
+    self:SetPos((ScrW() - w) / 2, min(72, (ScrH() - h) / 4))
 
     self.ply_frame:SetPos(8, y_logo_off + 109)
     self.ply_frame:SetSize(self:GetWide() - 16, self:GetTall() - 109 - y_logo_off - 5)

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -2,7 +2,6 @@
 ---- scoreboard.
 
 local draw = draw
-local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
 local pairs = pairs
@@ -12,6 +11,7 @@ local table = table
 local timer = timer
 local vgui = vgui
 
+local CallHook = hook.Call
 local GetAllPlayers = player.GetAll
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
@@ -83,7 +83,7 @@ function ScoreGroup(p)
     if not IsValid(p) then return -1 end -- will not match any group panel
 
     local fake_dead = (p.IsFakeDead and p:IsFakeDead())
-    local group = hook.Call("TTTScoreGroup", nil, p)
+    local group = CallHook("TTTScoreGroup", nil, p)
     -- Ignore the Dead Ringer's scoreboard override because it doesn't work with custom roles
     -- Otherwise, if that hook gave us a group, use it
     if group and not fake_dead then
@@ -181,7 +181,7 @@ function PANEL:Init()
         self.ply_groups[GROUP_SEARCHED] = t
     end
 
-    hook.Call("TTTScoreGroups", nil, self.ply_frame:GetCanvas(), self.ply_groups)
+    CallHook("TTTScoreGroups", nil, self.ply_frame:GetCanvas(), self.ply_groups)
 
     -- the various score column headers
     self.cols = {}
@@ -198,7 +198,7 @@ function PANEL:Init()
     self:AddFakeColumn(GetTranslation("equip_spec_name"), nil, 70, "name")
 
     -- Let hooks add their column headers (via AddColumn() or AddFakeColumn())
-    hook.Call("TTTScoreboardColumns", nil, self)
+    CallHook("TTTScoreboardColumns", nil, self)
 
     self:UpdateScoreboard()
     self:StartUpdateTimer()

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -234,7 +234,7 @@ function PANEL:Paint(width, height)
     end
 
     -- Allow external addons (like new roles) to manipulate how a player appears on the scoreboard
-    local new_color, new_role_str, flash_role = hook.Run("TTTScoreboardPlayerRole", ply, client, c, roleStr)
+    local new_color, new_role_str, flash_role = hook.Call("TTTScoreboardPlayerRole", nil, ply, client, c, roleStr)
     if new_color then c = new_color end
     if new_role_str then roleStr = new_role_str end
 
@@ -316,7 +316,7 @@ function PANEL:UpdatePlayerData()
     local client = LocalPlayer()
     self.nick:SetText(ply:Nick())
     if GetRoundState() >= ROUND_ACTIVE then
-        local nick_override = hook.Run("TTTScoreboardPlayerName", ply, client, self.nick:GetText())
+        local nick_override = hook.Call("TTTScoreboardPlayerName", nil, ply, client, self.nick:GetText())
         if nick_override then self.nick:SetText(nick_override) end
     end
 

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -13,6 +13,8 @@ local table = table
 local timer = timer
 local vgui = vgui
 
+local CallHook = hook.Call
+local RunHook = hook.Run
 local GetTranslation = LANG.GetTranslation
 local MathClamp = math.Clamp
 local MathMax = math.max
@@ -55,7 +57,7 @@ function PANEL:Init()
     end
 
     -- Let hooks add their custom columns
-    hook.Call("TTTScoreboardColumns", nil, self)
+    CallHook("TTTScoreboardColumns", nil, self)
 
     for _, c in ipairs(self.cols) do
         c:SetMouseInputEnabled(false)
@@ -174,7 +176,7 @@ end
 
 local function ColorForPlayer(ply)
     if IsValid(ply) then
-        local c = hook.Call("TTTScoreboardColorForPlayer", GAMEMODE, ply)
+        local c = RunHook("TTTScoreboardColorForPlayer", ply)
 
         -- verify that we got a proper color
         if c and istable(c) and c.r and c.b and c.g and c.a then
@@ -202,7 +204,7 @@ function PANEL:Paint(width, height)
     --   end
 
     local ply = self.Player
-    local c = hook.Run("TTTScoreboardRowColorForPlayer", ply)
+    local c = RunHook("TTTScoreboardRowColorForPlayer", ply)
 
     -- Use the default color for players without roles
     if type(c) == "number" and c <= ROLE_NONE then
@@ -234,7 +236,7 @@ function PANEL:Paint(width, height)
     end
 
     -- Allow external addons (like new roles) to manipulate how a player appears on the scoreboard
-    local new_color, new_role_str, flash_role = hook.Call("TTTScoreboardPlayerRole", nil, ply, client, c, roleStr)
+    local new_color, new_role_str, flash_role = CallHook("TTTScoreboardPlayerRole", nil, ply, client, c, roleStr)
     if new_color then c = new_color end
     if new_role_str then roleStr = new_role_str end
 
@@ -316,7 +318,7 @@ function PANEL:UpdatePlayerData()
     local client = LocalPlayer()
     self.nick:SetText(ply:Nick())
     if GetRoundState() >= ROUND_ACTIVE then
-        local nick_override = hook.Call("TTTScoreboardPlayerName", nil, ply, client, self.nick:GetText())
+        local nick_override = CallHook("TTTScoreboardPlayerName", nil, ply, client, self.nick:GetText())
         if nick_override then self.nick:SetText(nick_override) end
     end
 
@@ -435,7 +437,7 @@ function PANEL:DoRightClick()
     local menu = DermaMenu()
     menu.Player = self:GetPlayer()
 
-    local close = hook.Call("TTTScoreboardMenu", nil, menu)
+    local close = CallHook("TTTScoreboardMenu", nil, menu)
     if close then
         menu:Remove()
         return

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -7,7 +7,6 @@ local file = file
 local hook = hook
 local ipairs = ipairs
 local IsValid = IsValid
-local math = math
 local pairs = pairs
 local surface = surface
 local table = table
@@ -15,6 +14,11 @@ local timer = timer
 local vgui = vgui
 
 local GetTranslation = LANG.GetTranslation
+local MathClamp = math.Clamp
+local MathMax = math.max
+local MathMin = math.min
+local MathRound = math.Round
+local MathSin = math.sin
 
 SB_ROW_HEIGHT = 24 --16
 
@@ -32,17 +36,17 @@ function PANEL:Init()
     if KARMA.IsEnabled() then
         self:AddColumn(GetTranslation("sb_karma"), function(ply)
             if GetConVar("ttt_show_raw_karma_value"):GetBool() then
-                return math.Round(ply:GetBaseKarma())
+                return MathRound(ply:GetBaseKarma())
             else
                 local dmgpct = 100
                 if ply:GetBaseKarma() < 1000 then
                     local k = ply:GetBaseKarma() - 1000
                     if GetGlobalBool("ttt_karma_strict", false) then
-                        dmgpct = math.Round(math.Clamp(1 + (0.0007 * k) + (-0.000002 * (k ^ 2)), 0.1, 1.0) * 100)
+                        dmgpct = MathRound(MathClamp(1 + (0.0007 * k) + (-0.000002 * (k ^ 2)), 0.1, 1.0) * 100)
                     elseif GetGlobalBool("ttt_karma_lenient", false) then
-                        dmgpct = math.Round(math.Clamp(1 + (0.0005 * k) + (-0.0000005 * (k ^ 2)), 0.1, 1.0) * 100)
+                        dmgpct = MathRound(MathClamp(1 + (0.0005 * k) + (-0.0000005 * (k ^ 2)), 0.1, 1.0) * 100)
                     else
-                        dmgpct = math.Round(math.Clamp(1 + (-0.0000025 * (k ^ 2)), 0.1, 1.0) * 100)
+                        dmgpct = MathRound(MathClamp(1 + (-0.0000025 * (k ^ 2)), 0.1, 1.0) * 100)
                     end
                 end
                 return dmgpct .. "%"
@@ -183,7 +187,7 @@ local function ColorForPlayer(ply)
 end
 
 local function DrawFlashingBorder(width, role)
-    surface.SetDrawColor(ColorAlpha(ROLE_COLORS[role], math.Round(math.sin(RealTime() * 8) / 2 + 0.5) * 20))
+    surface.SetDrawColor(ColorAlpha(ROLE_COLORS[role], MathRound(MathSin(RealTime() * 8) / 2 + 0.5) * 20))
     surface.DrawRect(0, 0, width, SB_ROW_HEIGHT)
     surface.SetDrawColor(ROLE_COLORS_DARK[role])
     surface.DrawOutlinedRect(SB_ROW_HEIGHT, 0, width - SB_ROW_HEIGHT, SB_ROW_HEIGHT)
@@ -253,7 +257,7 @@ function PANEL:Paint(width, height)
     end
 
     if ply == client then
-        surface.SetDrawColor(200, 200, 200, math.Clamp(math.sin(RealTime() * 2) * 50, 0, 100))
+        surface.SetDrawColor(200, 200, 200, MathClamp(MathSin(RealTime() * 2) * 50, 0, 100))
         surface.DrawRect(0, 0, width, SB_ROW_HEIGHT)
     end
 
@@ -448,8 +452,8 @@ function PANEL:ShowMicVolumeSlider()
     local sliderHeight = 16
     local sliderDisplayHeight = 8
 
-    local x = math.max(gui.MouseX() - width, 0)
-    local y = math.min(gui.MouseY(), ScrH() - height)
+    local x = MathMax(gui.MouseX() - width, 0)
+    local y = MathMin(gui.MouseY(), ScrH() - height)
 
     local currentPlayerVolume = self:GetPlayer():GetVoiceVolumeScale()
     currentPlayerVolume = currentPlayerVolume ~= nil and currentPlayerVolume or 1
@@ -509,7 +513,7 @@ function PANEL:ShowMicVolumeSlider()
     -- Render slider "knob" & text
     slider.Knob.Paint = function(s, w, h)
         if slider:IsEditing() then
-            local textValue = math.Round(slider:GetSlideX() * 100) .. "%"
+            local textValue = MathRound(slider:GetSlideX() * 100) .. "%"
             local textPadding = 5
 
             -- The position of the text and size of rounded box are not relative to the text size. May cause problems if font size changes

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -2,6 +2,18 @@
 
 include("sb_info.lua")
 
+local draw = draw
+local file = file
+local hook = hook
+local ipairs = ipairs
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local surface = surface
+local table = table
+local timer = timer
+local vgui = vgui
+
 local GetTranslation = LANG.GetTranslation
 
 SB_ROW_HEIGHT = 24 --16

--- a/gamemodes/terrortown/gamemode/vgui/simpleicon.lua
+++ b/gamemodes/terrortown/gamemode/vgui/simpleicon.lua
@@ -1,6 +1,14 @@
 -- Altered version of gmod's SpawnIcon
 -- This panel does not deal with models and such
 
+local draw = draw
+local ipairs = ipairs
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local surface = surface
+local table = table
+local vgui = vgui
 
 local matHover = Material( "vgui/spawnmenu/hover" )
 

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -1,7 +1,25 @@
 include("weaponry_shd.lua") -- inits WEPS tbl
 
+local concommand = concommand
+local file = file
+local hook = hook
+local ipairs = ipairs
+local IsPlayer = IsPlayer
+local IsValid = IsValid
+local math = math
+local net = net
+local pairs = pairs
+local player = player
+local string = string
+local table = table
+local timer = timer
+local util = util
+local weapons = weapons
+
 ---- Weapon system, pickup limits, etc
 
+local GetAllPlayers = player.GetAll
+local CreateEntity = ents.Create
 local IsEquipment = WEPS.IsEquipment
 
 -- Prevent players from picking up multiple weapons of the same type etc
@@ -146,7 +164,7 @@ local function GiveLoadoutSpecial(ply)
     if ply:IsActiveDetectiveTeam() and GetConVar("ttt_detective_hats"):GetBool() and CanWearHat(ply) then
 
         if not IsValid(ply.hat) then
-            local hat = ents.Create("ttt_hat_deerstalker")
+            local hat = CreateEntity("ttt_hat_deerstalker")
             if not IsValid(hat) then return end
 
             hat:SetPos(ply:GetPos() + Vector(0, 0, 70))
@@ -210,7 +228,7 @@ function GM:PlayerLoadout(ply)
 end
 
 function GM:UpdatePlayerLoadouts()
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in ipairs(GetAllPlayers()) do
         hook.Call("PlayerLoadout", GAMEMODE, ply)
     end
 end
@@ -299,7 +317,7 @@ local function DropActiveAmmo(ply)
 
     ply:AnimPerformGesture(ACT_GMOD_GESTURE_ITEM_GIVE)
 
-    local box = ents.Create(wep.AmmoEnt)
+    local box = CreateEntity(wep.AmmoEnt)
     if not IsValid(box) then return end
 
     box:SetPos(pos + dir)
@@ -559,7 +577,7 @@ concommand.Add("ttt_order_equipment", OrderEquipment)
 concommand.Add("ttt_order_for_someone", function(ply, cmd, args)
     local target_name = args[1]
     local target = nil
-    for _, v in pairs(player.GetAll()) do
+    for _, v in pairs(GetAllPlayers()) do
         if target_name == v:Nick() then
             target = v
             break
@@ -719,12 +737,12 @@ net.Receive("TTT_ConfigureRoleWeapons", function(len, ply)
         return
     end
 
-    local id = net.ReadString():lower()
+    local id = string.lower(net.ReadString())
     local role = net.ReadInt(8)
     local includeSelected = net.ReadBool()
     local excludeSelected = net.ReadBool()
     local noRandomSelected = net.ReadBool()
-    local roleName = ROLE_STRINGS_RAW[role]:lower()
+    local roleName = string.lower(ROLE_STRINGS_RAW[role])
 
     -- Ensure directories exist
     if not file.IsDir("roleweapons", "DATA") then

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -20,6 +20,7 @@ local weapons = weapons
 local GetAllPlayers = player.GetAll
 local CreateEntity = ents.Create
 local IsEquipment = WEPS.IsEquipment
+local StringLower = string.lower
 
 -- Prevent players from picking up multiple weapons of the same type etc
 function GM:PlayerCanPickupWeapon(ply, wep)
@@ -736,12 +737,12 @@ net.Receive("TTT_ConfigureRoleWeapons", function(len, ply)
         return
     end
 
-    local id = string.lower(net.ReadString())
+    local id = StringLower(net.ReadString())
     local role = net.ReadInt(8)
     local includeSelected = net.ReadBool()
     local excludeSelected = net.ReadBool()
     local noRandomSelected = net.ReadBool()
-    local roleName = string.lower(ROLE_STRINGS_RAW[role])
+    local roleName = StringLower(ROLE_STRINGS_RAW[role])
 
     -- Ensure directories exist
     if not file.IsDir("roleweapons", "DATA") then

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -4,7 +4,6 @@ local concommand = concommand
 local file = file
 local hook = hook
 local ipairs = ipairs
-local IsPlayer = IsPlayer
 local IsValid = IsValid
 local math = math
 local net = net

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -1,5 +1,14 @@
 WEPS = {}
 
+local ipairs = ipairs
+local IsValid = IsValid
+local math = math
+local pairs = pairs
+local table = table
+local util = util
+
+local GetWeapons = weapons.GetList
+
 function WEPS.TypeForWeapon(class)
     local tbl = util.WeaponForClass(class)
     return tbl and tbl.Kind or WEAPON_NONE
@@ -73,7 +82,7 @@ end
 
 function WEPS.ResetWeaponsCache()
     -- Reset the CanBuy list or save the original for next time
-    for _, v in pairs(weapons.GetList()) do
+    for _, v in pairs(GetWeapons()) do
         if v and v.CanBuy then
             if v.CanBuyOrig then
                 v.CanBuy = table.Copy(v.CanBuyOrig)
@@ -122,7 +131,7 @@ function WEPS.DoesRoleHaveWeapon(role, promoted)
         return true
     end
 
-    for _, w in ipairs(weapons.GetList()) do
+    for _, w in ipairs(GetWeapons()) do
         if w and w.CanBuy and table.HasValue(w.CanBuy, role) then
             DoesRoleHaveWeaponCache[role] = true
             return true

--- a/lua/autorun/server/force_download.lua
+++ b/lua/autorun/server/force_download.lua
@@ -1,4 +1,6 @@
 if SERVER then
+    local resource = resource
+
     ---------------
     -- Materials --
     ---------------


### PR DESCRIPTION
**Additions**
- Added ability to allow spirits to see eachother when there is a medium (enabled by default)

**Changes**
- Changed voice keybind handling to work with upcoming permission system
- Changed large parts across most of the addon in an attempt to increase performance

**Fixes**
- Fixed bodysnatcher killed event redefining existing event ID
- Fixed freeze in round summary when a player has multi-byte characters in their name
- Fixed round summary highlights player stats spacing
- Fixed killing a jester team member causing the team kill "awards" to show on the round summary highlight tab
- Fixed medium being told there was a medium when they died
- Fixed assassin not getting a new target when their target's role changes to one that is an invalid target

**Developer**
- Added parameter to `GenerateNewEventID` to allow roles to associate generated event IDs back to the role
- Added warning message to `GenerateNewEventID` when role parameter is missing so developers know to update
- Added parameter to `GenerateNewWinID` to allow roles to associate generated win IDs back to the role
- Added warning message to `GenerateNewWinID` when role parameter is missing so developers know to update

*NOTE*: If the role parameter is not passed, we try to figure out the role that the generated ID belongs to but this is not promised to work. Developers should update to use the new parameter as soon as possible. Developers who are using these methods to generate IDs not linked to roles should pass `ROLE_NONE`.