### PR TITLE
Misc. fixes and additions

### DIFF
--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -28,6 +28,12 @@ Methods available when called from a Player object (within the defined realm)
 *Parameters:*
 - *activeOnly* - Whether the player must also be active (Defaults to `false`)
 
+**plymeta:DrunkRememberRole(role)** - Sets the drunk's role and runs required checks for that role.\
+*Realm:* Server\
+*Added in:* 1.1.9\
+*Parameters:*
+- *role* - Which role to set the drunk to (see ROLE_* global enumeration)
+
 **plymeta:GetDisplayedRole()** - Gets the role that should be displayed for the player.\
 *Realm:* Client and Server\
 *Added in:* 1.5.3
@@ -156,12 +162,24 @@ Methods available when called from a Player object (within the defined realm)
 *Realm:* Client and Server\
 *Added in:* 1.0.0
 
+**plymeta:IsZombifying()** - Whether the player is in the process of respawning as a zombie.\
+*Realm:* Client and Server\
+*Added in:* 1.5.12
+
 **plymeta:MoveRoleState(target, keepOnSource)** - Moves role state data (such as promotion and monster prime status) to the target.\
 *Realm:* Client and Server\
 *Added in:* 1.0.5\
 *Parameters:*
 - *target* - The player to move the role state data to
-- *keepOnSource* - Wheter the source player should also keep the role state data (Defaults to `false`)
+- *keepOnSource* - Whether the source player should also keep the role state data (Defaults to `false`)
+
+**plymeta:ResetPlayerScale()** - Reset's the players size to default by adjusting models, step sizes, hulls and view offsets.\
+*Realm:* Server\
+*Added in:* 1.3.1
+
+**plymeta:RespawnAsZombie()** - Respawns the player as a zombie after a 3 second delay.\
+*Realm:* Server\
+*Added in:* 1.5.12
 
 **plymeta:SetRoleAndBroadcast(role)** - Sets the player's role to the given one and (if called on the server) broadcasts the change to all clients for scoreboard tracking.\
 *Realm:* Client and Server\
@@ -229,12 +247,6 @@ Methods available when called from a Player object (within the defined realm)
 *Parameters:*
 - *team* - Which team to choose a role from (see ROLE_TEAM_* global enumeration)
 
-**plymeta:DrunkRememberRole(role)** - Sets the drunk's role and runs required checks for that role.\
-*Realm:* Server\
-*Added in:* 1.1.9\
-*Parameters:*
-- *role* - Which role to set the drunk to (see ROLE_* global enumeration)
-
 **plymeta:StripRoleWeapons()** - Strips all weapons from the player whose `Category` property matches the global `WEAPON_CATEGORY_ROLE` value.\
 *Realm:* Client and Server\
 *Added in:* 1.0.5
@@ -244,7 +256,3 @@ Methods available when called from a Player object (within the defined realm)
 *Added in:* 1.3.1\
 *Parameters:*
 - *scale* - The value with which to scale the players size, relative to their current size.
-
-**plymeta:ResetPlayerScale()** - Reset's the players size to default by adjusting models, step sizes, hulls and view offsets.\
-*Realm:* Server\
-*Added in:* 1.3.1

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -507,6 +507,7 @@ ttt_zombie_thrall_convert_chance            1.0     // The chance that a zombie 
 
 // Mad Scientist
 ttt_madscientist_device_time                4       // The amount of time (in seconds) the mad scientist's device takes to use
+ttt_madscientist_respawn_enable             0       // Whether the mad scientist should respawn as a zombie when they are killed
 
 // ----------------------------------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed zombie respawn notification getting trampled by the "medium can sense your spirit" notification
+- Fixed minor grammatical problem in the zombie tutorial when the role is renamed
 
 ### Developer
 - Added `plymeta:IsZombifying()` to check whether a player is respawning as a zombie

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.5.12 (Beta)
 **Released:**
 
+### Additions
+- Added ability for mad scientist to respawn as a zombie when they die (disabled by default)
+
 ### Fixes
 - Fixed zombie respawn notification getting trampled by the "medium can sense your spirit" notification
 - Fixed minor grammatical problem in the zombie tutorial when the role is renamed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 1.5.12 (Beta)
