### PR TITLE
Misc. changes

### DIFF
--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -38,6 +38,14 @@ Methods available when called from a Player object (within the defined realm)
 *Parameters:*
 - *role* - Which role to set the drunk to (see ROLE_* global enumeration)
 
+**plymeta:GetAvoidDetective()/plymeta:ShouldAvoidDetective() (Added in 1.6.2)** - Whether this player wants to avoid being a detective role.\
+*Realm:* Server\
+*Added in:* 1.0.0
+
+**plymeta:GetBypassCulling()/plymeta:ShouldBypassCulling()** - Whether this player wants to bypass map optimizations like vis leafs and culling for things like role head icons and highlighting.\
+*Realm:* Server\
+*Added in:* 1.6.2
+
 **plymeta:GetDisplayedRole()** - Gets the role that should be displayed for the player.\
 *Realm:* Client and Server\
 *Added in:* 1.5.3
@@ -135,6 +143,13 @@ Methods available when called from a Player object (within the defined realm)
 **plymeta:IsMonsterTeam()** - Whether the player is on the monster team.\
 *Realm:* Client and Server\
 *Added in:* 1.0.0
+
+**plymeta:IsOnScreen(ent_or_pos, limit)** - Whether the entity or position given is on screen for the player, within the given value limit.\
+*Realm:* Client and Server\
+*Added in:* 1.6.2\
+*Parameters:*
+- *ent_or_pos* - The entity or position vector that is being checked
+- *limit* - The maximum value limit before a player is determined to be "off screen" (Defaults to 1)
 
 **plymeta:IsRoleActive()** - Whether the player's role feature has been activated.\
 *Realm:* Client and Server\

--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -232,6 +232,12 @@ Methods available when called from a Player object (within the defined realm)
 *Realm:* Server\
 *Added in:* 1.5.12
 
+**plymeta:SetDefaultCredits(keep_existing)** - Sets the credits on the player based on their role's starting credits convars.\
+*Realm:* Server\
+*Added in:* 1.0.0\
+*Parameters:*
+- *keep_existing* - Whether to keep the player's existing credits (Defaults to `false`) *(Added in 1.6.2)*
+
 **plymeta:SetRoleAndBroadcast(role)** - Sets the player's role to the given one and (if called on the server) broadcasts the change to all clients for scoreboard tracking.\
 *Realm:* Client and Server\
 *Added in:* 1.0.0\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - Fixed scoreboard showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
 - Fixed scoreboard showing the detective color and icon for a promoted impersonator when `ttt_impersonator_use_detective_icon` was `0`
 - Fixed overhead role icon showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
+- Fixed chance of two impersonators spawning when `ttt_impersonator_detective_chance` is used
 
 ### Changes
 - Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 - Fixed scoreboard showing the detective color and icon for a promoted impersonator when `ttt_impersonator_use_detective_icon` was `0`
 - Fixed overhead role icon showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
 - Fixed chance of two impersonators spawning when `ttt_impersonator_detective_chance` is used
+- Fixed impersonator not getting activation credits when they are immediately promoted because `ttt_impersonator_detective_chance` is used
 
 ### Changes
 - Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)
@@ -17,6 +18,7 @@
 - Added `plymeta:ShouldAvoidDetective` as an alias for `plymeta:GetAvoidDetective`
 - Added `plymeta:GetBypassCulling`/`plymeta:ShouldBypassCulling` as a way to get a player's `ttt_bypass_culling` setting value
 - Added `plymeta:IsOnScreen` to determine if an entity or position is on screen within a value limit
+- Added optional `keep_existing` parameter to `plymeta:SetDefaultCredits`
 
 ## 1.6.1 (Beta)
 **Released: June 18th, 2022**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,11 @@
 ## 1.6.2 (Beta)
 **Released:**
 
+### Fixes
+- Fixed scoreboard showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
+- Fixed scoreboard showing the detective color and icon for a promoted impersonator when `ttt_impersonator_use_detective_icon` was `0`
+- Fixed overhead role icon showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
+
 ### Changes
 - Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)
   - This is controlled by a new client-side convar, `ttt_bypass_culling`, which is enabled by default

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ### Developer
 - Added `plymeta:ShouldAvoidDetective` as an alias for `plymeta:GetAvoidDetective`
 - Added `plymeta:GetBypassCulling`/`plymeta:ShouldBypassCulling` as a way to get a player's `ttt_bypass_culling` setting value
