### PR TITLE
Misc. fixes and additions

### DIFF
--- a/API/GLOBAL_ENUMERATIONS.md
+++ b/API/GLOBAL_ENUMERATIONS.md
@@ -10,8 +10,8 @@ Enumerations available globally (within the defined realm). There are additional
 *Added in:* 1.0.11\
 *Values:*
 - ROLE_CONVAR_TYPE_NUM - A number. Will use a slider in the configuration UI.
-- ROLE_CONVAR_TYPE_BOOL = A boolean. Will use a checkbox in the configuration UI.
-- ROLE_CONVAR_TYPE_TEXT = A text value. Will use a text box in the configuration UI.
+- ROLE_CONVAR_TYPE_BOOL - A boolean. Will use a checkbox in the configuration UI.
+- ROLE_CONVAR_TYPE_TEXT - A text value. Will use a text box in the configuration UI.
 
 **ROLE_TEAM_\*** - Which role team an external role is registered to. A "role team" is a way of grouping roles by common functionality and mostly maps to the logical team with the exception of the detective role team. The detective role team is part of the innocent logical team.\
 *Realm:* Client and Server\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -21,7 +21,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 *Parameters:*
 - *ply* - The player who is attempting to identify a corpse
 - *rag* - The ragdoll being identified
-- *wasTraitor* - Whether the player who the targetted ragdoll represents belonged to the traitor team
+- *wasTraitor* - Whether the player who the targeted ragdoll represents belonged to the traitor team
 
 *Return:* Whether or not the given player should be able to identify the given corpse (Defaults to `false`).
 
@@ -105,7 +105,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 *Added in:* 1.2.7\
 *Parameters:*
 - *ply* - The player who is being spawned or respawned
-- *deadOnly* - Whether this call is specifically targetted at dead players
+- *deadOnly* - Whether this call is specifically targeted at dead players
 
 **TTTPrintResultMessage(type)** - Called before the round win results message is printed to the top-right corner of the screen. Can be used to print a replacement message for custom win types that this would not normally handle.\
 *Realm:* Server\

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -400,9 +400,9 @@ ttt_independents_update_scoreboard          0       // Whether all independent r
 // Drunk
 ttt_drunk_sober_time                        180     // Time in seconds for the drunk to remember their role
 ttt_drunk_innocent_chance                   0.7     // Chance that the drunk will become an innocent role when remembering their role
-ttt_drunk_any_role                          0       // Whether the drunk can become any enabled role (other than the drunk, the glitch, or roles that were already used this round)
 ttt_drunk_become_clown                      0       // Whether the drunk should become a clown (instead of joining the losing team) if the round would end before they sober up
 ttt_drunk_notify_mode                       0       // The logic to use when notifying players that a drunk has sobered up. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_drunk_any_role                          0       // Whether the drunk can become any enabled role (other than the drunk, the glitch, or roles that were already used this round). The ttt_drunk_can_be_* convars below can be used to prevent the drunk from becoming specific roles
 ttt_drunk_can_be_traitor                    1       // Whether the drunk can become a traitor
 ttt_drunk_can_be_hypnotist                  1       // Whether the drunk can become a hypnotist
 ttt_drunk_can_be_impersonator               1       // Whether the drunk can become an impersonator

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.4.7 (Beta)
+**Released:**
+
+### Fixes
+- Fixed detective-like players (deputy, impersonator) not being promoted when the active detective team player's role is changed
+- Fixed veteran buff state not being reset if their role was changed
+
 ## 1.4.6 (Beta)
 **Released: January 15th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.4.7 (Beta)
 **Released:**
 
+### Additions
+- Added map name to scoreboard and round summary title
+
 ### Fixes
 - Fixed detective-like players (deputy, impersonator) not being promoted when the active detective team player's role is changed
 - Fixed veteran buff state not being reset if their role was changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 ### Additions
 - Added map name to scoreboard and round summary title
 
+### Changes
+- Changed head icon placement to hopefully work better with scaled-up heads
+
 ### Fixes
 - Fixed detective-like players (deputy, impersonator) not being promoted when the active detective team player's role is changed
 - Fixed veteran buff state not being reset if their role was changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Fixes
 - Fixed detective-like players (deputy, impersonator) not being promoted when the active detective team player's role is changed
 - Fixed veteran buff state not being reset if their role was changed
+- Fixed role logic not starting if someone's role was changed
 
 ## 1.4.6 (Beta)
 **Released: January 15th, 2022**

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -1100,7 +1100,7 @@ function CLSCORE:ShowPanel()
     local margin = 15
     parentPanel:SetSize(w, h)
     parentPanel:Center()
-    parentPanel:SetTitle("Round Report - " .. GAMEMODE.Version)
+    parentPanel:SetTitle("Round Report - " .. GAMEMODE.Version .. " - " .. StringUpper(game.GetMap()))
     parentPanel:SetVisible(true)
     parentPanel:ShowCloseButton(true)
     parentPanel:SetMouseInputEnabled(true)

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -207,7 +207,7 @@ L.search_eyes = "Using your investigative skills, you identified the last person
 
 
 -- Scoreboard
-L.sb_playing = "You are playing {version} on..."
+L.sb_playing = "You are playing {map} with {version} on..."
 L.sb_mapchange = "Map changes in {num} rounds or in {time}"
 
 L.sb_mia = "Missing In Action"

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -26,7 +26,9 @@ function plymeta:SetRole(role)
     local oldRole = self:GetRole()
     oldSetRole(self, role)
     CallHook("TTTPlayerRoleChanged", nil, self, oldRole, role)
