### PR TITLE
Misc. fixes and additions

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -406,6 +406,9 @@ ttt_lootgoblin_sprint_recovery              0.12    // The amount of stamina to 
 ttt_lootgoblin_notify_mode                  4       // The logic to use when notifying players that a loot goblin is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_lootgoblin_notify_sound                 1       // Whether to play a cheering sound when a loot goblin is killed
 ttt_lootgoblin_notify_confetti              1       // Whether to throw confetti when a loot goblin is a killed
+ttt_lootgoblin_regen_mode                   2       // Whether the loot goblin should regenerate health and using what logic. 0 - No regeneration. 1 - Constant regen while active. 2 - Regen while standing still. 3 - Regen after taking damage
+ttt_lootgoblin_regen_rate                   3       // How often (in seconds) a loot goblin should regain health while regenerating
+ttt_lootgoblin_regen_delay                  0       // The length of the delay (in seconds) before the loot goblin's health will start to regenerate
 
 // ----------------------------------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Fixed players whose roles are changed to loot goblin not being granted the jump boost
+- Fixed old man's view being stuck if their adrenaline rush activated while they were using a scoped weapon (Thanks Lillie!)
 
 ## 1.5.5
 **Released: February 28th, 2022**\
@@ -317,7 +318,7 @@ Includes all beta updates from [1.3.1](#131-beta) to [1.3.7](#137-beta).
 - Added ability to use common jester notifications (message, sound, confetti) when the bodysnatcher is killed (disabled by default)
 - Added ability to make the paramedic defib rebuyable if ttt_paramedic_device_shop is enabled (disabled by default)
 - Added ability to make the hypnotist brainwashing device rebuyable if ttt_hypnotist_device_shop is enabled (disabled by default)
-- Added ability to prevent the drunk and clown from being selected in the same round (disabled by default)
+- Added ability to prevent the drunk and clown from being selected in the same round (disabled by default) (Thanks Matty!)
 - Added ability to show loadout equipment in shops (disabled by default)
 - Added ability to configure the amount of time the various role devices take to be used
   - Bodysnatching Device
@@ -382,8 +383,8 @@ Includes all beta updates from [1.2.4](#124-beta) to [1.2.9](#129-beta).
 **Released: October 3rd, 2021**
 
 ### Additions
-- Added ability for independents to see missing in action players on the scoreboard (disabled by default)
-- Added ability for the killer to see missing in action players on the scoreboard (enabled by default)
+- Added ability for independents to see missing in action players on the scoreboard (disabled by default) (Thanks Matty!)
+- Added ability for the killer to see missing in action players on the scoreboard (enabled by default) (Thanks Matty!)
 - Added ability to control whether a vampire can loot credits (enabled by default)
 - Added ability to control whether special detectives (all detective roles other than the original detective itself) get armor automatically for free (enabled by default)
 
@@ -910,7 +911,7 @@ Includes all beta updates from [1.0.2](#102-beta) to [1.0.15](#1015-beta).
 - Fixed missing ttt_clown_shop_mode
 - Fixed weapons added to detective or traitor via the roleweapons system not being buyable by roles using the shop mode convars
 - Fixed old man not also winning when a map declares a winning team
-- Fixed the glitch from being shown as a traitor to zombies if zombies are on the traitor team
+- Fixed the glitch from being shown as a traitor to zombies if zombies are on the traitor team (Thanks Matty!)
 
 ### Developer
 - Added the ability for SWEPs to not be randomized out of the shop by setting "SWEP.BlockShopRandomization = true"
@@ -936,8 +937,8 @@ Includes all beta updates from [1.0.2](#102-beta) to [1.0.15](#1015-beta).
 - Added a message to a parasite victim when they are killed by the parasite coming back to life
 - Added a message to a non-prime vampire when they are killed/reverted if the prime was killed
 - Ported "TTT: add more validation to corpse commands" from base TTT
-- Added new Assassin target priority convar
-- Added new convar to heal the Clown when they activate
+- Added new Assassin target priority convar (Thanks Matty!)
+- Added new convar to heal the clown when they activate (Thanks Matty!)
 
 ### Changes
 - Changed revenger to receive a different message if their lover is killed when they are already dead

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+### 1.5.6 (Beta)
+**Released:**
+
+### Additions
+- Added the ability for loot goblins to regenerate health under certain circumstances
+  - By default, the loot goblin will now regen health slowly while standing still
+
+### Fixes
+- Fixed players whose roles are changed to loot goblin not being granted the jump boost
+
 ## 1.5.5
 **Released: February 28th, 2022**\
 Includes all beta updates from [1.5.1](#151-beta) to [1.5.4](#154-beta).

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -152,6 +152,22 @@ hook.Add("TTTTutorialRoleText", "LootGoblin_TTTTutorialRoleText", function(role,
         -- Win condition
         html = html .. "<span style='display: block; margin-top: 10px;'>If <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>the " .. ROLE_STRINGS[ROLE_LOOTGOBLIN] .. "</span> survives until another team wins the round, they will share the win with that team.</span>"
 
+        -- Regeneration
+        local regenMode = GetGlobalInt("ttt_lootgoblin_regen_mode", LOOTGOBLIN_REGEN_MODE_STILL)
+        if regenMode > LOOTGOBLIN_REGEN_MODE_NONE then
+            html = html .. "<span style='display: block; margin-top: 10px;'>While activated, <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>the " .. ROLE_STRINGS[ROLE_LOOTGOBLIN] .. "</span> will regenerate health "
+
+            if regenMode == LOOTGOBLIN_REGEN_MODE_ALWAYS then
+                html = html .. "constantly"
+            elseif regenMode == LOOTGOBLIN_REGEN_MODE_STILL then
+                html = html .. "while not moving"
+            else
+                html = html .. "after taking damage"
+            end
+
+            html = html .. ".</span>"
+        end
+
         return html
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
@@ -5,6 +5,11 @@ local table = table
 
 local TableInsert = table.insert
 
+LOOTGOBLIN_REGEN_MODE_NONE = 0
+LOOTGOBLIN_REGEN_MODE_ALWAYS = 1
+LOOTGOBLIN_REGEN_MODE_STILL = 2
+LOOTGOBLIN_REGEN_MODE_AFTER_DAMAGE = 3
+
 -- Initialize role features
 ROLE_STARTING_HEALTH[ROLE_LOOTGOBLIN] = 50
 ROLE_MAX_HEALTH[ROLE_LOOTGOBLIN] = 50
@@ -90,4 +95,19 @@ table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
     cvar = "ttt_lootgoblin_sprint_recovery",
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 2
+})
+table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
+    cvar = "ttt_lootgoblin_regen_mode",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
+})
+table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
+    cvar = "ttt_lootgoblin_regen_rate",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
+})
+table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
+    cvar = "ttt_lootgoblin_regen_delay",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.5"
+CR_VERSION = "1.5.6"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Additions**
- Added the ability for loot goblins to regenerate health under certain circumstances
  - By default, the loot goblin will now regen health slowly while standing still

**Fixes**
- Fixed players whose roles are changed to loot goblin not being granted the jump boost