+- Added `plymeta:IsOnScreen` to determine if an entity or position is on screen within a value limit
 
 ### Fixes
 - Fixed monster role count logic not working for external monster roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,18 @@
 # Release Notes
 
+## 1.6.2 (Beta)
+**Released:**
+
 ## 1.6.1 (Beta)
 **Released: June 18th, 2022**
+
+### Changes
+- Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)
+  - This is controlled by a new client-side convar, `ttt_bypass_culling`, which is enabled by default
+
+### Developer
+- Added `plymeta:ShouldAvoidDetective` as an alias for `plymeta:GetAvoidDetective`
+- Added `plymeta:GetBypassCulling`/`plymeta:ShouldBypassCulling` as a way to get a player's `ttt_bypass_culling` setting value
 
 ### Fixes
 - Fixed monster role count logic not working for external monster roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,9 +3,6 @@
 ## 1.6.2 (Beta)
 **Released:**
 
-## 1.6.1 (Beta)
-**Released: June 18th, 2022**
-
 ### Changes
 - Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)
   - This is controlled by a new client-side convar, `ttt_bypass_culling`, which is enabled by default
@@ -14,6 +11,9 @@
 - Added `plymeta:ShouldAvoidDetective` as an alias for `plymeta:GetAvoidDetective`
 - Added `plymeta:GetBypassCulling`/`plymeta:ShouldBypassCulling` as a way to get a player's `ttt_bypass_culling` setting value
 - Added `plymeta:IsOnScreen` to determine if an entity or position is on screen within a value limit
+
+## 1.6.1 (Beta)
+**Released: June 18th, 2022**
 
 ### Fixes
 - Fixed monster role count logic not working for external monster roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 1.6.2 (Beta)
-**Released:**
+**Released: June 26th, 2022**
 
 ### Fixes
 - Fixed scoreboard showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
@@ -12,7 +12,7 @@
 
 ### Changes
 - Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)
-  - This is controlled by a new client-side convar, `ttt_bypass_culling`, which is enabled by default
+  - This is controlled by a new client-side convar, `ttt_bypass_culling`, which is enabled by default and available in the F1 settings menu
 
 ### Developer
 - Added `plymeta:ShouldAvoidDetective` as an alias for `plymeta:GetAvoidDetective`

--- a/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
@@ -143,12 +143,7 @@ if SERVER then
         local targetPos = target:GetPos()
         if ownerPos:Distance(targetPos) > GetConVar("ttt_informant_scanner_distance"):GetInt() then return false end
 
-        local dir = targetPos - ownerPos
-        dir:Normalize()
-        local eye = self:GetOwner():EyeAngles():Forward()
-        if math.acos(dir:Dot(eye)) > 0.35 then return false end
-
-        return true
+        return self:GetOwner():IsOnScreen(target, 0.35)
     end
 
     function SWEP:ScanAllowed(target)

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -67,6 +67,8 @@ CreateClientConVar("ttt_avoid_detective", "0", true, true)
 CreateClientConVar("ttt_hide_role", "0", true, false)
 CreateClientConVar("ttt_hide_ammo", "0", true, false)
 
+CreateClientConVar("ttt_bypass_culling", "1", true, true, "Whether to bypass vis leafs and culling in maps for player icons and highlighting", 0, 1)
+
 HELPSCRN = {}
 
 local dframe
@@ -178,6 +180,9 @@ function HELPSCRN:Show()
 
     cb = dgui:TextEntry(GetTranslation("set_radio_button"), "ttt_radio_button")
     cb:SetTooltip(GetTranslation("set_radio_button_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_bypass_culling"), "ttt_bypass_culling")
+    cb:SetTooltip(GetTranslation("set_bypass_culling_tip"))
 
     dsettings:AddItem(dgui)
 

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -167,12 +167,12 @@ function GM:PostDrawTranslucentRenderables()
                             color_role = ROLE_JESTER
                             noz = false
                         elseif v:IsTraitorTeam() then
+                            if glitchRound then
+                                role, color_role = GetGlitchedRole(v, glitchMode)
                             -- If the impersonator is promoted, use the Detective's icon with the Impersonator's color
-                            if v:IsImpersonator() and v:IsRoleActive() then
+                            elseif v:IsImpersonator() and v:IsRoleActive() then
                                 role = GetDetectiveIconRole(true)
                                 color_role = ROLE_IMPERSONATOR
