### PR TITLE
Optimise scoreboard

### DIFF
--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -633,6 +633,12 @@ ROLE_STRINGS_SHORT = {
     [ROLE_INFORMANT] = "inf"
 }
 
+ROLE_MATERIAL_ICONS = {}
+for k, v in pairs(ROLE_STRINGS_SHORT) do
+    local filepath = string.format("materials/vgui/ttt/roles/%s/tab_%s.png", v, v)
+    ROLE_MATERIAL_ICONS[k] = Material(file.Exists(filepath, "GAME") and filepath or string.format("vgui/ttt/tab_%s.png", v))
+end
+
 function StartsWithVowel(word)
     local firstletter = StringSub(word, 1, 1)
     return firstletter == "a" or

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -235,8 +235,8 @@ function PANEL:Paint(width, height)
 
     local client = LocalPlayer()
     local roleStr = ""
+    local role = c
     if c ~= defaultcolor then
-        local role = c
         local color = nil
 
         if client:IsTraitorTeam() then
@@ -287,12 +287,8 @@ function PANEL:Paint(width, height)
     surface.SetDrawColor(c)
     surface.DrawRect(0, 0, width, SB_ROW_HEIGHT)
 
-    if roleStr ~= "" then
-        if file.Exists("materials/vgui/ttt/roles/" .. roleStr .. "/tab_" .. roleStr .. ".png", "GAME") then
-            self.sresult:SetImage("vgui/ttt/roles/" .. roleStr .. "/tab_" .. roleStr .. ".png")
-        else
-            self.sresult:SetImage("vgui/ttt/tab_" .. roleStr .. ".png")
-        end
+    if ROLE_MATERIAL_ICONS and ROLE_MATERIAL_ICONS[role] then
+        self.sresult:SetMaterial(ROLE_MATERIAL_ICONS[role])
         self.sresult:SetVisible(true)
     else
         self.sresult:SetVisible(false)


### PR DESCRIPTION
Cache role icon materials in ROLE_MATERIAL_ICONS to prevent Material calls in Paint hooks in the scoreboard (very unoptimised)