### PR TITLE
Misc. fixes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -362,9 +362,17 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *smokeParticle* - The new smokeParticle value to use or the original passed into the hook
 - *smokeOffset* - The new smokeOffset value to use or the original passed into the hook
 
+**TTTSyncEventIDs()** - Called when the server is syncing generated event IDs to the client.\
+*Realm:* Client\
+*Added in:* 1.4.6
+
 **TTTSyncGlobals()** - Called when the server is syncing convars to global variables for client access.\
 *Realm:* Server\
 *Added in:* 1.2.7
+
+**TTTSyncWinIDs()** - Called when the server is syncing generated win IDs to the client.\
+*Realm:* Client\
+*Added in:* 1.4.6
 
 **TTTTargetIDPlayerBlockIcon(ply, client)** - Called before a player's overhead icon is shown, allowing you to block it.\
 *Realm:* Client\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -182,7 +182,10 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 *Added in:* 1.4.1\
 *Parameters:*
 - *wintype* - The round win type
-- *secondaryWins* - The table of role identifiers for roles who should have a secondary win on the round summary. Insert any role identifiers you would like to display into this table
+- *secondaryWins* - The table of role information for who should have a secondary win on the round summary. Insert any role data you would like to display into this table. Role data can either be the role's identifier (to use the default text and color logic) or, *as of version 1.4.6*, a table of the following data (to use your own text and colors):
+  - rol - The role identifier
+  - txt - The text to display
+  - col - The background color to use
 
 **TTTScoringSummaryRender(ply, roleFileName, groupingRole, roleColor, nameLabel, startingRole, finalRole)** - Called before the round summary screen is shown. Used to modify the color, position, and icon for a player.\
 *Realm:* Client\

--- a/API/METHODS_GLOBAL.md
+++ b/API/METHODS_GLOBAL.md
@@ -24,16 +24,20 @@ Methods available globally (within the defined realm)
 *Returns*: An accessible position around the given position or `false` if none can be found
 
 **GenerateNewEventID(role)** - Generates a new ID to be used for custom scoring events.\
-*Realm:* Client and Server\
+*Realm:* Client *(Deprecated in 1.4.6)* and Server\
 *Added in:* 1.2.5\
 *Parameters:*
 - *role* - The ID of the role that the generated event ID belongs to. Pass `ROLE_NONE` if this should not be associated with any role *(Added in 1.4.2)*
 
+*NOTE:* To get this value on the client, use the `TTTSyncEventIDs` hook and pull the value out of the `EVENTS_BY_ROLE` global table
+
 **GenerateNewWinID(role)** - Generates a new ID to be used for custom win conditions.\
-*Realm:* Client and Server\
+*Realm:* Client *(Deprecated in 1.4.6)* and Server\
 *Added in:* 1.2.5\
 *Parameters:*
 - *role* - The ID of the role that the generated win ID belongs to. Pass `ROLE_NONE` if this should not be associated with any role *(Added in 1.4.2)*
+
+*NOTE:* To get this value on the client, use the `TTTSyncWinIDs` hook and pull the value out of the `WINS_BY_ROLE` global table
 
 **GetEquipmentItemById(id)** - Gets an equipment item's definition by their ID.\
 *Realm:* Client and Server\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 - Fixed the "A loot goblin has been spotted!" message not updating when the role is renamed
 
 ### Developer
+- Added ability to pass a table of role data to the TTTScoringSecondaryWins hook to customize how secondary wins are displayed
 - Reworked Event ID and Win ID generation to fix case where external roles could have their conditions conflict due to the client and server not generating IDs in the same order. This involved the following changes:
   - **BREAKING CHANGE** - Deprecated `GenerateNewEventID` on the client and made it a no-op that prints an error message reminding the developer to update
   - **BREAKING CHANGE** - Deprecated `GenerateNewWinID` on the client and made it a no-op that prints an error message reminding the developer to update

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,13 @@
 ### Fixes
 - Fixed error caused by vampire fangs when trying to consume a body that didn't contain player information
 
