### PR TITLE
Prep for 1.5.0 release

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -192,7 +192,8 @@ ttt_vampire_fang_dead_timer                 0       // The amount of time fangs 
 ttt_vampire_fang_heal                       50      // The amount of health a vVampire will heal by when they fully drain a target's blood
 ttt_vampire_fang_overheal                   25      // The amount over the vampire's normal maximum health (e.g. 100 + this ConVar) that the vampire can heal to by drinking blood.
 ttt_vampire_fang_overheal_living            -1      // The amount of overheal (see "ttt_vampire_fang_overheal") to give if the vampire's target is living. Set to -1 to use the same amount as "ttt_vampire_fang_overheal" instead
-ttt_vampire_prime_death_mode                0       // What to do when the prime vampire(s) (e.g. playters who spawn as vampires originally) are killed. 0 - Do nothing. 1 - Kill all vampire thralls (non-prime vampires). 2 - Revert all vampire thralls (non-prime vampires) to their original role
+ttt_vampire_fang_unfreeze_delay             2       // The number of seconds before players who were frozen in place by the fangs should be released if the vampire stops using the fangs on them
+ttt_vampire_prime_death_mode                0       // What to do when the prime vampire(s) (e.g. players who spawn as vampires originally) are killed. 0 - Do nothing. 1 - Kill all vampire thralls (non-prime vampires). 2 - Revert all vampire thralls (non-prime vampires) to their original role
 ttt_vampire_prime_only_convert              1       // Whether only prime vampires (e.g. players who spawn as vampire originally) are allowed to convert other players
 ttt_vampire_kill_credits                    1       // Whether the vampire receives credits when they kill another player
 ttt_vampire_loot_credits                    1       // Whether the vampire can loot credits from a dead player

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,12 +7,12 @@ Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).
 ### Fixes
 - Fixed very minor bug with loadout items hook, making it consistent with normal shop usage
 
-## 1.4.9 (Beta)
-**Released: February 6th, 2022**
-
 ### Changes
 - Changed vampire unfreeze delay to be longer by default to help vampires with high pings
 - Changed vampire weapon hint to be translatable and to show that the primary fire button must be held to drain blood
+
+## 1.4.9 (Beta)
+**Released: February 6th, 2022**
 
 ### Fixes
 - Fixed shop sync not working for custom equipment items for special detectives

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,10 +6,11 @@ Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).
 
 ### Fixes
 - Fixed very minor bug with loadout items hook, making it consistent with normal shop usage
+- Fixed vampire fang usage hint not showing
 
 ### Changes
 - Changed vampire unfreeze delay to be longer by default to help vampires with high pings
-- Changed vampire weapon hint to be translatable and to show that the primary fire button must be held to drain blood
+- Changed vampire fang usage hint to be translatable and to show that the primary fire button must be held to drain blood
 
 ## 1.4.9 (Beta)
 **Released: February 6th, 2022**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,10 @@
 ## 1.4.9 (Beta)
 **Released: February 6th, 2022**
 
+### Changes
+- Changed vampire unfreeze delay to be longer by default to help vampires with high pings
+- Changed vampire weapon hint to be translatable and to show that the primary fire button must be held to drain blood
+
 ### Fixes
 - Fixed shop sync not working for custom equipment items for special detectives
 - Fixed external detective roles not being able to be configured to disallow looting credits

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.5.0
+**Released: February 9th, 2022**
+Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).
+
+### Fixes
+- Fixed very minor bug with loadout items hook, making it consistent with normal shop usage
+
 ## 1.4.9 (Beta)
 **Released: February 6th, 2022**
 

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -457,6 +457,8 @@ end
 
 if CLIENT then
     function SWEP:DrawHUD()
+        self.BaseClass.DrawHUD(self)
+
         local x = ScrW() / 2.0
         local y = ScrH() / 2.0
 

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -71,7 +71,7 @@ local vampire_fang_timer = CreateConVar("ttt_vampire_fang_timer", "5")
 local vampire_fang_heal = CreateConVar("ttt_vampire_fang_heal", "50")
 local vampire_fang_overheal = CreateConVar("ttt_vampire_fang_overheal", "25")
 local vampire_fang_overheal_living = CreateConVar("ttt_vampire_fang_overheal_living", "-1")
-local vampire_fang_unfreeze_delay = CreateConVar("ttt_vampire_fang_unfreeze_delay", "1")
+local vampire_fang_unfreeze_delay = CreateConVar("ttt_vampire_fang_unfreeze_delay", "2")
 local vampire_prime_convert = CreateConVar("ttt_vampire_prime_only_convert", "1")
 
 function SWEP:SetupDataTables()
@@ -92,7 +92,7 @@ function SWEP:Initialize()
     self.fading = false
 
     if CLIENT then
-        self:AddHUDHelp("Left-click to suck blood", "Right-click to fade", false)
+        self:AddHUDHelp("vam_fangs_help_pri", "vam_fangs_help_sec", true)
     end
     return self.BaseClass.Initialize(self)
 end

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -20,10 +20,14 @@ hook.Add("Initialize", "Vampire_Translations_Initialize", function()
     LANG.AddToLanguage("english", "ev_vampi_revert_converted", "The last {vampire} Prime ({prime}) was killed and all their thralls had their humanity restored")
     LANG.AddToLanguage("english", "ev_vampi_kill_converted", "The last {vampire} Prime ({prime}) was killed and took all their thralls with them")
 
+    -- Fangs
+    LANG.AddToLanguage("english", "vam_fangs_help_pri", "Hold {primaryfire} to suck blood")
+    LANG.AddToLanguage("english", "vam_fangs_help_sec", "Press {secondaryfire} to fade from view")
+
     -- Popup
     LANG.AddToLanguage("english", "info_popup_vampire", [[You are {role}! {comrades}
 
-You can use your fangs (left-click) to drink blood and refill your health or to fade from view (right-click).
+You can use your fangs (hold left-click) to drink blood and refill your health or to fade from view (right-click).
     
 Press {menukey} to receive your special equipment!]])
 end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,8 +17,8 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.4.9"
-CR_BETA = true
+CR_VERSION = "1.5.0"
+CR_BETA = false
 
 function CRVersion(version)
     local installedVersionRaw = StringSplit(CR_VERSION, ".")


### PR DESCRIPTION
Also includes:

**Fixes**
- Fixed very minor bug with loadout items hook, making it consistent with normal shop usage
- Fixed vampire fang usage hint not showing

**Changes**
- Changed vampire unfreeze delay to be longer by default to help vampires with high pings
- Changed vampire weapon hint to be translatable and to show that the primary fire button must be held to drain blood