### PR TITLE
Informant tweaks and other updates

### DIFF
--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -42,6 +42,10 @@ Methods available when called from a Player object (within the defined realm)
 *Realm:* Client and Server\
 *Added in:* 1.5.3
 
+*Returns:*
+- *display_role* - The role that should be displayed for the player.
+- *changed* - Whether the return value was changed and should be hidden
+
 **plymeta:GetHeight()** - Gets the *estimated* height of the player based on their player model.\
 *Realm:* Client\
 *Added in:* 1.0.2

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -234,7 +234,7 @@ ttt_single_phantom_parasite                 0       // Whether only a single pha
 ttt_informant_share_scans                   1       // Whether the informant should automatically share their information with fellow traitors or not
 ttt_informant_can_scan_jesters              0       // Whether the informant should be able to scan jesters
 ttt_informant_can_scan_glitches             0       // Whether the informant should be able to scan glitches
-ttt_informant_scanner_time                  5       // The amount of time (in seconds) the informant's scanner takes to use
+ttt_informant_scanner_time                  8       // The amount of time (in seconds) the informant's scanner takes to use
 ttt_informant_scanner_float_time            1       // The amount of time (in seconds) it takes for the informant's scanner to lose it's target without line of sight
 ttt_informant_scanner_cooldown              3       // The amount of time (in seconds) the informant's tracker goes on cooldown for after losing it's target
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 
 ### Changes
 - Changed jester team to show question mark icons over their head and on the scoreboard instead of the jester icon
+- Changed detective team to show question mark icons over their head and on the scoreboard instead of the detective icon if roles are hidden
 - Changed maps which send messages to specific vanilla roles to instead send those messages to the equivalent team
 
 ### Developer

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,8 +10,9 @@
 
 ### Changes
 - Changed jester team to show question mark icons over their head and on the scoreboard instead of the jester icon
-- Changed detective team to show question mark icons over their head and on the scoreboard instead of the detective icon if roles are hidden
 - Changed maps which send messages to specific vanilla roles to instead send those messages to the equivalent team
+- Changed detective team to show question mark icons over their head and on the scoreboard instead of the detective icon if roles are hidden
+- Changed hidden detective HUD text to make it clear that the role is unknown but others still know its a detective
 
 ### Developer
 - Added `plymeta:IsTargetIDOverridden` to determine whether the player is currently overriding a piece of Target ID information

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 - Changed maps which send messages to specific vanilla roles to instead send those messages to the equivalent team
 - Changed detective team to show question mark icons over their head and on the scoreboard instead of the detective icon if roles are hidden
 - Changed hidden detective HUD text to make it clear that the role is unknown but others still know its a detective
+- Updated detective tutorials to explain role hiding logic
 
 ### Developer
 - Added `plymeta:IsTargetIDOverridden` to determine whether the player is currently overriding a piece of Target ID information

--- a/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
@@ -52,10 +52,7 @@ SWEP.InLoadoutFor           = {ROLE_INFORMANT}
 
 SWEP.AllowDrop              = false
 
-SWEP.WorldModelAttachment  = "ValveBiped.Bip01_R_Hand"
-SWEP.WorldModelVector      = Vector(5, -5, 0)
-SWEP.WorldModelAngle       = Angle(180, 180, 0)
-SWEP.ViewModelDistance     = 100
+SWEP.ViewModelOffset        = Vector(4, 100, -1)
 
 local SCANNER_IDLE = 0
 local SCANNER_LOCKED = 1
@@ -96,13 +93,6 @@ function SWEP:Holster()
     self:SetTargetLost(-1)
     self:SetCooldown(-1)
     return true
-end
-
-function SWEP:GetViewModelPosition(pos, ang) -- TODO: Move out of way of crosshair
-	local forward = ang:Forward()
-    -- Move the model away from the player camera so it doesn't take up half the screen
-    local dist = Vector(-forward.x * self.ViewModelDistance, -forward.y * self.ViewModelDistance, -forward.z * self.ViewModelDistance)
-	return pos - dist, ang
 end
 
 function SWEP:Deploy()
@@ -181,20 +171,6 @@ if SERVER then
     function SWEP:Scan(target)
         if target:IsActive() then
             local stage = target:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