+### Developer
+- Reworked Event ID and Win ID generation to fix case where external roles could have their conditions conflict due to the client and server not generating IDs in the same order. This involved the following changes:
+  - **BREAKING CHANGE** - Deprecated `GenerateNewEventID` on the client and made it a no-op that prints an error message reminding the developer to update
+  - **BREAKING CHANGE** - Deprecated `GenerateNewWinID` on the client and made it a no-op that prints an error message reminding the developer to update
+  - Added TTTSyncEventIDs hook to allow developers to get generated Event IDs on the client after they have been synced
+  - Added TTTSyncWinIDs hook to allow developers to get generated Win IDs on the client after they have been synced
+
 ## 1.4.5 (Beta)
 **Released: January 8th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.4.6 (Beta)
+**Released:**
+
+### Fixes
+- Fixed error caused by vampire fangs when trying to consume a body that didn't contain player information
+
 ## 1.4.5 (Beta)
 **Released: January 8th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Changes
 - Changed role selection logic to shuffle the list of players to hopefully help the randomization
+- Changed role vision logic to hopefully increase performance for traitors
 
 ### Fixes
 - Fixed error caused by vampire fangs when trying to consume a body that didn't contain player information

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -276,7 +276,7 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
 - Added ability to set a different amount of health overheal if a vampire drains a living target (disabled by default)
 - Added ability to block rewarding vampires when they (or their allies) kill someone (disabled by default)
 - Added ability to give the veteran credits when they are activated (disabled by default)
-- Added ability to set the maximum number of players before "single jester or indepdent" is automatically disabled (disabled by default)
+- Added ability to set the maximum number of players before "single jester or independent" is automatically disabled (disabled by default)
 
 ### Changes
 - Changed custom win events to show in the end-of-round summary's Events tab with an "unknown win event" message until the new TTTEventFinishText hooks are used
@@ -289,7 +289,7 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
   - This does allow players who are resurrected after the assassin is assigned their final target to slide under the radar
 - Fixed roles with custom win conditions being able to block jester, clown, and old man wins as well as drunks remembering their role
 - Fixed traitor vampires being able to drain glitches
-- Fixed promoted deputies not being grouped with other detectives in assassin targetting logic
+- Fixed promoted deputies not being grouped with other detectives in assassin targeting logic
 - Fixed independent vampire popup still having "{comrades}" placeholder
 - Fixed a drunk who becomes a clown in the same round as another jester role showing in the same row on the round summary screen
 - Fixed error when a vampire is killed after they release a target being drained but before that target gets unfrozen
@@ -298,7 +298,7 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
 - Added TTTBlockPlayerFootstepSound hook to block a player's footstep sound
 - Added TTTKarmaGiveReward hook to block a player from receiving karma
 - Added TTTKarmaShouldGivePenalty hook to determine whether a player should have their karma rewarded or penalized
-- Added TTTPlayerSpawnForRound hook to react to when a player is spawned (or respawed)
+- Added TTTPlayerSpawnForRound hook to react to when a player is spawned (or respawned)
 - Added TTTEventFinishText and TTTEventFinishIconText hooks to add detail to the round finished event row for custom win conditions
 - Added TTTPlayerRoleChanged hook to react to when a player's role changes
 - Added TTTShouldPlayerSmoke hook to affect whether a player should smoke and how that should look
@@ -343,7 +343,7 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
 - Added ability for hypnotist device to convert detective and deputies that appear as detective to impersonator (disabled by default)
 - Added ability for traitor or quack to buy an exorcism device usable to remove a haunting phantom (disabled by default)
 - Added configuration for whether assassin damage bonus applies to weapons bought from the shop (enabled by default)
