### PR TITLE
Misc. changes and fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@
 - Fixed casing on "A Drunk has remembered their role" message
 - Fixed roleweapons config menu not applying search bar value when updating the same role as the one the search was used on
 - Fixed tooltip on bomb station not updating if a player's role changed after it was placed
+- Fixed role checks not starting for the role with the highest role ID
 
 ### Changes
 - Changed zombies to no longer be able to drown

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,8 @@
 
 ### Changes
 - Changed zombies to no longer be able to drown
+- Changed the activated clown to be able to see other jesters so they don't kill them
+- Changed the jester to win, like normal, if they are somehow to killed by other members of the jester team
 
 ### Developer
 - Added new `plymeta:ShouldNotDrown` to determine if a player should drown

--- a/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -26,9 +26,13 @@ AccessorFuncDT(ENT, "StoredHealth", "StoredHealth")
 
 AccessorFunc(ENT, "Placer", "Placer")
 
-
 local function ShouldReduceHealth(ply)
-    local rolestring = ROLE_STRINGS_RAW[ply:GetRole()]
+    if not ply:Alive() or ply:IsSpec() then return false end
+
+    local role = ply:GetRole()
+    if role <= ROLE_NONE or role > ROLE_MAX then return false end
+
+    local rolestring = ROLE_STRINGS_RAW[role]
     local convar = "ttt_" .. rolestring .. "_healthstation_reduce_max"
     return ConVarExists(convar) and GetConVar(convar):GetBool()
 end

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -30,9 +30,9 @@ function plymeta:SetRole(role)
     -- Role checks only run on the server
     if not SERVER then return end
     -- Only do this if they had an old role. This handles the case where they were assigned a role at the beginning of the round
-    if not oldRole or oldRole <= ROLE_NONE or oldRole >= ROLE_MAX then return end
+    if not oldRole or oldRole <= ROLE_NONE or oldRole > ROLE_MAX then return end
     -- Only do this if the new role is valid. This is not strictly necessary since there wouldn't be a role check for an invalid role, but just for safety
-    if not role or role <= ROLE_NONE or role >= ROLE_MAX then return end
+    if not role or role <= ROLE_NONE or role > ROLE_MAX then return end
     -- Only do this if the player's role actually changed
     if oldRole == role then return end
 

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -34,29 +34,45 @@ hook.Add("TTTTargetIDPlayerKillIcon", "Clown_TTTTargetIDPlayerKillIcon", functio
     end
 end)
 
-local function IsClownVisible(ply)
-    return IsPlayer(ply) and ply:IsClown() and ply:IsRoleActive() and not GetGlobalBool("ttt_clown_hide_when_active", false)
+local function IsClownActive(ply)
+    return IsPlayer(ply) and ply:IsClown() and ply:IsRoleActive()
 end
 
--- Show the clown icon if the player is an activated clown
+local function IsClownVisible(ply)
+    return IsClownActive(ply) and not GetGlobalBool("ttt_clown_hide_when_active", false)
+end
+
 hook.Add("TTTTargetIDPlayerRoleIcon", "Clown_TTTTargetIDPlayerRoleIcon", function(ply, cli, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
+    -- If the local client is an activated clown and the target is a jester, show the jester icon
+    if IsClownActive(cli) and ply:ShouldActLikeJester() then
+        return ROLE_JESTER, false, ROLE_JESTER
+    end
+    -- Show the clown icon if the target is an activated clown
     if IsClownVisible(ply) then
         return ROLE_CLOWN, false, ROLE_CLOWN
     end
 end)
 
--- Show the clown information and color when you look at the player
-hook.Add("TTTTargetIDPlayerRing", "Clown_TTTTargetIDPlayerRing", function(ent, client, ring_visible)
+hook.Add("TTTTargetIDPlayerRing", "Clown_TTTTargetIDPlayerRing", function(ent, cli, ring_visible)
     if GetRoundState() < ROUND_ACTIVE then return end
 
+    -- If the local client is an activated clown and the target is a jester, show the jester information
+    if IsPlayer(ent) and IsClownActive(cli) and ent:ShouldActLikeJester() then
+        return true, ROLE_COLORS_RADAR[ROLE_JESTER]
+    end
+    -- Show the clown information and color when you look at the target
     if IsClownVisible(ent) then
         return true, ROLE_COLORS_RADAR[ROLE_CLOWN]
     end
 end)
 
-hook.Add("TTTTargetIDPlayerText", "Clown_TTTTargetIDPlayerText", function(ent, client, text, col, secondary_text)
+hook.Add("TTTTargetIDPlayerText", "Clown_TTTTargetIDPlayerText", function(ent, cli, text, col, secondary_text)
     if GetRoundState() < ROUND_ACTIVE then return end
 
+    -- If the local client is an activated clown and the target is a jester, show the jester information
+    if IsPlayer(ent) and IsClownActive(cli) and ent:ShouldActLikeJester() then
+        return StringUpper(ROLE_STRINGS[ROLE_JESTER]), ROLE_COLORS_RADAR[ROLE_JESTER]
+    end
     if IsClownVisible(ent) then
         return StringUpper(ROLE_STRINGS[ROLE_CLOWN]), ROLE_COLORS_RADAR[ROLE_CLOWN]
     end

--- a/gamemodes/terrortown/gamemode/roles/jester/jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/jester.lua
@@ -42,7 +42,7 @@ hook.Add("PlayerDeath", "Jester_WinCheck_PlayerDeath", function(victim, infl, at
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if not valid_kill then return end
 
-    if victim:IsJester() and (not attacker:IsJesterTeam()) then
+    if victim:IsJester() then
         JesterKilledNotification(attacker, victim)
         victim:SetNWString("JesterKiller", attacker:Nick())
 


### PR DESCRIPTION
**Fixes**
- Fixed spectators getting errors when looking at health stations
- Fixed role checks not starting for the role with the highest role ID

**Changes**
- Changed the activated clown to be able to see other jesters so they don't kill them
- Changed the jester to win, like normal, if they are somehow to killed by other members of the jester team