### PR TITLE
Misc. fixes

### DIFF
--- a/API/GLOBAL_VARIABLES.md
+++ b/API/GLOBAL_VARIABLES.md
@@ -93,6 +93,10 @@ Variables available globally (within the defined realm)
 *Realm:* Client and Server\
 *Added in:* 1.0.0
 
+**ROLE_TEAMS_WITH_SHOP** - The lookup table of which *ROLE_TEAM_* enumeration values normally have a shop.\
+*Realm:* Client and Server\
+*Added in:* 1.5.9
+
 **ROLE_STRINGS** - Table of title-case names for each role.\
 *Realm:* Client and Server\
 *Added in:* 1.0.0

--- a/API/GLOBAL_VARIABLES.md
+++ b/API/GLOBAL_VARIABLES.md
@@ -95,7 +95,7 @@ Variables available globally (within the defined realm)
 
 **ROLE_TEAMS_WITH_SHOP** - The lookup table of which *ROLE_TEAM_* enumeration values normally have a shop.\
 *Realm:* Client and Server\
-*Added in:* 1.5.9
+*Added in:* 1.5.8
 
 **ROLE_STRINGS** - Table of title-case names for each role.\
 *Realm:* Client and Server\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@ Includes beta updates [1.5.6](#156-beta) and [1.5.7](#157-beta).
 ### Fixes
 - Fixed roles without shops by default belonging to teams that normally get shops by default not having the "shop sync" convars created
 - Fixed error using search in shop or role weapons config menu
+- Fixed loot goblins being shown by traitor vision when it was enabled
 
 ### 1.5.7 (Beta)
 **Released: March 19th, 2022**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+### 1.5.9 (Beta)
+**Released:**
+
+### Fixes
+- Fixed roles without shops by default belonging to teams that normally get shops by default not having the "shop sync" convars created
+
 ### 1.5.8
 **Released: March 22nd, 2022**
 Includes beta updates [1.5.6](#156-beta) and [1.5.7](#157-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,12 @@
 # Release Notes
 
-### 1.5.9 (Beta)
-**Released:**
-
-### Fixes
-- Fixed roles without shops by default belonging to teams that normally get shops by default not having the "shop sync" convars created
-
 ### 1.5.8
 **Released: March 22nd, 2022**
 Includes beta updates [1.5.6](#156-beta) and [1.5.7](#157-beta).
+
+### Fixes
+- Fixed roles without shops by default belonging to teams that normally get shops by default not having the "shop sync" convars created
+- Fixed error using search in shop or role weapons config menu
 
 ### 1.5.7 (Beta)
 **Released: March 19th, 2022**

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -436,7 +436,13 @@ end
 concommand.Add("ttt_cl_traitorpopup_close", ForceCloseTraitorMenu)
 
 local function DoesValueMatch(item, data, value)
-    return item[data] and StringFind(StringLower(SafeTranslate(item[data])), StringLower(value))
+    if not item[data] then return false end
+
+    local itemdata = item[data]
+    if isfunction(itemdata) then
+        itemdata = itemdata()
+    end
+    return itemdata and StringFind(StringLower(SafeTranslate(itemdata)), StringLower(value))
 end
 
 local function TraitorMenuPopup()

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -832,13 +832,17 @@ end)
 
 -- Player highlights
 
+local function ShouldHideFromHighlight(ply, client)
+    return ply:IsLootGoblin() and ply:IsRoleActive()
+end
+
 function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies, traitorAllies, onlyShowEnemies)
     if GetRoundState() ~= ROUND_ACTIVE then return end
     local enemies = {}
     local friends = {}
     local jesters = {}
     for _, v in pairs(GetAllPlayers()) do
-        if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= client then
+        if IsValid(v) and v:Alive() and not v:IsSpec() and v ~= client and not ShouldHideFromHighlight(v, client) then
             local hideBeggar = v:GetNWBool("WasBeggar", false) and not client:ShouldRevealBeggar(v)
             local hideBodysnatcher = v:GetNWBool("WasBodysnatcher", false) and not client:ShouldRevealBodysnatcher(v)
             if showJesters and (v:ShouldActLikeJester() or hideBeggar or hideBodysnatcher) then

--- a/gamemodes/terrortown/gamemode/cl_roleweapons.lua
+++ b/gamemodes/terrortown/gamemode/cl_roleweapons.lua
@@ -16,7 +16,13 @@ local StringLower = string.lower
 local function ItemIsWeapon(item) return not tonumber(item.id) end
 
 local function DoesValueMatch(item, data, value)
-    return item[data] and StringFind(StringLower(SafeTranslate(item[data])), StringLower(value))
+    if not item[data] then return false end
+
+    local itemdata = item[data]
+    if isfunction(itemdata) then
+        itemdata = itemdata()
+    end
+    return itemdata and StringFind(StringLower(SafeTranslate(itemdata)), StringLower(value))
 end
 
 local function OpenDialog(client)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,8 +17,8 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.9"
-CR_BETA = true
+CR_VERSION = "1.5.8"
+CR_BETA = false
 
 function CRVersion(version)
     local installedVersionRaw = StringSplit(CR_VERSION, ".")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.8"
+CR_VERSION = "1.5.9"
 CR_BETA = true
 
 function CRVersion(version)
@@ -665,6 +665,9 @@ ROLE_TEAM_INDEPENDENT = 3
 ROLE_TEAM_MONSTER = 4
 ROLE_TEAM_DETECTIVE = 5
 
+ROLE_TEAMS_WITH_SHOP = {}
+AddRoleAssociations(ROLE_TEAMS_WITH_SHOP, {ROLE_TEAM_TRAITOR, ROLE_TEAM_INDEPENDENT, ROLE_TEAM_MONSTER, ROLE_TEAM_DETECTIVE})
+
 ROLE_DATA_EXTERNAL = {}
 
 ROLE_TRANSLATIONS = {}
@@ -791,7 +794,9 @@ function RegisterRole(tbl)
     end
 
     -- Equipment
-    if tbl.shop then
+    -- Make sure teams that normally have shops are added to the shop list, even if they don't have things in their shop by default
+    -- This allows the "sync" and "mode" convars to be created
+    if tbl.shop or ROLE_TEAMS_WITH_SHOP[tbl.team] then
         ROLE_SHOP_ITEMS[roleID] = tbl.shop
         AddRoleAssociations(SHOP_ROLES, {roleID})
     end


### PR DESCRIPTION
**Fixes**
- Fixed error using search in shop or role weapons config menu
- Fixed roles without shops by default belonging to teams that normally get shops by default not having the "shop sync" convars created
- Fixed loot goblins being shown by traitor vision when it was enabled