-- Added ability for bodysnatcher's role change to be hidden based on which team they joined (disbled by default)
+- Added ability for bodysnatcher's role change to be hidden based on which team they joined (disabled by default)
 - Added a shop icon for the bomb station
 - Added new microphone volume tip from base TTT
 
@@ -372,8 +372,8 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
 - Added TTTTargetIDPlayerHintText hook for controlling what text to show when rendering an entity's hint text
 - Added TTTTargetIDPlayerName hook for controlling what text to show when rendering a player's name
 - Added TTTTargetIDRagdollName hook for controlling what text to show when rendering a ragdoll's name
-- Added `plymeta:ShouldRevealBeggar` to determine if a palyer should be able to tell that a target player is no longer a beggar (e.g. converted to an innocent or traitor)
-- Added `plymeta:ShouldRevealBodysnatcher` to determine if a palyer should be able to tell that a target player is no longer a bodysnatcher (e.g. has snatched a role from a dead body)
+- Added `plymeta:ShouldRevealBeggar` to determine if a player should be able to tell that a target player is no longer a beggar (e.g. converted to an innocent or traitor)
+- Added `plymeta:ShouldRevealBodysnatcher` to determine if a player should be able to tell that a target player is no longer a bodysnatcher (e.g. has snatched a role from a dead body)
 - Added `was_bodysnatcher` property to TTTRadarPlayerRender hook's `tgt` parameter
 - Changed the global `ShouldHideJesters` to be deprecated in favor of `plymeta:ShouldHideJesters`
 - Fixed returning false for either text value in TTTTargetIDPlayerText hook not actually stopping the original text from being used
@@ -435,7 +435,7 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
 - Fixed translations in C4 UI not working sometimes
 - Fixed a player who is turning into a zombie not stopping the round from ending
 - Fixed medium ghosts creating shadows
-- Adjusted medium ghost logic to hopefully fix another "floating kliener" case
+- Adjusted medium ghost logic to hopefully fix another "floating kleiner" case
 
 ### Developer
 - Added `plymeta:GiveDelayedShopItems` to give a player their delayed shop items

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.4.6 (Beta)
 **Released:**
 
+### Changes
+- Changed role selection logic to shuffle the list of players to hopefully help the randomization
+
 ### Fixes
 - Fixed error caused by vampire fangs when trying to consume a body that didn't contain player information
 - Fixed the "A loot goblin has been spotted!" message not updating when the role is renamed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed error caused by vampire fangs when trying to consume a body that didn't contain player information
+- Fixed the "A loot goblin has been spotted!" message not updating when the role is renamed
 
 ### Developer
 - Reworked Event ID and Win ID generation to fix case where external roles could have their conditions conflict due to the client and server not generating IDs in the same order. This involved the following changes:

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -121,8 +121,18 @@ function SWEP:CanConvert()
 end
 
 local function GetPlayerFromBody(body)
-    local ply = player.GetBySteamID64(body.sid64) or player.GetBySteamID(body.sid)
+    local ply = false
+
+    if body.sid64 then
+        ply = player.GetBySteamID64(body.sid64)
+    elseif body.sid == "BOT" then
+        ply = player.GetByUniqueID(body.uqid)
+    else
+        ply = player.GetBySteamID(body.sid)
+    end
+
     if not IsValid(ply) then return false end
+
     return ply
 end
 

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -18,6 +18,7 @@ local vgui = vgui
 
 local CallHook = hook.Call
 local RunHook = hook.Run
+local RemoveHook = hook.Remove
 local GetAllPlayers = player.GetAll
 local MathApproach = math.Approach
 local MathMax = math.max
@@ -233,7 +234,7 @@ local function ReceiveRole()
 
     -- Disable highlights on role change
     if vision_enabled then
-        hook.Remove("PreDrawHalos", "AddPlayerHighlights")
+        RemoveHook("PreDrawHalos", "AddPlayerHighlights")
         vision_enabled = false
     end
 
@@ -887,7 +888,7 @@ end
 function HandleRoleHighlights(client)
     if not IsValid(client) then return end
 
