### PR TITLE
Hide promoted message if role is hidden.

### DIFF
--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -979,6 +979,13 @@ function HELPSCRN:CreateTutorial(parent)
     end
 
     brole.DoClick = function()
+        local hide_role = false
+        if ConVarExists("ttt_hide_role") then
+            hide_role = GetConVar("ttt_hide_role"):GetBool()
+        end
+
+        if hide_role then return end
+
         local client = LocalPlayer()
         local role = client:GetDisplayedRole()
         if not IsValid(client) or role <= ROLE_NONE or role > ROLE_MAX then return end

--- a/gamemodes/terrortown/gamemode/roles/beggar/cl_beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/cl_beggar.lua
@@ -106,6 +106,13 @@ end)
 ---------
 
 hook.Add("TTTHUDInfoPaint", "Beggar_TTTHUDInfoPaint", function(client, label_left, label_top)
+    local hide_role = false
+    if ConVarExists("ttt_hide_role") then
+        hide_role = GetConVar("ttt_hide_role"):GetBool()
+    end
+
+    if hide_role then return end
+
     if (client:IsInnocent() or client:IsTraitor()) and client:GetNWBool("WasBeggar", false) then
         local beggarMode = BEGGAR_REVEAL_ALL
         if client:IsInnocent() then beggarMode = GetGlobalInt("ttt_beggar_reveal_innocent", BEGGAR_REVEAL_TRAITORS)

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/cl_bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/cl_bodysnatcher.lua
@@ -106,6 +106,13 @@ end)
 ---------
 
 hook.Add("TTTHUDInfoPaint", "Bodysnatcher_TTTHUDInfoPaint", function(client, label_left, label_top)
+    local hide_role = false
+    if ConVarExists("ttt_hide_role") then
+        hide_role = GetConVar("ttt_hide_role"):GetBool()
+    end
+
+    if hide_role then return end
+
     if client:GetNWBool("WasBodysnatcher", false) then
         local bodysnatcherMode = BODYSNATCHER_REVEAL_ALL
         if client:IsInnocentTeam() then bodysnatcherMode = GetGlobalInt("ttt_bodysnatcher_reveal_innocent", BODYSNATCHER_REVEAL_ALL)

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
@@ -65,7 +65,7 @@ hook.Add("TTTHUDInfoPaint", "DetectiveLike_TTTHUDInfoPaint", function(client, la
             hide_role = GetConVar("ttt_hide_role"):GetBool()
         end
             
-        if hide_role == true then return end
+        if hide_role then return end
             
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
@@ -60,6 +60,13 @@ hook.Add("TTTHUDInfoPaint", "DetectiveLike_TTTHUDInfoPaint", function(client, la
             label_top = label_top + 20
         end
     elseif client:IsDetectiveLike() then
+        local hide_role = false
+        if ConVarExists("ttt_hide_role") then
+            hide_role = GetConVar("ttt_hide_role"):GetBool()
+        end
+            
+        if hide_role == true then return end
+            
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)
 

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
@@ -45,6 +45,13 @@ end)
 ---------
 
 hook.Add("TTTHUDInfoPaint", "DetectiveLike_TTTHUDInfoPaint", function(client, label_left, label_top)
+    local hide_role = false
+    if ConVarExists("ttt_hide_role") then
+        hide_role = GetConVar("ttt_hide_role"):GetBool()
+    end
+
+    if hide_role then return end
+
     if client:IsDetectiveTeam() then
         if GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE) == SPECIAL_DETECTIVE_HIDE_FOR_OTHERS then
             surface.SetFont("TabLarge")
@@ -60,13 +67,6 @@ hook.Add("TTTHUDInfoPaint", "DetectiveLike_TTTHUDInfoPaint", function(client, la
             label_top = label_top + 20
         end
     elseif client:IsDetectiveLike() then
-        local hide_role = false
-        if ConVarExists("ttt_hide_role") then
-            hide_role = GetConVar("ttt_hide_role"):GetBool()
-        end
-            
-        if hide_role then return end
-            
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)
 

--- a/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/cl_drunk.lua
@@ -74,6 +74,13 @@ end)
 ---------
 
 hook.Add("TTTHUDInfoPaint", "Drunk_TTTHUDInfoPaint", function(client, label_left, label_top)
+    local hide_role = false
+    if ConVarExists("ttt_hide_role") then
+        hide_role = GetConVar("ttt_hide_role"):GetBool()
+    end
+
+    if hide_role then return end
+
     if client:IsDrunk() then
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -128,6 +128,13 @@ end)
 ---------
 
 hook.Add("TTTHUDInfoPaint", "LootGoblin_TTTHUDInfoPaint", function(client, label_left, label_top)
+    local hide_role = false
+    if ConVarExists("ttt_hide_role") then
+        hide_role = GetConVar("ttt_hide_role"):GetBool()
+    end
+
+    if hide_role then return end
+
     if client:IsActiveLootGoblin() and not client:IsRoleActive() then
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)


### PR DESCRIPTION
Hides the label above the role box when role is hidden from `ttt_hide_role`
![image](https://user-images.githubusercontent.com/35779365/170898450-51e2c6fa-735e-4c14-8dd9-f58481f4f763.png)
-----
Just to be sure, is there anywhere else a message similar to this is shown so I can also modify it in this commit?
