### PR TITLE
Backport fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,8 @@ Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).
 - Fixed roles without shop items being able to open the shop and to loot credits if Shop For All was enabled
 - Fixed old man being invincible if adrenaline rush was disabled
 - Fixed errors displaying radar points when there was a decoy being used
+- Fixed roles added after the initial load not showing their role icon in the body search dialog
+- Fixed some external role icons not working in the body search dialog
 
 ### Changes
 - Changed vampire unfreeze delay to be longer by default to help vampires with high pings

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@ Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).
 - Fixed very minor bug with loadout items hook, making it consistent with normal shop usage
 - Fixed vampire fang usage hint not showing
 - Fixed roles without shop items being able to open the shop and to loot credits if Shop For All was enabled
+- Fixed old man being invincible if adrenaline rush was disabled
 
 ### Changes
 - Changed vampire unfreeze delay to be longer by default to help vampires with high pings

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Includes all beta updates from [1.4.5](#145-beta) to [1.4.9](#149-beta).
 - Fixed vampire fang usage hint not showing
 - Fixed roles without shop items being able to open the shop and to loot credits if Shop For All was enabled
 - Fixed old man being invincible if adrenaline rush was disabled
+- Fixed errors displaying radar points when there was a decoy being used
 
 ### Changes
 - Changed vampire unfreeze delay to be longer by default to help vampires with high pings

--- a/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/cl_search.lua
@@ -65,7 +65,7 @@ local TypeToMat = {
     eq_armor = "armor",
     eq_radar = "radar",
     eq_disg = "disguise",
-    role = ROLE_STRINGS_SHORT,
+    role = function(role) return ROLE_STRINGS_SHORT[role] end,
     c4 = "code",
     dmg = DmgToMat,
     wep = WeaponToIcon,
@@ -93,8 +93,12 @@ local function IconForInfoType(t, data)
 
     -- ugly special casing for weapons, because they are more likely to be
     -- customized and hence need more freedom in their icon filename
-    if t == "role" and file.Exists("materials/vgui/ttt/roles/" .. mat .. "/icon_" .. mat .. ".vtf", "GAME") then
-        return "vgui/ttt/roles/" .. mat .. "/icon_" .. mat
+    if t == "role" then
+        if file.Exists("materials/vgui/ttt/roles/" .. mat .. "/icon_" .. mat .. ".vtf", "GAME") then
+            return "vgui/ttt/roles/" .. mat .. "/icon_" .. mat
+        else
+            return "vgui/ttt/icon_" .. mat
+        end
     elseif t ~= "wep" then
         return base .. mat
     else

--- a/gamemodes/terrortown/gamemode/radar.lua
+++ b/gamemodes/terrortown/gamemode/radar.lua
@@ -51,9 +51,9 @@ local function RadarScan(ply, cmd, args)
                             pos = pos,
                             was_beggar = p:GetNWBool("WasBeggar", false),
                             was_bodysnatcher = p:GetNWBool("WasBodysnatcher", false),
-                            killer_clown_active = p:IsClown() and p:IsRoleActive(),
-                            should_act_like_jester = p:ShouldActLikeJester(),
-                            sid64 = p:SteamID64()
+                            killer_clown_active = p:IsPlayer() and p:IsClown() and p:IsRoleActive(),
+                            should_act_like_jester = p:IsPlayer() and p:ShouldActLikeJester(),
+                            sid64 = p:IsPlayer() and p:SteamID64() or ""
                         })
                     end
                 end

--- a/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
@@ -79,6 +79,10 @@ end
 
 local tempHealth = 10000
 hook.Add("EntityTakeDamage", "OldMan_EntityTakeDamage", function(ent, dmginfo)
+    -- Don't run this if adrenaline rush is disabled
+    local adrenalineTime = oldman_adrenaline_rush:GetInt()
+    if adrenalineTime <= 0 then return end
+
     if GetRoundState() ~= ROUND_ACTIVE then return end
     if not IsPlayer(ent) or not ent:IsOldMan() then return end
 
@@ -99,6 +103,10 @@ hook.Add("EntityTakeDamage", "OldMan_EntityTakeDamage", function(ent, dmginfo)
 end)
 
 hook.Add("PostEntityTakeDamage", "OldMan_PostEntityTakeDamage", function(ent, dmginfo, took)
+    -- Don't run this if adrenaline rush is disabled
+    local adrenalineTime = oldman_adrenaline_rush:GetInt()
+    if adrenalineTime <= 0 then return end
+
     if GetRoundState() ~= ROUND_ACTIVE then return end
     if not IsPlayer(ent) or not ent:IsOldMan() then return end
     if ent:IsRoleActive() then return end
@@ -111,10 +119,6 @@ hook.Add("PostEntityTakeDamage", "OldMan_PostEntityTakeDamage", function(ent, dm
     -- If they didn't take damage then we don't care
     if not took then return end
     if damage <= 0 then return end
-
-    -- Don't run this if adrenaline rush is disabled
-    local adrenalineTime = oldman_adrenaline_rush:GetInt()
-    if adrenalineTime <= 0 then return end
 
     -- Only give the Old Man an adrenaline rush once
     if ent:GetNWBool("AdrenalineRushed", false) then return end


### PR DESCRIPTION
- Fixed old man being invincible if adrenaline rush was disabled
- Fixed errors displaying radar points when there was a decoy being used
- Fixed roles added after the initial load not showing their role icon in the body search dialog
- Fixed some external role icons not working in the body search dialog