-            if stage == INFORMANT_UNSCANNED then
-                if target:IsDetectiveTeam() then
-                    if GetConVar("ttt_detective_hide_special_mode"):GetInt() >= SPECIAL_DETECTIVE_HIDE_FOR_ALL then
-                        target:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_TEAM)
-                        stage = INFORMANT_SCANNED_TEAM
-                    else
-                        target:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_ROLE)
-                        stage = INFORMANT_SCANNED_ROLE
-                    end
-                elseif target:IsJesterTeam() or target:IsTraitorTeam() or target:IsGlitch() then
-                    target:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_TEAM)
-                    stage = INFORMANT_SCANNED_TEAM
-                end
-            end
             if CurTime() - self:GetScanStart() >= GetConVar("ttt_informant_scanner_time"):GetInt() then
                 stage = stage + 1
                 if stage == INFORMANT_SCANNED_TEAM then
@@ -372,6 +348,19 @@ if CLIENT then
     end
 
     function SWEP:DrawWorldModel()
+    end
+
+    function SWEP:GetViewModelPosition(pos, ang)
+        local right = ang:Right()
+        local up = ang:Up()
+        local forward = ang:Forward()
+        local offset = self.ViewModelOffset
+
+        pos = pos + offset.x * right
+        pos = pos + offset.y * forward
+        pos = pos + offset.z * up
+
+        return pos, ang
     end
 end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
@@ -315,15 +315,6 @@ if CLIENT then
             self:DrawStructure(x, y, w, h, m, color)
 
             local target = player.GetBySteamID64(self:GetTarget())
-            -- TODO: Remove this
-            if not IsPlayer(target) then
-                for _, ply in ipairs(GetAllPlayers()) do
-                    if ply:Nick() == "Bot01" then
-                        target = ply
-                        break
-                    end
-                end
-            end
             local targetState = target:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
 
             local cc = math.min(1, 1 - ((time - CurTime()) / scan))

--- a/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
@@ -63,7 +63,7 @@ local SCANNER_SEARCHING = 2
 local SCANNER_LOST = 3
 
 if SERVER then
-    CreateConVar("ttt_informant_scanner_time", "5", FCVAR_NONE, "The amount of time (in seconds) the informant's scanner takes to use", 0, 60)
+    CreateConVar("ttt_informant_scanner_time", "8", FCVAR_NONE, "The amount of time (in seconds) the informant's scanner takes to use", 0, 60)
     CreateConVar("ttt_informant_scanner_float_time", "1", FCVAR_NONE, "The amount of time (in seconds) it takes for the informant's scanner to lose it's target without line of sight", 0, 60)
     CreateConVar("ttt_informant_scanner_cooldown", "3", FCVAR_NONE, "The amount of time (in seconds) the informant's tracker goes on cooldown for after losing it's target", 0, 60)
 end

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -130,6 +130,9 @@ function GM:PostDrawTranslucentRenderables()
                 local noz = false
                 if v:IsDetectiveTeam() then
                     role = v:GetDisplayedRole()
+                    if role == ROLE_NONE then
+                        color_role = ROLE_DETECTIVE
+                    end
                 elseif v:IsDetectiveLike() and not (v:IsImpersonator() and client:IsTraitorTeam()) then
                     role = GetDetectiveIconRole(false)
                 end
@@ -310,6 +313,7 @@ function GM:HUDDrawTargetID()
     local target_traitor = false
     local target_special_traitor = false
     local target_detective = false
+    local target_unknown_detective = false
     local target_special_detective = false
 
     local target_glitch = false
@@ -413,7 +417,9 @@ function GM:HUDDrawTargetID()
         if GetRoundState() > ROUND_PREP then
             if ent:GetDisplayedRole() == ROLE_DETECTIVE or ((ent:IsDeputy() or (ent:IsImpersonator() and not client:IsTraitorTeam())) and ent:IsRoleActive()) then
                 target_detective = true
-            elseif ent:IsDetectiveTeam() and not target_detective then
+            elseif ent:GetDisplayedRole() == ROLE_NONE then
+                target_unknown_detective = true
+            elseif ent:IsDetectiveTeam() then
                 target_special_detective = true
             end
         end
@@ -452,7 +458,7 @@ function GM:HUDDrawTargetID()
 
     local w, h = 0, 0 -- text width/height, reused several times
 
-    local ring_visible = target_traitor or target_special_traitor or target_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
+    local ring_visible = target_traitor or target_special_traitor or target_detective or target_unknown_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
 
     local new_visible, color_override = CallHook("TTTTargetIDPlayerRing", nil, ent, client, ring_visible)
     if type(new_visible) == "boolean" then ring_visible = new_visible end