-    if client:IsTraitorTeam() and traitor_vision then
+    if traitor_vision and client:IsTraitorTeam() then
         if not vision_enabled then
             EnableTraitorHighlights(client)
             vision_enabled = true
@@ -896,8 +897,8 @@ function HandleRoleHighlights(client)
         vision_enabled = false
     end
 
-    if not vision_enabled then
-        hook.Remove("PreDrawHalos", "AddPlayerHighlights")
+    if traitor_vision and not vision_enabled then
+        RemoveHook("PreDrawHalos", "AddPlayerHighlights")
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -642,9 +642,15 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     winlbl:SetPos(xwin, ywin)
 
     for i, r in ipairs(secondary_win_roles) do
+        local role_string
+        if type(r) == "table" then
+            role_string = r.txt
+        else
+            role_string = PT("hilite_win_role_singular_additional", { role = StringUpper(ROLE_STRINGS[r]) })
+        end
         local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = StringUpper(ROLE_STRINGS[r]) }))
+        exwinlbl:SetText(role_string)
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2
@@ -655,9 +661,15 @@ function CLSCORE:BuildSummaryPanel(dpanel)
     bg.PaintOver = function()
         draw.RoundedBox(8, 8, ywin - 5, w - 14, winlbl:GetTall() + 10, title.c)
         for i, r in ipairs(secondary_win_roles) do
+            local role_color
+            if type(r) == "table" then
+                role_color = r.col
+            else
+                role_color = ROLE_COLORS[r]
+            end
             local round_bottom = i == #secondary_win_roles
             local height = 28
-            draw.RoundedBoxEx(8, 8, 65 + (height * (i - 1)), w - 14, height, ROLE_COLORS[r], false, false, round_bottom, round_bottom)
+            draw.RoundedBoxEx(8, 8, 65 + (height * (i - 1)), w - 14, height, role_color, false, false, round_bottom, round_bottom)
         end
         draw.RoundedBox(0, 8, ywin + winlbl:GetTall() + 15 + height_extra_secondaries, 341, 329 + height_extra, Color(164, 164, 164, 255))
         draw.RoundedBox(0, 357, ywin + winlbl:GetTall() + 15 + height_extra_secondaries, 341, 329 + height_extra, Color(164, 164, 164, 255))
@@ -936,9 +948,15 @@ function CLSCORE:BuildHilitePanel(dpanel)
     winlbl:SetPos(xwin, ywin)
 
     for i, r in ipairs(secondary_win_roles) do
+        local role_string
+        if type(r) == "table" then
+            role_string = r.txt
+        else
+            role_string = PT("hilite_win_role_singular_additional", { role = StringUpper(ROLE_STRINGS[r]) })
+        end
         local exwinlbl = vgui.Create("DLabel", dpanel)
         exwinlbl:SetFont("WinSmall")
-        exwinlbl:SetText(PT("hilite_win_role_singular_additional", { role = StringUpper(ROLE_STRINGS[r]) }))
+        exwinlbl:SetText(role_string)
         exwinlbl:SetTextColor(COLOR_WHITE)
         exwinlbl:SizeToContents()
         local xexwin = (w - exwinlbl:GetWide()) / 2
@@ -949,9 +967,15 @@ function CLSCORE:BuildHilitePanel(dpanel)
     bg.PaintOver = function()
         draw.RoundedBox(8, 8, ywin - 5, w - 14, winlbl:GetTall() + 10, title.c)
         for i, r in ipairs(secondary_win_roles) do
+            local role_color
+            if type(r) == "table" then
+                role_color = r.col
+            else
+                role_color = ROLE_COLORS[r]
+            end
             local round_bottom = i == #secondary_win_roles
             local height = 28