-                            elseif glitchRound then
-                                role, color_role = GetGlitchedRole(v, glitchMode)
                             else
                                 role = v:GetRole()
                             end

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1561,7 +1561,7 @@ function SelectRoles()
         local tertiary_options = {}
         for _, p in ipairs(choices) do
             if not KARMA.IsEnabled() or p:GetBaseKarma() >= min_karma then
-                if not p:GetAvoidDetective() then
+                if not p:ShouldAvoidDetective() then
                     table.insert(options, p)
                 end
                 table.insert(secondary_options, p)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1644,6 +1644,9 @@ function SelectRoles()
             traitors_copy = table.Copy(traitors)
             choices_copy = table.Copy(choices)
 
+            -- Remove the option so we don't have 2 impersonators
+            table.RemoveByValue(specialTraitorRoles, ROLE_IMPERSONATOR)
+
             -- Only allow one to be an impersonator
             has_impersonator = false
         else

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1816,7 +1816,8 @@ function SelectRoles()
                 ply:SetRole(ROLE_INNOCENT)
             end
 
-            ply:SetDefaultCredits()
+            -- Keep existing credits so pre-promoted roles have their bonuses
+            ply:SetDefaultCredits(true)
         end
 
         -- store a steamid -> role map

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -275,6 +275,8 @@ L.set_hide_ammo = "Hide your weapon ammo in the HUD"
 L.set_hide_ammo_tip = "By default your weapon ammo will appear in the bottom left of the HUD. Turn this on if you have another addon that does that for you."
 L.set_radio_button = "Radio menu button"
 L.set_radio_button_tip = "What button to press to open/close the radio menu"
+L.set_bypass_culling = "Bypass map culling"
+L.set_bypass_culling_tip = "Whether to bypass vis leafs and culling in maps for player icons and highlighting. Disable for performance if you don't care about icons and highlighting lagging behind players sometimes."
 
 L.set_title_play = "Gameplay settings"
 

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -479,6 +479,12 @@ end
 function plymeta:GetAvoidDetective()
     return self:GetInfoNum("ttt_avoid_detective", 0) > 0
 end
+plymeta.ShouldAvoidDetective = plymeta.GetAvoidDetective
+
+function plymeta:GetBypassCulling()
+    return self:GetInfoNum("ttt_bypass_culling", 1) > 0
+end
+plymeta.ShouldBypassCulling = plymeta.GetBypassCulling
 
 function plymeta:Ignite(dur, radius)
     -- Keep track of extended ignition information so when multiple things are causing burning the later ones don't lose their data. See PlayerTakeDamage in player.lua

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -72,7 +72,7 @@ function plymeta:AddCredits(amt)
 end
 function plymeta:SubtractCredits(amt) self:AddCredits(-amt) end
 
-function plymeta:SetDefaultCredits()
+function plymeta:SetDefaultCredits(keep_existing)
     if self:IsSpec() or self:GetRole() == ROLE_NONE then return end
 
     local c = 0
@@ -94,7 +94,11 @@ function plymeta:SetDefaultCredits()
         end
     end
 
-    self:SetCredits(c)
+    if not keep_existing then
+        self:SetCredits(c)
+    else
+        self:AddCredits(c)
+    end
 end
 
 function plymeta:SendCredits()

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -15,6 +15,7 @@ local util = util
 local CallHook = hook.Call
 local GetAllPlayers = player.GetAll
 local MathAbs = math.abs
+local MathAcos = math.acos
 
 function plymeta:IsTerror() return self:Team() == TEAM_TERROR end
 function plymeta:IsSpec() return self:Team() == TEAM_SPEC end
@@ -322,6 +323,19 @@ function plymeta:GetEyeTrace(mask)
     self.PlayerTrace = tr
 
     return tr