-    self:BeginRoleChecks()
+    if SERVER then
+        self:BeginRoleChecks()
+    end
 end
 
 -- Player is alive and in an active round

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -26,6 +26,7 @@ function plymeta:SetRole(role)
     local oldRole = self:GetRole()
     oldSetRole(self, role)
     CallHook("TTTPlayerRoleChanged", nil, self, oldRole, role)
+    self:BeginRoleChecks()
 end
 
 -- Player is alive and in an active round

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
@@ -45,6 +45,34 @@ local function BeginRoleChecks(ply)
     end
 end
 
+local function FindAndPromoteDetectiveLike()
+    for _, ply in pairs(GetAllPlayers()) do
+        if ply:IsDetectiveLikePromotable() then
+            local alive = ply:Alive()
+            if alive then
+                ply:PrintMessage(HUD_PRINTTALK, "You have been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!")
+                ply:PrintMessage(HUD_PRINTCENTER, "You have been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!")
+            end
+
+            -- If the player is an Impersonator, tell all their team members when they get promoted
+            if ply:IsImpersonator() then
+                for _, v in pairs(GetAllPlayers()) do
+                    if v ~= ply and v:IsTraitorTeam() and v:Alive() and not v:IsSpec() then
+                        local message = "The " .. ROLE_STRINGS[ROLE_IMPERSONATOR] .. " has been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!"
+                        if not alive then
+                            message = message .. " Too bad they're dead..."
+                        end
+                        v:PrintMessage(HUD_PRINTTALK, message)
+                        v:PrintMessage(HUD_PRINTCENTER, message)
+                    end
+                end
+            end
+
+            ply:HandleDetectiveLikePromotion()
+        end
+    end
+end
+
 ROLE_ON_ROLE_ASSIGNED[ROLE_DEPUTY] = BeginRoleChecks
 ROLE_ON_ROLE_ASSIGNED[ROLE_IMPERSONATOR] = BeginRoleChecks
 
@@ -56,30 +84,12 @@ end)
 
 hook.Add("PlayerDeath", "DetectiveLike_RoleState_PlayerDeath", function(victim, infl, attacker)
     if victim:IsDetectiveTeam() and GetRoundState() == ROUND_ACTIVE and ShouldPromoteDetectiveLike() then
-        for _, ply in pairs(GetAllPlayers()) do
-            if ply:IsDetectiveLikePromotable() then
-                local alive = ply:Alive()
-                if alive then
-                    ply:PrintMessage(HUD_PRINTTALK, "You have been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!")
-                    ply:PrintMessage(HUD_PRINTCENTER, "You have been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!")
-                end
+        FindAndPromoteDetectiveLike()
+    end
+end)
 
-                -- If the player is an Impersonator, tell all their team members when they get promoted
-                if ply:IsImpersonator() then
-                    for _, v in pairs(GetAllPlayers()) do
-                        if v ~= ply and v:IsTraitorTeam() and v:Alive() and not v:IsSpec() then
-                            local message = "The " .. ROLE_STRINGS[ROLE_IMPERSONATOR] .. " has been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!"
-                            if not alive then
-                                message = message .. " Too bad they're dead..."
-                            end
-                            v:PrintMessage(HUD_PRINTTALK, message)
-                            v:PrintMessage(HUD_PRINTCENTER, message)
-                        end
-                    end
-                end
-
-                ply:HandleDetectiveLikePromotion()
-            end
-        end
+hook.Add("TTTPlayerRoleChanged", "DetectiveLike_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
+    if DETECTIVE_ROLES[oldRole] and GetRoundState() == ROUND_ACTIVE and ShouldPromoteDetectiveLike() then
+        FindAndPromoteDetectiveLike()
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
+++ b/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
@@ -87,3 +87,9 @@ hook.Add("TTTPrepareRound", "Veteran_RoleFeatures_PrepareRound", function()
         v:SetNWBool("VeteranActive", false)
     end
 end)
+
+hook.Add("TTTPlayerRoleChanged", "Veteran_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
+    if oldRole == ROLE_VETERAN then
+        ply:SetNWBool("VeteranActive", false)
+    end
+end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.4.6"
+CR_VERSION = "1.4.7"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -17,6 +17,7 @@ local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 local StringFormat = string.format
 local StringSub = string.sub
+local StringUpper = string.upper
 
 local clamp = math.Clamp
 local max = math.max
@@ -142,7 +143,7 @@ _G.sboard_sort = {
 function PANEL:Init()
 
     self.hostdesc = vgui.Create("DLabel", self)
-    self.hostdesc:SetText(GetPTranslation("sb_playing", { version = GAMEMODE.Version }))
+    self.hostdesc:SetText(GetPTranslation("sb_playing", { version = GAMEMODE.Version, map = StringUpper(game.GetMap())}))
     self.hostdesc:SetContentAlignment(9)
 
     self.hostname = vgui.Create("DLabel", self)


### PR DESCRIPTION
**Additions**
- Added map name to scoreboard and round summary title

**Changes**
- Changed head icon placement to hopefully work better with scaled-up heads

**Fixes**
- Fixed detective-like players (deputy, impersonator) not being promoted when the active detective team player's role is changed
- Fixed veteran buff state not being reset if their role was changed
- Fixed role logic not starting if someone's role was changed