### PR TITLE
Misc. fixes and changes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ### Changes
 - Increased head icon offset when a player's head is scaled up so the icon is visible on models with larger heads
+- Changed the shop to only be openable if the player has buyable items (previously this behavior only happened when shop-for-all was enabled)
 
 ## 1.5.12 (Beta)
 **Released: April 23rd, 2022**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 ### Fixes
 - Fixed binoculars showing while a player is dead if they died while their binoculars are out
 
+### Changes
+- Increased head icon offset when a player's head is scaled up so the icon is visible on models with larger heads
+
 ## 1.5.12 (Beta)
 **Released: April 23rd, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.5.13 (Beta)
+**Released:**
+
+### Fixes
+- Fixed binoculars showing while a player is dead if they died while their binoculars are out
+
 ## 1.5.12 (Beta)
 **Released: April 23rd, 2022**
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
@@ -109,7 +109,8 @@ function SWEP:SetZoom(level)
         -- Only show the view model when we're not zoomed in
         if level <= 1 then
             timer.Simple(0.25, function()
-                if IsValid(owner) then
+                -- Don't use the cached owner because we need to make sure the binocs weren't dropped
+                if IsValid(self:GetOwner()) then
                     owner:DrawViewModel(true)
                 end
             end)
@@ -257,31 +258,31 @@ if CLIENT then
     end
 
     function SWEP:DrawWorldModel()
-        if not self.WorldModelEnt then
-            self.WorldModelEnt = ClientsideModel(self.WorldModel)
-            self.WorldModelEnt:SetNoDraw(true)
-        end
+       if not self.WorldModelEnt then
+           self.WorldModelEnt = ClientsideModel(self.WorldModel)
+           self.WorldModelEnt:SetNoDraw(true)
+       end
 
-        local owner = self:GetOwner()
-        if IsValid(owner) then
-            local boneid = owner:LookupBone(self.WorldModelAttachment)
-            if not boneid or boneid <= 0 then return end
+       local owner = self:GetOwner()
+       if IsValid(owner) then
+           local boneid = owner:LookupBone(self.WorldModelAttachment)
+           if not boneid or boneid <= 0 then return end
 
-            local matrix = owner:GetBoneMatrix(boneid)
-            if not matrix then return end
+           local matrix = owner:GetBoneMatrix(boneid)
+           if not matrix then return end
 
-            local newPos, newAng = LocalToWorld(self.WorldModelVector, self.WorldModelAngle, matrix:GetTranslation(), matrix:GetAngles())
+           local newPos, newAng = LocalToWorld(self.WorldModelVector, self.WorldModelAngle, matrix:GetTranslation(), matrix:GetAngles())
 
-            self.WorldModelEnt:SetPos(newPos)
-            self.WorldModelEnt:SetAngles(newAng)
+           self.WorldModelEnt:SetPos(newPos)
+           self.WorldModelEnt:SetAngles(newAng)
 
-            self.WorldModelEnt:SetupBones()
-        else
-            self.WorldModelEnt:SetPos(self:GetPos())
-            self.WorldModelEnt:SetAngles(self:GetAngles())
-        end
+           self.WorldModelEnt:SetupBones()
+       else
+           self.WorldModelEnt:SetPos(self:GetPos())
+           self.WorldModelEnt:SetAngles(self:GetAngles())
+       end
 
-        self.WorldModelEnt:DrawModel()
+       self.WorldModelEnt:DrawModel()
     end
 
     function SWEP:AdjustMouseSensitivity()

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -107,13 +107,7 @@ function plymeta:IsShopRole()
     return hasShop
 end
 function plymeta:CanUseShop()
-    local isShopRole = self:IsShopRole()
-    -- Don't perform the additional checks if "shop for all" is enabled
-    if GetGlobalBool("ttt_shop_for_all", false) then
-        return isShopRole and WEPS.DoesRoleHaveWeapon(self:GetRole(), self:IsDetectiveLike())
-    end
-
-    return isShopRole
+    return self:IsShopRole() and WEPS.DoesRoleHaveWeapon(self:GetRole(), self:IsDetectiveLike())
 end
 function plymeta:ShouldDelayShopPurchase()
     local role = self:GetRole()

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -365,7 +365,7 @@ if CLIENT then
         if headId then
             local headScale = self:GetManipulateBoneScale(headId)
             if headScale.z > 1 then
-                max_bone_z = max_bone_z + ((headScale.z - 1) * 10)
+                max_bone_z = max_bone_z + ((headScale.z - 1) * 25)
             end
         end
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.5.12"
+CR_VERSION = "1.5.13"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
### Fixes
- Fixed binoculars showing while a player is dead if they died while their binoculars are out

### Changes
- Increased head icon offset when a player's head is scaled up so the icon is visible on models with larger heads
- Changed the shop to only be openable if the player has buyable items (previously this behavior only happened when shop-for-all was enabled)