+end
+
+function plymeta:IsOnScreen(ent_or_pos, limit)
+    local ent_pos = ent_or_pos
+    if type(ent_pos) ~= "Vector" then
+        ent_pos = ent_pos:GetPos()
+    end
+    if not limit then limit = 1 end
+
+    local dir = ent_pos - self:GetPos()
+    dir:Normalize()
+    local eye = self:EyeAngles():Forward()
+    return MathAcos(dir:Dot(eye)) <= limit
 end
 
 if CLIENT then

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -268,3 +268,28 @@ hook.Add("ScalePlayerDamage", "Assassin_ScalePlayerDamage", function(ply, hitgro
         end
     end
 end)
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add the target player to the PVS for the assassin if highlighting or Kill icon are enabled
+hook.Add("SetupPlayerVisibility", "Assassin_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveAssassin() then return end
+    if not assassin_target_vision_enable:GetBool() and not assassin_show_target_icon:GetBool() then return end
+
+    local target_nick = ply:GetNWString("AssassinTarget", "")
+    for _, v in ipairs(GetAllPlayers()) do
+        if v:Nick() ~= target_nick then continue end
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+
+        -- Assassins can only have one target so if we found them don't bother looping anymore
+        break
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/independents/independents.lua
+++ b/gamemodes/terrortown/gamemode/roles/independents/independents.lua
@@ -1,0 +1,28 @@
+AddCSLuaFile()
+
+local hook = hook
+local ipairs = ipairs
+local player = player
+
+local GetAllPlayers = player.GetAll
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add all independents to the PVS for other independents since they can see eachother
+-- This sounds counter-intuitive but roles like Zombies and Vampires can duplicate when they are on the Independent team so they aren't really alone
+hook.Add("SetupPlayerVisibility", "Independents_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveIndependentTeam() then return end
+
+    for _, v in ipairs(GetAllPlayers()) do
+        if not v:IsActiveIndependentTeam() then continue end
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -353,3 +353,23 @@ hook.Add("TTTPrintResultMessage", "Killer_TTTPrintResultMessage", function(type)
         ServerLog("Result: " .. ROLE_STRINGS[ROLE_KILLER] .. " wins.\n")
     end
 end)
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add all players to the PVS for the killer if highlighting or Kill icon are enabled
+hook.Add("SetupPlayerVisibility", "Killer_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveKiller() then return end
+    if not killer_vision_enable:GetBool() and not killer_show_target_icon:GetBool() then return end
+
+    for _, v in ipairs(GetAllPlayers()) do
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/monsters/monsters.lua
+++ b/gamemodes/terrortown/gamemode/roles/monsters/monsters.lua
@@ -1,0 +1,27 @@
+AddCSLuaFile()
+
+local hook = hook
+local ipairs = ipairs
+local player = player
+
+local GetAllPlayers = player.GetAll
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add all monsters to the PVS for other monsters since they can see eachother
+hook.Add("SetupPlayerVisibility", "Monsters_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveMonsterTeam() then return end
+
+    for _, v in ipairs(GetAllPlayers()) do
+        if not v:IsActiveMonsterTeam() then continue end
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/traitor/traitor.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/traitor.lua
@@ -2,6 +2,8 @@ AddCSLuaFile()
 
 local hook = hook
 
+local GetAllPlayers = player.GetAll
+
 -------------
 -- CONVARS --
 -------------
@@ -10,4 +12,24 @@ local traitor_phantom_cure = CreateConVar("ttt_traitor_phantom_cure", "0")
 
 hook.Add("TTTSyncGlobals", "Traitor_TTTSyncGlobals", function()
     SetGlobalBool("ttt_traitor_phantom_cure", traitor_phantom_cure:GetBool())
+end)
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add all traitors to the PVS for all players they can see via Target ID with NoZ (Traitors, Glitch)
+hook.Add("SetupPlayerVisibility", "Traitors_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveTraitorTeam() then return end
+
+    for _, v in ipairs(GetAllPlayers()) do
+        if not v:IsActiveTraitorTeam() and not v:IsActiveGlitch() then continue end
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+    end
 end)

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -298,3 +298,27 @@ hook.Add("PlayerCanPickupWeapon", "Vampire_Weapons_PlayerCanPickupWeapon", funct
         return ply:IsVampire()
     end
 end)
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add all players to the PVS for the vampire if highlighting or Kill icon are enabled
+hook.Add("SetupPlayerVisibility", "Vampire_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveVampire() then return end
+    if not vampire_vision_enable:GetBool() and not vampire_show_target_icon:GetBool() then return end
+
+    -- Only use this when the vampire would see the highlighting and icons (when they have their fangs out)
+    local hasFangs = ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_vam_fangs"
+    if not hasFangs then return end
+
+    for _, v in ipairs(GetAllPlayers()) do
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -165,7 +165,7 @@ end)
 -- ROLE WEAPONS --
 ------------------
 
--- Make sure the vampire keeps their appropriate weapons
+-- Make sure the zombie keeps their appropriate weapons and coloring
 hook.Add("TTTPlayerAliveThink", "Zombie_TTTPlayerAliveThink", function(ply)
     if not IsValid(ply) or ply:IsSpec() or GetRoundState() ~= ROUND_ACTIVE then return end
 
@@ -259,3 +259,27 @@ function plymeta:RespawnAsZombie()
         SendFullStateUpdate()
     end)
 end
+
+-----------------------
+-- PLAYER VISIBILITY --
+-----------------------
+
+-- Add all players to the PVS for the zombie if highlighting or Kill icon are enabled
+hook.Add("SetupPlayerVisibility", "Zombie_SetupPlayerVisibility", function(ply)
+    if not ply:ShouldBypassCulling() then return end
+    if not ply:IsActiveZombie() then return end
+    if not zombie_vision_enable:GetBool() and not zombie_show_target_icon:GetBool() then return end
+
+    -- Only use this when the zombie would see the highlighting and icons (when they have their claws out)
+    local hasFangs = ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_zom_claws"
+    if not hasFangs then return end
+
+    for _, v in ipairs(GetAllPlayers()) do
+        if ply:TestPVS(v) then continue end
+
+        local pos = v:GetPos()
+        if ply:IsOnScreen(pos) then
+            AddOriginToPVS(pos)
+        end
+    end
+end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -17,7 +17,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.6.1"
+CR_VERSION = "1.6.2"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -239,8 +239,21 @@ function PANEL:Paint(width, height)
         local role = c
         local color = nil
 
+        if client:IsTraitorTeam() then
+            if GetGlobalBool("ttt_glitch_round", false) and (ply:IsTraitorTeam() or (ply:IsGlitch() and not GetGlobalBool("ttt_zombie_round", false))) and client ~= ply then
+                local glitch_role, color_role = GetGlitchedRole(ply, GetGlobalInt("ttt_glitch_mode", GLITCH_SHOW_AS_TRAITOR))
+                role = glitch_role
+                if color_role then
+                    color = ROLE_COLORS_SCOREBOARD[color_role]
+                end
+            elseif ply:IsImpersonator() then
+                if GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
+                    role = ROLE_DETECTIVE
+                end
+                color = ROLE_COLORS_SCOREBOARD[ROLE_IMPERSONATOR]
+            end
         -- Swap the deputy/impersonator icons depending on which settings are enabled
-        if ply:IsDetectiveLike() then
+        elseif ply:IsDetectiveLike() then
             if ply:IsDetectiveTeam() then
                 local disp_role, changed = ply:GetDisplayedRole()
                 -- If the displayed role was changed, use it for the color but use the question mark for the icon
@@ -254,19 +267,6 @@ function PANEL:Paint(width, height)
                 role = ROLE_DETECTIVE
             else
                 role = ROLE_DEPUTY
-            end
-        elseif client:IsTraitorTeam() then
-            if ply:IsImpersonator() then
-                if GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
-                    role = ROLE_DETECTIVE
-                end
-                color = ROLE_COLORS_SCOREBOARD[ROLE_IMPERSONATOR]
-            elseif GetGlobalBool("ttt_glitch_round", false) and (ply:IsTraitorTeam() or (ply:IsGlitch() and not GetGlobalBool("ttt_zombie_round", false))) and client ~= ply then
-                local glitch_role, color_role = GetGlitchedRole(ply, GetGlobalInt("ttt_glitch_mode", GLITCH_SHOW_AS_TRAITOR))
-                role = glitch_role
-                if color_role then
-                    color = ROLE_COLORS_SCOREBOARD[color_role]
-                end
             end
         end
 


### PR DESCRIPTION
**Fixes**
- Fixed scoreboard showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
- Fixed scoreboard showing the detective color and icon for a promoted impersonator when `ttt_impersonator_use_detective_icon` was `0`
- Fixed overhead role icon showing the impersonator color and icon when there was a glitch and `ttt_glitch_mode` was `2`
- Fixed chance of two impersonators spawning when `ttt_impersonator_detective_chance` is used
- Fixed impersonator not getting activation credits when they are immediately promoted because `ttt_impersonator_detective_chance` is used

**Changes**
- Changed player role icons (over their heads) and highlighting to ignore map optimizations which prevented them from updating regularly (Thanks to wget for the logic help!)
  - This is controlled by a new client-side convar, `ttt_bypass_culling`, which is enabled by default

**Developer**
- Added `plymeta:ShouldAvoidDetective` as an alias for `plymeta:GetAvoidDetective`
- Added `plymeta:GetBypassCulling`/`plymeta:ShouldBypassCulling` as a way to get a player's `ttt_bypass_culling` setting value
- Added `plymeta:IsOnScreen` to determine if an entity or position is on screen within a value limit
- Added optional `keep_existing` parameter to `plymeta:SetDefaultCredits`