### PR TITLE
Misc. fixes and changes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -546,7 +546,7 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *client* - The local player
 - *role* - What role is currently being shown for the target player
 - *noZ* - Whether the icon is currently visible through walls
-- *colorRole* - What role is being used for the icon background color (Only used when a different color than the only belonging to *role* is being used)
+- *colorRole* - What role is being used for the icon background color (Only used when a different color than the one belonging to *role* is being used)
 - *hideBeggar* - Whether the target was a beggar whose new role should be hidden
 - *showJester* - Whether the target is a jester and the local player would normally know that
 - *hideBodysnatcher* - Whether the target is a bodysnatcher whose new role should be hidden *(Added in 1.2.5)*

--- a/API/METHODS_GLOBAL.md
+++ b/API/METHODS_GLOBAL.md
@@ -24,7 +24,7 @@ Methods available globally (within the defined realm)
 *Returns*: An accessible position around the given position or `false` if none can be found
 
 **GenerateNewEventID(role)** - Generates a new ID to be used for custom scoring events.\
-*Realm:* Client *(Deprecated in 1.4.6)* and Server\
+*Realm:* Server\
 *Added in:* 1.2.5\
 *Parameters:*
 - *role* - The ID of the role that the generated event ID belongs to. Pass `ROLE_NONE` if this should not be associated with any role *(Added in 1.4.2)*
@@ -32,7 +32,7 @@ Methods available globally (within the defined realm)
 *NOTE:* To get this value on the client, use the `TTTSyncEventIDs` hook and pull the value out of the `EVENTS_BY_ROLE` global table
 
 **GenerateNewWinID(role)** - Generates a new ID to be used for custom win conditions.\
-*Realm:* Client *(Deprecated in 1.4.6)* and Server\
+*Realm:* Server\
 *Added in:* 1.2.5\
 *Parameters:*
 - *role* - The ID of the role that the generated win ID belongs to. Pass `ROLE_NONE` if this should not be associated with any role *(Added in 1.4.2)*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 ### Developer
 - Removed deprecated global `GenerateNewEventID` from the client realm. Use the `TTTSyncEventIDs` hook instead
 - Removed deprecated global `GenerateNewWinID` from the client realm. Use the `TTTSyncWinIDs` hook instead
+- Changed custom win and event tracking to be protected against file reloading, preventing errors while debugging
 
 ## 1.5.0
 **Released: February 9th, 2022**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed a few cases where roles without items in their shop could open the shop when Shop For All was enabled
+- Fixed errors displaying radar points when there was a decoy being used
 
 ### Developer
 - Removed deprecated global `GenerateNewEventID` from the client realm. Use the `TTTSyncEventIDs` hook instead

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 1.5.1
+## 1.5.1 (Beta)
 **Released:**
 
 ### Developer

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.5.1
+**Released:**
+
+### Developer
+- Removed deprecated global `GenerateNewEventID` from the client realm. Use the `TTTSyncEventIDs` hook instead
+- Removed deprecated global `GenerateNewWinID` from the client realm. Use the `TTTSyncWinIDs` hook instead
+
 ## 1.5.0
 **Released: February 9th, 2022**\
 Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.5.1 (Beta)
 **Released:**
 
+### Fixes
+- Fixed a few cases where roles without items in their shop could open the shop when Shop For All was enabled
+
 ### Developer
 - Removed deprecated global `GenerateNewEventID` from the client realm. Use the `TTTSyncEventIDs` hook instead
 - Removed deprecated global `GenerateNewWinID` from the client realm. Use the `TTTSyncWinIDs` hook instead

--- a/gamemodes/terrortown/gamemode/radar.lua
+++ b/gamemodes/terrortown/gamemode/radar.lua
@@ -51,9 +51,9 @@ local function RadarScan(ply, cmd, args)
                             pos = pos,
                             was_beggar = p:GetNWBool("WasBeggar", false),
                             was_bodysnatcher = p:GetNWBool("WasBodysnatcher", false),
-                            killer_clown_active = p:IsClown() and p:IsRoleActive(),
-                            should_act_like_jester = p:ShouldActLikeJester(),
-                            sid64 = p:SteamID64()
+                            killer_clown_active = p:IsPlayer() and p:IsClown() and p:IsRoleActive(),
+                            should_act_like_jester = p:IsPlayer() and p:ShouldActLikeJester(),
+                            sid64 = p:IsPlayer() and p:SteamID64() or ""
                         })
                     end
                 end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -927,12 +927,9 @@ EVENT_BEGGARKILLED = 26
 EVENT_INFECT = 27
 EVENT_BODYSNATCHERKILLED = 28
 
--- Don't redefine this every time we load this file
-if not EVENT_MAX then
-    EVENT_MAX = 28
-end
+EVENT_MAX = EVENT_MAX or 28
+EVENTS_BY_ROLE = EVENTS_BY_ROLE or {}
 
-EVENTS_BY_ROLE = {}
 if SERVER then
     util.AddNetworkString("TTT_SyncEventIDs")
 
@@ -983,12 +980,9 @@ WIN_MONSTER = 10
 WIN_VAMPIRE = 11
 WIN_LOOTGOBLIN = 12
 
--- Don't redefine this every time we load this file
-if not WIN_MAX then
-    WIN_MAX = 12
-end
+WIN_MAX = WIN_MAX or 12
+WINS_BY_ROLE = WINS_BY_ROLE or {}
 
-WINS_BY_ROLE = {}
 if SERVER then
     util.AddNetworkString("TTT_SyncWinIDs")
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.0"
+CR_VERSION = "1.5.1"
 CR_BETA = true
 
 function CRVersion(version)
@@ -962,10 +962,6 @@ if SERVER then
     end)
 end
 if CLIENT then
-    function GenerateNewEventID(role)
-        ErrorNoHaltWithStack("WARNING: Role is using 'GenerateNewEventID' on the client. This is deprecated as of v1.4.6 and should be replaced with the new 'TTTSyncEventIDs' hook.\n")
-    end
-
     net.Receive("TTT_SyncEventIDs", function()
         EVENTS_BY_ROLE = net.ReadTable()
         EVENT_MAX = net.ReadUInt(16)
@@ -1022,10 +1018,6 @@ if SERVER then
     end)
 end
 if CLIENT then
-    function GenerateNewWinID(role)
-        ErrorNoHaltWithStack("WARNING: Role is using 'GenerateNewWinID' on the client. This is deprecated as of v1.4.6 and should be replaced with the new 'TTTSyncWinIDs' hook.\n")
-    end
-
     net.Receive("TTT_SyncWinIDs", function()
         WINS_BY_ROLE = net.ReadTable()
         WIN_MAX = net.ReadUInt(16)


### PR DESCRIPTION
**Fixes**
- Fixed a few cases where roles without items in their shop could open the shop when Shop For All was enabled
- Fixed errors displaying radar points when there was a decoy being used

**Developer**
- Removed deprecated global `GenerateNewEventID` from the client realm. Use the `TTTSyncEventIDs` hook instead
- Removed deprecated global `GenerateNewWinID` from the client realm. Use the `TTTSyncWinIDs` hook instead
- Changed custom win and event tracking to be protected against file reloading, preventing errors while debugging