### PR TITLE
Misc. fixes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -603,6 +603,15 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 *Return:* `true` to tell the tutorial page to use the content set in this hook rather than calling the `TTTTutorialRoleText` hook
 
+**TTTTutorialRolePageExtra(role, parentPanel, titleLabel, roleIcon)** - Called after a role's tutorial page is rendered. This can be used to provide additional data to show for a role.\
+*Realm:* Client\
+*Added in:* 1.5.3\
+*Parameters:*
+- *role* - Which role's tutorial page is being rendered
+- *parentPanel* - The parent [DPanel](https://wiki.facepunch.com/gmod/DPanel) that this tutorial page is being rendered within
+- *titleLabel* - The [DLabel](https://wiki.facepunch.com/gmod/DLabel) that is being used as the title of the rendered tutorial page. Has the role's name automatically set as the label text
+- *roleIcon* - The [DImage](https://wiki.facepunch.com/gmod/DImage) that is being used to show the role's icon on the rendered tutorial page
+
 **TTTTutorialRoleText(role, titleLabel, roleIcon)** - Called before a role's tutorial page is rendered. This can be used to provide the text to show for a role.\
 *Realm:* Client\
 *Added in:* 1.2.7\
@@ -612,6 +621,17 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 - *roleIcon* - The [DImage](https://wiki.facepunch.com/gmod/DImage) that is being used to show the role's icon on the rendered tutorial page
 
 *Return:* The string value to show on the tutorial page for this role. Can be HTML and will be rendered within a `<div>`
+
+**TTTTutorialRoleTextExtra(role, titleLabel, roleIcon, htmlData)** - Called before a role's tutorial page is rendered but after `TTTTutorialRoleText` is called. This can be used to provide additional text to show for a role.\
+*Realm:* Client\
+*Added in:* 1.5.3\
+*Parameters:*
+- *role* - Which role's tutorial page is being rendered
+- *titleLabel* - The [DLabel](https://wiki.facepunch.com/gmod/DLabel) that is being used as the title of the rendered tutorial page. Has the role's name automatically set as the label text
+- *roleIcon* - The [DImage](https://wiki.facepunch.com/gmod/DImage) that is being used to show the role's icon on the rendered tutorial page
+- *htmlData* - The string HTML data that would be shown for the given role. It does not include the closing `</div>` tag, meaning additional HTML can be appended to the end without worrying about proper structure.
+
+*Return:* The full string value to show on the tutorial page for this role. Should not include the closing `</div>` tag as this is appended automatically.
 
 **TTTUpdateRoleState()** - Called after globals are synced but but before role colors and strings are set. Can be used to update role states (team membership) and role weapon (buyable, loadout, etc.) states based on configurations.\
 *Realm:* Client and Server\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,10 @@
 - Fixed parasite infection not being cured on a player if they resurrected the parasite and changed their role
 - Fixed phantom haunting state not being cleared when their role was changed
 
+### Developer
+- Added new `TTTTutorialRoleTextExtra` hook to allow addons to provide more text information for a role's tutorial page
+- Added new `TTTTutorialRolePageExtra` hook to allow addons to manipulate the tutorial page controls for a role
+
 ## 1.5.2 (Beta)
 **Released: February 20th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.5.3 (Beta)
 **Released:**
 
+### Additions
+- Added ability to hide weapon ammo display
+
 ### Fixes
 - Fixed assassin target information not being cleared from the scoreboard if an assassin's role was changed
 - Fixed parasite infection not being cured on a player if they resurrected the parasite and changed their role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 1.5.3 (Beta)
+**Released:**
+
+### Fixes
+- Fixed assassin target information not being cleared from the scoreboard if an assassin's role was changed
+- Fixed parasite infection not being cured on a player if they resurrected the parasite and changed their role
+- Fixed phantom haunting state not being cleared when their role was changed
+
 ## 1.5.2 (Beta)
 **Released: February 20th, 2022**
 

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -64,7 +64,8 @@ CreateClientConVar("ttt_custom_mon_color_b", "0", true, false)
 UpdateRoleColours()
 
 CreateClientConVar("ttt_avoid_detective", "0", true, true)
-CreateClientConVar("ttt_hide_role", "0", true, true)
+CreateClientConVar("ttt_hide_role", "0", true, false)
+CreateClientConVar("ttt_hide_ammo", "0", true, false)
 
 HELPSCRN = {}
 
@@ -171,6 +172,9 @@ function HELPSCRN:Show()
 
     cb = dgui:CheckBox(GetTranslation("set_hide_role"), "ttt_hide_role")
     cb:SetTooltip(GetTranslation("set_hide_role_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_hide_ammo"), "ttt_hide_ammo")
+    cb:SetTooltip(GetTranslation("set_hide_ammo_tip"))
 
     cb = dgui:TextEntry(GetTranslation("set_radio_button"), "ttt_radio_button")
     cb:SetTooltip(GetTranslation("set_radio_button_tip"))

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -839,11 +839,20 @@ local function ShowTutorialPage(pnl, page)
                 htmlData = htmlData .. roleText
             end
 
+            -- Allow other addons to add more information to this role's tutorial text
+            local updatedHtml = hook.Call("TTTTutorialRoleTextExtra", nil, role, titleLabel, roleIcon, htmlData)
+            if updatedHtml and #updatedHtml > 0 then
+                htmlData = updatedHtml
+            end
+
             -- Close the page
             htmlData = htmlData .. "</div>"
 
             html:SetHTML(htmlData)
         end
+
+        -- Allow other addons to add more information to this role's tutorial page
+        hook.Call("TTTTutorialRolePageExtra", nil, role, pnl, titleLabel, roleIcon)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -335,7 +335,7 @@ local function InfoPaint(client)
     end
 
     -- Draw ammo
-    if client:GetActiveWeapon().Primary then
+    if client:GetActiveWeapon().Primary and not GetConVar("ttt_hide_ammo"):GetBool() then
         local ammo_clip, ammo_max, ammo_inv = GetAmmo(client)
         if ammo_clip ~= -1 then
             local ammo_y = health_y + bar_height + margin

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -271,6 +271,8 @@ L.set_karma_total_pct_tip = "Shows the karma value in the scoreboard as a percen
 L.set_color_mode = "Color settings"
 L.set_hide_role = "Hide your role in the HUD"
 L.set_hide_role_tip = "By default your role will appear in the bottom left of the HUD. Turn this on to prevent screen cheating."
+L.set_hide_ammo = "Hide your weapon ammo in the HUD"
+L.set_hide_ammo_tip = "By default your weapon ammo will appear in the bottom left of the HUD. Turn this on if you have another addon that does that for you."
 L.set_radio_button = "Radio menu button"
 L.set_radio_button_tip = "What button to press to open/close the radio menu"
 

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -186,11 +186,19 @@ local function ValidTarget(role)
     return true
 end
 
-hook.Add("TTTPlayerRoleChanged", "Assassin_Target_TTTPlayerRoleChanged", function(ply, oldRole, role)
+hook.Add("TTTPlayerRoleChanged", "Assassin_Target_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
     if not ply:Alive() or ply:IsSpec() then return end
 
+    -- If this player is not longer an assassin, clear out thier target
+    if oldRole == ROLE_ASSASSIN and oldRole ~= newRole then
+        ply:SetNWString("AssassinTarget", "")
+        ply:SetNWBool("AssassinFailed", false)
+        ply:SetNWBool("AssassinComplete", false)
+        timer.Remove(ply:Nick() .. "AssassinTarget")
+    end
+
     -- If this player's role could have been a valid target and definitely isn't anymore, update any assassin that has them as a target
-    if ValidTarget(oldRole) and not ValidTarget(role) then
+    if ValidTarget(oldRole) and not ValidTarget(newRole) then
         UpdateAssassinTargets(ply)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -76,6 +76,13 @@ hook.Add("TTTPlayerSpawnForRound", "Parasite_TTTPlayerSpawnForRound", function(p
     ResetPlayer(ply)
 end)
 
+-- Un-haunt the device owner if they used their device on the parasite
+hook.Add("TTTPlayerDefibRoleChange", "Parasite_TTTPlayerDefibRoleChange", function(ply, tgt)
+    if tgt:IsParasite() and tgt:GetNWString("ParasiteInfectingTarget", nil) == ply:SteamID64() then
+        ply:SetNWBool("ParasiteInfected", false)
+    end
+end)
+
 local function DoParasiteRespawnWithoutBody(parasite, hide_messages)
     if not hide_messages then
         parasite:PrintMessage(HUD_PRINTCENTER, "You have drained your host of energy and created a new body.")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.2"
+CR_VERSION = "1.5.3"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Fixes**
- Fixed assassin target information not being cleared from the scoreboard if an assassin's role was changed
- Fixed parasite infection not being cured on a player if they resurrected the parasite and changed their role
- Fixed phantom haunting state not being cleared when their role was changed

**Developer**
- Added new `TTTTutorialRoleTextExtra` hook to allow addons to provide more text information for a role's tutorial page
- Added new `TTTTutorialRolePageExtra` hook to allow addons to manipulate the tutorial page controls for a role