@@ -466,7 +472,7 @@ function GM:HUDDrawTargetID()
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_TRAITOR])
         elseif target_special_traitor then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_TRAITOR, "radar"))
-        elseif target_detective then
+        elseif target_detective or target_unknown_detective then
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_DETECTIVE])
         elseif target_special_detective then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_DETECTIVE, "radar"))
@@ -618,6 +624,9 @@ function GM:HUDDrawTargetID()
         col = ROLE_COLORS_RADAR[bluff]
     elseif target_detective then
         text = StringUpper(ROLE_STRINGS[ROLE_DETECTIVE])
+        col = ROLE_COLORS_RADAR[ROLE_DETECTIVE]
+    elseif target_unknown_detective then
+        text = GetPTranslation("target_unknown_team", { targettype = StringUpper(ROLE_STRINGS[ROLE_DETECTIVE]) })
         col = ROLE_COLORS_RADAR[ROLE_DETECTIVE]
     elseif target_special_detective then
         local role = ent:GetRole()

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -130,9 +130,6 @@ function GM:PostDrawTranslucentRenderables()
                 local noz = false
                 if v:IsDetectiveTeam() then
                     role = v:GetDisplayedRole()
-                    if role == ROLE_NONE then
-                        color_role = ROLE_DETECTIVE
-                    end
                 elseif v:IsDetectiveLike() and not (v:IsImpersonator() and client:IsTraitorTeam()) then
                     role = GetDetectiveIconRole(false)
                 end
@@ -313,7 +310,6 @@ function GM:HUDDrawTargetID()
     local target_traitor = false
     local target_special_traitor = false
     local target_detective = false
-    local target_unknown_detective = false
     local target_special_detective = false
 
     local target_glitch = false
@@ -417,9 +413,7 @@ function GM:HUDDrawTargetID()
         if GetRoundState() > ROUND_PREP then
             if ent:GetDisplayedRole() == ROLE_DETECTIVE or ((ent:IsDeputy() or (ent:IsImpersonator() and not client:IsTraitorTeam())) and ent:IsRoleActive()) then
                 target_detective = true
-            elseif ent:GetDisplayedRole() == ROLE_NONE then
-                target_unknown_detective = true
-            elseif ent:IsDetectiveTeam() then
+            elseif ent:IsDetectiveTeam() and not target_detective then
                 target_special_detective = true
             end
         end
@@ -458,7 +452,7 @@ function GM:HUDDrawTargetID()
 
     local w, h = 0, 0 -- text width/height, reused several times
 
-    local ring_visible = target_traitor or target_special_traitor or target_detective or target_unknown_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
+    local ring_visible = target_traitor or target_special_traitor or target_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
 
     local new_visible, color_override = CallHook("TTTTargetIDPlayerRing", nil, ent, client, ring_visible)
     if type(new_visible) == "boolean" then ring_visible = new_visible end
@@ -472,7 +466,7 @@ function GM:HUDDrawTargetID()
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_TRAITOR])
         elseif target_special_traitor then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_TRAITOR, "radar"))
-        elseif target_detective or target_unknown_detective then
+        elseif target_detective then
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_DETECTIVE])
         elseif target_special_detective then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_DETECTIVE, "radar"))
@@ -624,9 +618,6 @@ function GM:HUDDrawTargetID()
         col = ROLE_COLORS_RADAR[bluff]
     elseif target_detective then
         text = StringUpper(ROLE_STRINGS[ROLE_DETECTIVE])
-        col = ROLE_COLORS_RADAR[ROLE_DETECTIVE]
-    elseif target_unknown_detective then
-        text = GetPTranslation("target_unknown_team", { targettype = StringUpper(ROLE_STRINGS[ROLE_DETECTIVE]) })
         col = ROLE_COLORS_RADAR[ROLE_DETECTIVE]
     elseif target_special_detective then
         local role = ent:GetRole()

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -198,23 +198,23 @@ function plymeta:IsRoleActive()
 end
 
 function plymeta:GetDisplayedRole()
-    if self:IsDetectiveTeam() and not self:IsDetective() then
+    if self:IsDetectiveTeam() then
         local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
-        -- By default, show detective unless this is disabled
-        local show_detective = special_detective_mode ~= SPECIAL_DETECTIVE_HIDE_NONE
+        -- By default, show the question mark unless this is disabled
+        local role_hidden = special_detective_mode ~= SPECIAL_DETECTIVE_HIDE_NONE
 
         -- But if we're on the client