+**Released:**
+
+### Fixes
+- Fixed zombie respawn notification getting trampled by the "medium can sense your spirit" notification
+
+### Developer
+- Added `plymeta:IsZombifying()` to check whether a player is respawning as a zombie
+- Added `plymeta:RespawnAsZombie()` to allow respawning a player as a zombie
+
 ## 1.5.11 (Beta)
 **Released: April 16th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 1.5.12 (Beta)
-**Released:**
+**Released: April 23rd, 2022**
 
 ### Additions
 - Added ability for mad scientist to respawn as a zombie when they die (disabled by default)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1215,7 +1215,7 @@ function GM:TTTCheckForWin()
                 innocent_alive = true
             end
         -- Handle zombification differently because the player's original role should have no impact on this
-        elseif v:GetNWBool("IsZombifying", false) then
+        elseif v:IsZombifying() then
             if TRAITOR_ROLES[ROLE_ZOMBIE] then
                 traitor_alive = true
             elseif MONSTER_ROLES[ROLE_ZOMBIE] then

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -596,7 +596,7 @@ function player.TeamLivingCount(ignorePassiveWinners)
                 end
             end
         -- Handle zombification differently because the player's original role should have no impact on this
-        elseif v:GetNWBool("IsZombifying", false) then
+        elseif v:IsZombifying() then
             if TRAITOR_ROLES[ROLE_ZOMBIE] then
                 traitor_alive = traitor_alive + 1
             elseif INDEPENDENT_ROLES[ROLE_ZOMBIE] then
@@ -638,7 +638,7 @@ function player.LivingCount(ignorePassiveWinners)
         -- If the player is alive and we're either not ignoring passive winners or this isn't a passive winning role
         if (v:Alive() and v:IsTerror() and (not ignorePassiveWinners or not ROLE_HAS_PASSIVE_WIN[v:GetRole()])) or
             -- Handle zombification differently because the player's original role should have no impact on this
-            v:GetNWBool("IsZombifying", false) then
+            v:IsZombifying() then
             players_alive = players_alive + 1
         end
     end