-            draw.RoundedBoxEx(8, 8, 65 + (height * (i - 1)), w - 14, height, ROLE_COLORS[r], false, false, round_bottom, round_bottom)
+            draw.RoundedBoxEx(8, 8, 65 + (height * (i - 1)), w - 14, height, role_color, false, false, round_bottom, round_bottom)
         end
     end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1302,6 +1302,7 @@ function SelectRoles()
         end
     end
 
+    table.Shuffle(choices)
     local choice_count = #choices
 
     -- special spawning cvars

--- a/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
@@ -4,6 +4,7 @@ local IsValid = IsValid
 local pairs = pairs
 local string = string
 
+local RemoveHook = hook.Remove
 local GetAllPlayers = player.GetAll
 
 ------------------
@@ -106,7 +107,7 @@ hook.Add("TTTUpdateRoleState", "Assassin_Highlight_TTTUpdateRoleState", function
 
     -- Disable highlights on role change
     if vision_enabled then
-        hook.Remove("PreDrawHalos", "Assassin_Highlight_PreDrawHalos")
+        RemoveHook("PreDrawHalos", "Assassin_Highlight_PreDrawHalos")
         vision_enabled = false
     end
 end)
@@ -124,8 +125,8 @@ hook.Add("Think", "Assassin_Highlight_Think", function()
         vision_enabled = false
     end
 
-    if not vision_enabled then
-        hook.Remove("PreDrawHalos", "Assassin_Highlight_PreDrawHalos")
+    if assassin_target_vision and not vision_enabled then
+        RemoveHook("PreDrawHalos", "Assassin_Highlight_PreDrawHalos")
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -1,6 +1,8 @@
 local hook = hook
 local string = string
 
+local RemoveHook = hook.Remove
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -69,7 +71,7 @@ hook.Add("TTTUpdateRoleState", "Killer_Highlight_TTTUpdateRoleState", function()
 
     -- Disable highlights on role change
     if vision_enabled then
-        hook.Remove("PreDrawHalos", "Killer_Highlight_PreDrawHalos")
+        RemoveHook("PreDrawHalos", "Killer_Highlight_PreDrawHalos")
         vision_enabled = false
     end
 end)
@@ -87,8 +89,8 @@ hook.Add("Think", "Killer_Highlight_Think", function()
         vision_enabled = false
     end
 
-    if not vision_enabled then
-        hook.Remove("PreDrawHalos", "Killer_Highlight_PreDrawHalos")
+    if killer_vision and not vision_enabled then
+        RemoveHook("PreDrawHalos", "Killer_Highlight_PreDrawHalos")
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -111,8 +111,9 @@ local function StartGoblinTimers()
             elseif revealMode == JESTER_NOTIFY_EVERYONE or
                     (v:IsActiveTraitorTeam() and (revealMode == JESTER_NOTIFY_TRAITOR or JESTER_NOTIFY_DETECTIVE_AND_TRAITOR)) or
                     (not v:IsActiveDetectiveLike() and (revealMode == JESTER_NOTIFY_DETECTIVE or JESTER_NOTIFY_DETECTIVE_AND_TRAITOR)) then
-                v:PrintMessage(HUD_PRINTTALK, "A loot goblin has been spotted!")
-                v:PrintMessage(HUD_PRINTCENTER, "A loot goblin has been spotted!")
+                local message = string.Capitalize(ROLE_STRINGS_EXT[ROLE_LOOTGOBLIN]) .. " has been spotted!"
+                v:PrintMessage(HUD_PRINTTALK, message)
+                v:PrintMessage(HUD_PRINTCENTER, message)
             end
         end
 

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -4,6 +4,8 @@ local net = net
 local player = player
 local string = string
 
+local RemoveHook = hook.Remove
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -181,7 +183,7 @@ hook.Add("TTTUpdateRoleState", "Vampire_Highlight_TTTUpdateRoleState", function(
 
     -- Disable highlights on role change
     if vision_enabled then
-        hook.Remove("PreDrawHalos", "Vampire_Highlight_PreDrawHalos")
+        RemoveHook("PreDrawHalos", "Vampire_Highlight_PreDrawHalos")
         vision_enabled = false
     end
 end)
@@ -199,8 +201,8 @@ hook.Add("Think", "Vampire_Highlight_Think", function()
         vision_enabled = false
     end
 
-    if not vision_enabled then
-        hook.Remove("PreDrawHalos", "Vampire_Highlight_PreDrawHalos")
+    if vampire_vision and not vision_enabled then
+        RemoveHook("PreDrawHalos", "Vampire_Highlight_PreDrawHalos")
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -4,6 +4,8 @@ local net = net
 local player = player
 local string = string
 
+local RemoveHook = hook.Remove
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -156,7 +158,7 @@ hook.Add("TTTUpdateRoleState", "Zombie_Highlight_TTTUpdateRoleState", function()
 
     -- Disable highlights on role change
     if vision_enabled then
-        hook.Remove("PreDrawHalos", "Zombie_Highlight_PreDrawHalos")
+        RemoveHook("PreDrawHalos", "Zombie_Highlight_PreDrawHalos")
         vision_enabled = false
     end
 end)
@@ -174,8 +176,8 @@ hook.Add("Think", "Zombie_Highlight_Think", function()
         vision_enabled = false
     end
 
-    if not vision_enabled then
-        hook.Remove("PreDrawHalos", "Zombie_Highlight_PreDrawHalos")
+    if zombie_vision and not vision_enabled then
+        RemoveHook("PreDrawHalos", "Zombie_Highlight_PreDrawHalos")
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -929,21 +929,45 @@ if not EVENT_MAX then
 end
 
 EVENTS_BY_ROLE = {}
-function GenerateNewEventID(role)
-    if not role or role < ROLE_NONE or role > ROLE_MAX then
-        -- Print message telling the server owners that the role dev needs to update
-        ErrorNoHaltWithStack("WARNING: Role is missing 'role' parameter when generating unique event ID. Contact developer of role and reference: GenerateNewEventID\n")
-        role = GetRoleFromStackTrace()
+if SERVER then
+    util.AddNetworkString("TTT_SyncEventIDs")
+
+    function GenerateNewEventID(role)
+        if not role or role < ROLE_NONE or role > ROLE_MAX then
+            -- Print message telling the server owners that the role dev needs to update
+            ErrorNoHaltWithStack("WARNING: Role is missing 'role' parameter when generating unique event ID. Contact developer of role and reference: GenerateNewEventID\n")
+            role = GetRoleFromStackTrace()
+        end
+
+        EVENT_MAX = EVENT_MAX + 1
+
+        -- Don't assign this event ID to a role we haven't found
+        if role and role > ROLE_NONE and role <= ROLE_MAX then
+            EVENTS_BY_ROLE[role] = EVENT_MAX
+        end
+
+        return EVENT_MAX
     end
 
-    EVENT_MAX = EVENT_MAX + 1
-
-    -- Don't assign this event ID to a role we haven't found
-    if role and role > ROLE_NONE and role <= ROLE_MAX then
-        EVENTS_BY_ROLE[role] = EVENT_MAX
+    -- Sync the Event IDs to all clients
+    hook.Add("TTTPrepareRound", "EventID_TTTPrepareRound", function()
+        net.Start("TTT_SyncEventIDs")
+        net.WriteTable(EVENTS_BY_ROLE)
+        net.WriteUInt(EVENT_MAX, 16)
+        net.Broadcast()
+    end)
+end
+if CLIENT then
+    function GenerateNewEventID(role)
+        ErrorNoHaltWithStack("WARNING: Role is using 'GenerateNewEventID' on the client. This is deprecated as of v1.4.6 and should be replaced with the new 'TTTSyncEventIDs' hook.\n")
     end
 
-    return EVENT_MAX
+    net.Receive("TTT_SyncEventIDs", function()
+        EVENTS_BY_ROLE = net.ReadTable()
+        EVENT_MAX = net.ReadUInt(16)
+
+        CallHook("TTTSyncEventIDs", nil)
+    end)
 end
 
 WIN_NONE = 1
@@ -965,21 +989,45 @@ if not WIN_MAX then
 end
 
 WINS_BY_ROLE = {}
-function GenerateNewWinID(role)
-    if not role or role < ROLE_NONE or role > ROLE_MAX then
-        -- Print message telling the server owners that the role dev needs to update
-        ErrorNoHaltWithStack("WARNING: Role is missing 'role' parameter when generating unique win ID. Contact developer of role and reference: GenerateNewWinID\n")
-        role = GetRoleFromStackTrace()
+if SERVER then
+    util.AddNetworkString("TTT_SyncWinIDs")
+
+    function GenerateNewWinID(role)
+        if not role or role < ROLE_NONE or role > ROLE_MAX then
+            -- Print message telling the server owners that the role dev needs to update
+            ErrorNoHaltWithStack("WARNING: Role is missing 'role' parameter when generating unique win ID. Contact developer of role and reference: GenerateNewWinID\n")
+            role = GetRoleFromStackTrace()
+        end
+
+        WIN_MAX = WIN_MAX + 1
+
+        -- Don't assign this win ID to a role we haven't found
+        if role and role > ROLE_NONE and role <= ROLE_MAX then
+            WINS_BY_ROLE[role] = WIN_MAX
+        end
+
+        return WIN_MAX
     end
 
-    WIN_MAX = WIN_MAX + 1
-
-    -- Don't assign this win ID to a role we haven't found
-    if role and role > ROLE_NONE and role <= ROLE_MAX then
-        WINS_BY_ROLE[role] = WIN_MAX
+    -- Sync the Event IDs to all clients
+    hook.Add("TTTPrepareRound", "WinID_TTTPrepareRound", function()
+        net.Start("TTT_SyncWinIDs")
+        net.WriteTable(WINS_BY_ROLE)
+        net.WriteUInt(WIN_MAX, 16)
+        net.Broadcast()
+    end)
+end
+if CLIENT then
+    function GenerateNewWinID(role)
+        ErrorNoHaltWithStack("WARNING: Role is using 'GenerateNewWinID' on the client. This is deprecated as of v1.4.6 and should be replaced with the new 'TTTSyncWinIDs' hook.\n")
     end
 
-    return WIN_MAX
+    net.Receive("TTT_SyncWinIDs", function()
+        WINS_BY_ROLE = net.ReadTable()
+        WIN_MAX = net.ReadUInt(16)
+
+        CallHook("TTTSyncWinIDs", nil)
+    end)
 end
 
 -- Weapon categories, you can only carry one of each

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.4.5"
+CR_VERSION = "1.4.6"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Changes**
- Changed role selection logic to shuffle the list of players to hopefully help the randomization
- Changed role vision logic to hopefully increase performance for traitors

**Fixes**
- Fixed error caused by vampire fangs when trying to consume a body that didn't contain player information
- Fixed the "A loot goblin has been spotted!" message not updating when the role is renamed

**Developer**
- Added ability to pass a table of role data to the TTTScoringSecondaryWins hook to customize how secondary wins are displayed
- Reworked Event ID and Win ID generation to fix case where external roles could have their conditions conflict due to the client and server not generating IDs in the same order. This involved the following changes:
  - **BREAKING CHANGE** - Deprecated `GenerateNewEventID` on the client and made it a no-op that prints an error message reminding the developer to update
  - **BREAKING CHANGE** - Deprecated `GenerateNewWinID` on the client and made it a no-op that prints an error message reminding the developer to update
  - Added TTTSyncEventIDs hook to allow developers to get generated Event IDs on the client after they have been synced
  - Added TTTSyncWinIDs hook to allow developers to get generated Win IDs on the client after they have been synced