-        if show_detective and CLIENT then
+        if role_hidden and CLIENT then
             local client = LocalPlayer()
             -- Check if the local player is the special detective
             -- If they are, don't hide their role if we're only hiding for others
             if client == self and special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_OTHERS then
-                show_detective = false
+                role_hidden = false
             end
         end
 
-        if show_detective then
-            return ROLE_DETECTIVE
+        if role_hidden then
+            return ROLE_NONE
         end
     end
     return self:GetRole()

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -214,10 +214,10 @@ function plymeta:GetDisplayedRole()
         end
 
         if show_detective then
-            return ROLE_DETECTIVE
+            return ROLE_DETECTIVE, true
         end
     end
-    return self:GetRole()
+    return self:GetRole(), false
 end
 
 -- Returns printable role

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -198,23 +198,23 @@ function plymeta:IsRoleActive()
 end
 
 function plymeta:GetDisplayedRole()
-    if self:IsDetectiveTeam() then
+    if self:IsDetectiveTeam() and not self:IsDetective() then
         local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
-        -- By default, show the question mark unless this is disabled
-        local role_hidden = special_detective_mode ~= SPECIAL_DETECTIVE_HIDE_NONE
+        -- By default, show detective unless this is disabled
+        local show_detective = special_detective_mode ~= SPECIAL_DETECTIVE_HIDE_NONE
 
         -- But if we're on the client
-        if role_hidden and CLIENT then
+        if show_detective and CLIENT then
             local client = LocalPlayer()
             -- Check if the local player is the special detective
             -- If they are, don't hide their role if we're only hiding for others
             if client == self and special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_OTHERS then
-                role_hidden = false
+                show_detective = false
             end
         end
 
-        if role_hidden then
-            return ROLE_NONE
+        if show_detective then
+            return ROLE_DETECTIVE
         end
     end
     return self:GetRole()