--- a/gamemodes/terrortown/gamemode/roles/madscientist/cl_madscientist.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/cl_madscientist.lua
@@ -23,6 +23,13 @@ hook.Add("TTTTutorialRoleText", "MadScientist_TTTTutorialRoleText", function(rol
     if role == ROLE_MADSCIENTIST then
         local roleColor = GetRoleTeamColor(ROLE_TEAM_INDEPENDENT)
         local traitorColor = ROLE_COLORS[ROLE_TRAITOR]
-        return "The " .. ROLE_STRINGS[ROLE_MADSCIENTIST] .. " is an <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>independent</span> role whose goal is to resurrect dead bodies as their <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>" .. ROLE_STRINGS[ROLE_ZOMBIE] .. " minions</span>."
+        local html = "The " .. ROLE_STRINGS[ROLE_MADSCIENTIST] .. " is an <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>independent</span> role whose goal is to resurrect dead bodies as their <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>" .. ROLE_STRINGS[ROLE_ZOMBIE] .. " minions</span>."
+
+        -- Respawn
+        if GetGlobalBool("ttt_madscientist_respawn_enable", false) then
+            html = html .. "<span style='display: block; margin-top: 10px;'>If the " .. ROLE_STRINGS[ROLE_MADSCIENTIST] .. " is killed they will <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>respawn as " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " thrall</spawn>.</span>"
+        end
+
+        return html
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/madscientist/madscientist.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/madscientist.lua
@@ -1,0 +1,26 @@
+AddCSLuaFile()
+
+local hook = hook
+
+-------------
+-- CONVARS --
+-------------
+
+local madscientist_respawn_enable = CreateConVar("ttt_madscientist_respawn_enable", "0")
+
+hook.Add("TTTSyncGlobals", "MadScientist_TTTSyncGlobals", function()
+    SetGlobalBool("ttt_madscientist_respawn_enable", madscientist_respawn_enable:GetBool())
+end)
+
+-------------------
+-- ROLE FEATURES --
+-------------------
+
+hook.Add("PlayerDeath", "MadScientist_PlayerDeath", function(victim, infl, attacker)
+    if GetRoundState() ~= ROUND_ACTIVE then return end
+    if not victim:IsMadScientist() then return end
+    if not madscientist_respawn_enable:GetBool() then return end
+
+    -- Respawn the mad scientist as a zombie if they are killed
+    victim:RespawnAsZombie()
+end)

--- a/gamemodes/terrortown/gamemode/roles/madscientist/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/shared.lua
@@ -18,3 +18,7 @@ table.insert(ROLE_CONVARS[ROLE_MADSCIENTIST], {
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 0
 })
+table.insert(ROLE_CONVARS[ROLE_MADSCIENTIST], {
+    cvar = "ttt_madscientist_respawn_enable",
+    type = ROLE_CONVAR_TYPE_BOOL
+})

--- a/gamemodes/terrortown/gamemode/roles/medium/medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/medium.lua
@@ -79,8 +79,8 @@ hook.Add("PlayerDeath", "Medium_Spirits_PlayerDeath", function(victim, infl, att
         spirit:Spawn()
         spirits[victim:SteamID64()] = spirit
 
-        -- Let the player who died know there is a medium and this player isn't the only medium
-        if medium_dead_notify:GetBool() and (#mediums > 1 or not victim:IsMedium()) then
+        -- Let the player who died know there is a medium as long as this player isn't the only medium and they are not turning into a zombie
+        if medium_dead_notify:GetBool() and (#mediums > 1 or not victim:IsMedium()) and not victim:IsZombifying() then
             victim:PrintMessage(HUD_PRINTTALK, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
             victim:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
         end

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -204,7 +204,7 @@ end
 
 hook.Add("PlayerDeath", "Parasite_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
-    if valid_kill and victim:IsParasite() and not victim:GetNWBool("IsZombifying", false) then
+    if valid_kill and victim:IsParasite() and not victim:IsZombifying() then
         HandleParasiteInfection(attacker, victim)
 
         -- Delay this message so the player can see the target update message

--- a/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
@@ -96,7 +96,7 @@ end)
 
 hook.Add("PlayerDeath", "Phantom_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
-    if valid_kill and victim:IsPhantom() and not victim:GetNWBool("IsZombifying", false) then
+    if valid_kill and victim:IsPhantom() and not victim:IsZombifying() then
         attacker:SetNWBool("Haunted", true)
 
         if phantom_killer_haunt:GetBool() then

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -202,7 +202,7 @@ hook.Add("TTTTutorialRoleText", "Zombie_TTTTutorialRoleText", function(role, tit
         local html = "The " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " is a member of the <span style='color: rgb(" .. roleTeamColor.r .. ", " .. roleTeamColor.g .. ", " .. roleTeamColor.b .. ")'>" .. string.lower(roleTeamString) .. " team</span> that uses their claws to attack their enemies."
 
         -- Convert
-        html = html .. "<span style='display: block; margin-top: 10px;'>Killing a player with their claws will <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>turn the target</span> into a " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " thrall.</span>"
+        html = html .. "<span style='display: block; margin-top: 10px;'>Killing a player with their claws will <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>turn the target</span> into " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " thrall.</span>"
 
         -- Leap
         if GetGlobalBool("ttt_zombie_leap_enable", true) then

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -86,6 +86,8 @@ end
 plymeta.IsZombiePrime = plymeta.GetZombiePrime
 plymeta.IsZombieAlly = plymeta.GetZombieAlly
 
+function plymeta:IsZombifying() return self:GetNWBool("IsZombifying", false) end
+
 -----------------
 -- SPEED BONUS --
 -----------------

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.11"
+CR_VERSION = "1.5.12"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Additions**
- Added ability for mad scientist to respawn as a zombie when they die (disabled by default)

**Fixes**
- Fixed zombie respawn notification getting trampled by the "medium can sense your spirit" notification
- Fixed minor grammatical problem in the zombie tutorial when the role is renamed

**Developer**
- Added `plymeta:IsZombifying()` to check whether a player is respawning as a zombie
- Added `plymeta:RespawnAsZombie()` to allow respawning a player as a zombie