--- a/gamemodes/terrortown/gamemode/roles/detective/cl_detective.lua
+++ b/gamemodes/terrortown/gamemode/roles/detective/cl_detective.lua
@@ -26,6 +26,16 @@ hook.Add("TTTTutorialRoleText", "Detective_TTTTutorialRoleText", function(role, 
             html = html .. "<span style='display: block; margin-top: 10px;'>" .. ROLE_STRINGS_PLURAL[ROLE_DETECTIVE] .. " are the only roles allowed to <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>search bodies</span> to find information about who they were and how they died."
         end
 
-        return html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>."
+        html = html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>"
+        local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
+        if special_detective_mode > SPECIAL_DETECTIVE_HIDE_NONE then
+            html = html .. ", but not what specific type of " .. ROLE_STRINGS[ROLE_DETECTIVE]
+            if special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_ALL then
+                html = html .. ". <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Not even you know what type of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " you are</span>"
+            end
+        end
+        html = html .. ".</span>"
+
+        return html
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
@@ -12,7 +12,7 @@ hook.Add("Initialize", "DetectiveLike_Translations_Initialize", function()
 
     -- HUD
     LANG.AddToLanguage("english", "detective_promotion_hud", "You have been promoted to {detective}")
-    LANG.AddToLanguage("english", "detective_special_hidden_hud", "You appear as {detective} to others")
+    LANG.AddToLanguage("english", "detective_special_hidden_hud", "Your {detective} type is hidden from others")
 end)
 
 -------------
@@ -50,7 +50,7 @@ hook.Add("TTTHUDInfoPaint", "DetectiveLike_TTTHUDInfoPaint", function(client, la
             surface.SetFont("TabLarge")
             surface.SetTextColor(255, 255, 255, 230)
 
-            text = LANG.GetParamTranslation("detective_special_hidden_hud", { detective = ROLE_STRINGS_EXT[ROLE_DETECTIVE] })
+            text = LANG.GetParamTranslation("detective_special_hidden_hud", { detective = ROLE_STRINGS[ROLE_DETECTIVE] })
             local _, h = surface.GetTextSize(text)
 
             surface.SetTextPos(label_left, ScrH() - label_top - h)

--- a/gamemodes/terrortown/gamemode/roles/informant/cl_informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/cl_informant.lua
@@ -82,11 +82,12 @@ end)
 
 hook.Add("TTTTargetIDPlayerRing", "Informant_TTTTargetIDPlayerRing", function(ent, cli, ringVisible)
     if GetRoundState() < ROUND_ACTIVE then return end
+    if not IsPlayer(ent) then return end
 
-    local _, override, _ = cli:IsTargetIDOverridden(ply)
+    local _, override, _ = cli:IsTargetIDOverridden(ent)
     if override then return end
 
-    if IsPlayer(ent) and cli:IsInformant() or (cli:IsTraitorTeam() and GetGlobalBool("ttt_informant_share_scans", true)) then
+    if cli:IsInformant() or (cli:IsTraitorTeam() and GetGlobalBool("ttt_informant_share_scans", true)) then
         local state = ent:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
 
         local newRingVisible = ringVisible
@@ -106,11 +107,12 @@ end)
 
 hook.Add("TTTTargetIDPlayerText", "Informant_TTTTargetIDPlayerText", function(ent, cli, text, col, secondaryText)
     if GetRoundState() < ROUND_ACTIVE then return end
+    if not IsPlayer(ent) then return end
 
-    local _, _, override = cli:IsTargetIDOverridden(ply)
+    local _, _, override = cli:IsTargetIDOverridden(ent)
     if override then return end
 
-    if IsPlayer(ent) and cli:IsInformant() or (cli:IsTraitorTeam() and GetGlobalBool("ttt_informant_share_scans", true)) then
+    if cli:IsInformant() or (cli:IsTraitorTeam() and GetGlobalBool("ttt_informant_share_scans", true)) then
         local state = ent:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
 
         local newText = text

--- a/gamemodes/terrortown/gamemode/roles/informant/cl_informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/cl_informant.lua
@@ -124,26 +124,25 @@ hook.Add("TTTTargetIDPlayerText", "Informant_TTTTargetIDPlayerText", function(en
             local role = GetTeamRole(ent)
             newColor = ROLE_COLORS_RADAR[role]
 
-            local label_name = "target_unknown_team"
-            local label_param
-
-            local glitchMode = GetGlobalInt("ttt_glitch_mode", 0)
+            local labelName = "target_unknown_team"
+            local labelParam
 
             if TRAITOR_ROLES[role] then
+                local glitchMode = GetGlobalInt("ttt_glitch_mode", 0)
                 if glitchMode == GLITCH_SHOW_AS_TRAITOR or glitchMode == GLITCH_HIDE_SPECIAL_TRAITOR_ROLES then
-                    label_param = T("traitor")
+                    labelParam = T("traitor")
                 elseif glitchMode == GLITCH_SHOW_AS_SPECIAL_TRAITOR then
-                    label_name = "label_unconfirmed_role"
-                    label_param = ROLE_STRINGS[role]
+                    labelName = "label_unconfirmed_role"
+                    labelParam = ROLE_STRINGS[role]
                 end
-            elseif DETECTIVE_ROLES[role] then label_param = ROLE_STRINGS[ROLE_DETECTIVE]
-            elseif INNOCENT_ROLES[role] then label_param = T("innocent")
-            elseif INDEPENDENT_ROLES[role] then label_param = T("independent")
-            elseif JESTER_ROLES[role] then label_param = T("jester")
-            elseif MONSTER_ROLES[role] then label_param = T("monster") end
+            elseif DETECTIVE_ROLES[role] then labelParam = ROLE_STRINGS[ROLE_DETECTIVE]
+            elseif INNOCENT_ROLES[role] then labelParam = T("innocent")
+            elseif INDEPENDENT_ROLES[role] then labelParam = T("independent")
+            elseif JESTER_ROLES[role] then labelParam = T("jester")
+            elseif MONSTER_ROLES[role] then labelParam = T("monster") end
 
             if not (TRAITOR_ROLES[role] and not GetGlobalBool("ttt_glitch_round", false)) then
-                newText = PT(label_name, { targettype = StringUpper(label_param) })
+                newText = PT(labelName, { targettype = StringUpper(labelParam) })
             end
         elseif state >= INFORMANT_SCANNED_ROLE then
             newColor = ROLE_COLORS_RADAR[ent:GetRole()]

--- a/gamemodes/terrortown/gamemode/roles/informant/cl_informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/cl_informant.lua
@@ -28,7 +28,7 @@ end)
 ---------------
 
 local function GetTeamRole(ply)
-    local glitchMode = GetGlobalInt("ttt_glitch_mode", 0)
+    local glitchMode = GetGlobalInt("ttt_glitch_mode", GLITCH_SHOW_AS_TRAITOR)
 
     if ply:IsGlitch() then
         if glitchMode == GLITCH_SHOW_AS_TRAITOR or glitchMode == GLITCH_HIDE_SPECIAL_TRAITOR_ROLES then
@@ -128,11 +128,11 @@ hook.Add("TTTTargetIDPlayerText", "Informant_TTTTargetIDPlayerText", function(en
             local labelParam
 
             if TRAITOR_ROLES[role] then
-                local glitchMode = GetGlobalInt("ttt_glitch_mode", 0)
+                local glitchMode = GetGlobalInt("ttt_glitch_mode", GLITCH_SHOW_AS_TRAITOR)
                 if glitchMode == GLITCH_SHOW_AS_TRAITOR or glitchMode == GLITCH_HIDE_SPECIAL_TRAITOR_ROLES then
                     labelParam = T("traitor")
                 elseif glitchMode == GLITCH_SHOW_AS_SPECIAL_TRAITOR then
-                    labelName = "label_unconfirmed_role"
+                    labelName = "target_unconfirmed_role"
                     labelParam = ROLE_STRINGS[role]
                 end
             elseif DETECTIVE_ROLES[role] then labelParam = ROLE_STRINGS[ROLE_DETECTIVE]

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -65,7 +65,7 @@ end
 
 hook.Add("TTTPlayerRoleChanged", "Informant_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
     if oldRole ~= newRole then
-        if ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
+        if GetRoundState() == ROUND_ACTIVE and ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
             local share = GetGlobalBool("ttt_informant_share_scans", true)
             for _, v in pairs(GetAllPlayers()) do
                 if v:IsActiveInformant() then

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -48,16 +48,34 @@ end)
 -- ROLE CHANGES --
 ------------------
 
+local function SetDefaultScanState(ply)
+    if ply:IsDetectiveTeam() then
+        -- If the detective's role is not known, only skip the team scan
+        if GetConVar("ttt_detective_hide_special_mode"):GetInt() >= SPECIAL_DETECTIVE_HIDE_FOR_ALL then
+            ply:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_TEAM)
+        -- Otherwise skip the team and role scan
+        else
+            ply:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_ROLE)
+        end
+    -- Skip the team scanning stage for any role whose team is already known by a traitor
+    elseif ply:IsJesterTeam() or (ply:IsTraitorTeam() and not ply:IsInformant()) or ply:IsGlitch() then
+        ply:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_TEAM)
+    end
+end
+
 hook.Add("TTTPlayerRoleChanged", "Informant_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
-    if oldRole ~= newRole and ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
-        local share = GetGlobalBool("ttt_informant_share_scans", true)
-        for _, v in pairs(GetAllPlayers()) do
-            if v:IsActiveInformant() then
-                v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
-            elseif v:IsActiveTraitorTeam() and share then
-                v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. The " .. ROLE_STRINGS[ROLE_INFORMANT] .. " will need to rescan them.")
+    if oldRole ~= newRole then
+        if ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
+            local share = GetGlobalBool("ttt_informant_share_scans", true)
+            for _, v in pairs(GetAllPlayers()) do
+                if v:IsActiveInformant() then
+                    v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
+                elseif v:IsActiveTraitorTeam() and share then
+                    v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. The " .. ROLE_STRINGS[ROLE_INFORMANT] .. " will need to rescan them.")
+                end
             end
         end
-        ply:SetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
+
+        SetDefaultScanState(ply)
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/medium/cl_medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/cl_medium.lua
@@ -111,7 +111,7 @@ hook.Add("TTTTutorialRoleText", "Medium_TTTTutorialRoleText", function(role, tit
     if role == ROLE_MEDIUM then
         local roleColor = ROLE_COLORS[ROLE_INNOCENT]
         local detectiveColor = GetRoleTeamColor(ROLE_TEAM_DETECTIVE)
-        local html = "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
+        local html = "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " is a " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " and a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
 
         html = html .. "<span style='display: block; margin-top: 10px;'>Instead of getting a DNA Scanner like a vanilla <span style='color: rgb(" .. detectiveColor.r .. ", " .. detectiveColor.g .. ", " .. detectiveColor.b .. ")'>" .. ROLE_STRINGS[ROLE_DETECTIVE] .. "</span>, they have the ability to see the spirits of the dead as they move around the afterlife.</span>"
 
@@ -119,6 +119,16 @@ hook.Add("TTTTutorialRoleText", "Medium_TTTTutorialRoleText", function(role, tit
         if GetGlobalBool("ttt_medium_spirit_color", true) then
             html = html .. "<span style='display: block; margin-top: 10px;'>Each player will have a randomly assigned <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>spirit color</span> allowing the " .. ROLE_STRINGS[ROLE_MEDIUM] .. " to keep track of track specific spirits.</span>"
         end
+
+        html = html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>"
+        local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
+        if special_detective_mode > SPECIAL_DETECTIVE_HIDE_NONE then
+            html = html .. ", but not what specific type of " .. ROLE_STRINGS[ROLE_DETECTIVE]
+            if special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_ALL then
+                html = html .. ". <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Not even you know what type of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " you are</span>"
+            end
+        end
+        html = html .. ".</span>"
 
         return html
     end

--- a/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
@@ -62,7 +62,7 @@ hook.Add("TTTTutorialRoleText", "Paladin_TTTTutorialRoleText", function(role, ti
     if role == ROLE_PALADIN then
         local roleColor = ROLE_COLORS[ROLE_INNOCENT]
         local detectiveColor = GetRoleTeamColor(ROLE_TEAM_DETECTIVE)
-        local html = "The " .. ROLE_STRINGS[ROLE_PALADIN] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
+        local html = "The " .. ROLE_STRINGS[ROLE_PALADIN] .. " is a " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " and a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
 
         html = html .. "<span style='display: block; margin-top: 10px;'>Instead of getting a DNA Scanner like a vanilla <span style='color: rgb(" .. detectiveColor.r .. ", " .. detectiveColor.g .. ", " .. detectiveColor.b .. ")'>" .. ROLE_STRINGS[ROLE_DETECTIVE] .. "</span>, they have a healing and damage reduction aura.</span>"
 
@@ -81,6 +81,16 @@ hook.Add("TTTTutorialRoleText", "Paladin_TTTTutorialRoleText", function(role, ti
             html = html .. "affects them as well"
         else
             html = html .. "does NOT affect them, unfortunately"
+        end
+        html = html .. ".</span>"
+
+        html = html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>"
+        local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
+        if special_detective_mode > SPECIAL_DETECTIVE_HIDE_NONE then
+            html = html .. ", but not what specific type of " .. ROLE_STRINGS[ROLE_DETECTIVE]
+            if special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_ALL then
+                html = html .. ". <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Not even you know what type of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " you are</span>"
+            end
         end
         html = html .. ".</span>"
 

--- a/gamemodes/terrortown/gamemode/roles/sapper/cl_sapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/sapper/cl_sapper.lua
@@ -84,7 +84,7 @@ hook.Add("TTTTutorialRoleText", "Sapper_TTTTutorialRoleText", function(role, tit
     if role == ROLE_SAPPER then
         local roleColor = ROLE_COLORS[ROLE_INNOCENT]
         local detectiveColor = GetRoleTeamColor(ROLE_TEAM_DETECTIVE)
-        local html = "The " .. ROLE_STRINGS[ROLE_SAPPER] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
+        local html = "The " .. ROLE_STRINGS[ROLE_SAPPER] .. " is a " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " and a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
 
         local fire_immune = GetGlobalBool("ttt_sapper_fire_immune", false)
         local andfire = ""
@@ -109,6 +109,16 @@ hook.Add("TTTTutorialRoleText", "Sapper_TTTTutorialRoleText", function(role, tit
         if GetGlobalBool("ttt_sapper_c4_guaranteed_defuse", false) then
             html = html .. "<span style='display: block; margin-top: 10px;'>When defusing C4, the " .. ROLE_STRINGS[ROLE_SAPPER] .. " <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>will always succeeed</span>.</span>"
         end
+
+        html = html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>"
+        local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
+        if special_detective_mode > SPECIAL_DETECTIVE_HIDE_NONE then
+            html = html .. ", but not what specific type of " .. ROLE_STRINGS[ROLE_DETECTIVE]
+            if special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_ALL then
+                html = html .. ". <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Not even you know what type of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " you are</span>"
+            end
+        end
+        html = html .. ".</span>"
 
         return html
     end

--- a/gamemodes/terrortown/gamemode/roles/tracker/cl_tracker.lua
+++ b/gamemodes/terrortown/gamemode/roles/tracker/cl_tracker.lua
@@ -21,7 +21,7 @@ hook.Add("TTTTutorialRoleText", "Tracker_TTTTutorialRoleText", function(role, ti
     if role == ROLE_TRACKER then
         local roleColor = ROLE_COLORS[ROLE_INNOCENT]
         local detectiveColor = GetRoleTeamColor(ROLE_TEAM_DETECTIVE)
-        local html = "The " .. ROLE_STRINGS[ROLE_TRACKER] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
+        local html = "The " .. ROLE_STRINGS[ROLE_TRACKER] .. " is a " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " and a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> whose job is to find and eliminate their enemies."
 
         -- Footsteps
         local footstepTime = GetGlobalInt("ttt_tracker_footstep_time", 15)
@@ -32,6 +32,16 @@ hook.Add("TTTTutorialRoleText", "Tracker_TTTTutorialRoleText", function(role, ti
                 html = html .. "<span style='display: block; margin-top: 10px;'>Each player will have a randomly assigned <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>footstep color</span> allowing the " .. ROLE_STRINGS[ROLE_TRACKER] .. " to follow specific players.</span>"
             end
         end
+
+        html = html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>"
+        local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
+        if special_detective_mode > SPECIAL_DETECTIVE_HIDE_NONE then
+            html = html .. ", but not what specific type of " .. ROLE_STRINGS[ROLE_DETECTIVE]
+            if special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_ALL then
+                html = html .. ". <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Not even you know what type of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " you are</span>"
+            end
+        end
+        html = html .. ".</span>"
 
         return html
     end

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -140,7 +140,7 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
     end
 
     if ply:GetDetectiveLike() then
-        return ply:GetDisplayedRole()
+        return ROLE_DETECTIVE
     elseif ply:IsClown() and ply:IsRoleActive() then
         return ROLE_CLOWN
     end
@@ -232,6 +232,9 @@ function PANEL:Paint(width, height)
         if ply:IsDetectiveLike() then
             if ply:IsDetectiveTeam() then
                 role = ply:GetDisplayedRole()
+                if role == ROLE_NONE then
+                    color = ROLE_COLORS_SCOREBOARD[ROLE_DETECTIVE]
+                end
             elseif client:IsTraitorTeam() and ply:IsImpersonator() then
                 if GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
                     role = ROLE_DETECTIVE

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -140,7 +140,7 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
     end
 
     if ply:GetDetectiveLike() then
-        return ROLE_DETECTIVE
+        return ply:GetDisplayedRole()
     elseif ply:IsClown() and ply:IsRoleActive() then
         return ROLE_CLOWN
     end
@@ -232,9 +232,6 @@ function PANEL:Paint(width, height)
         if ply:IsDetectiveLike() then
             if ply:IsDetectiveTeam() then
                 role = ply:GetDisplayedRole()
-                if role == ROLE_NONE then
-                    color = ROLE_COLORS_SCOREBOARD[ROLE_DETECTIVE]
-                end
             elseif client:IsTraitorTeam() and ply:IsImpersonator() then
                 if GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
                     role = ROLE_DETECTIVE

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -231,7 +231,14 @@ function PANEL:Paint(width, height)
         -- Swap the deputy/impersonator icons depending on which settings are enabled
         if ply:IsDetectiveLike() then
             if ply:IsDetectiveTeam() then
-                role = ply:GetDisplayedRole()
+                local disp_role, changed = ply:GetDisplayedRole()
+                -- If the displayed role was changed, use it for the color but use the question mark for the icon
+                if changed then
+                    color = ROLE_COLORS_SCOREBOARD[ROLE_DETECTIVE]
+                    role = ROLE_NONE
+                else
+                    role = disp_role
+                end
             elseif client:IsTraitorTeam() and ply:IsImpersonator() then
                 if GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
                     role = ROLE_DETECTIVE


### PR DESCRIPTION
**Informant Changes**
- Fixed TargetID ring and text override checks
- Fixed wrong translation name for special traitor glitch
- Moved informant scanner view model out of the way of the crosshair
- Changed pre-determined scan state logic to happen when a round starts or a role changes rather than on first scan
- Changed default scan time to be higher

**Changes**
- Changed detective team to show question mark icons over their head and on the scoreboard instead of the detective icon if roles are hidden
- Changed hidden detective HUD text to make it clear that the role is unknown but others still know its a detective
- Updated detective tutorials to explain role hiding logic