### PR TITLE
Misc. fixes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -311,6 +311,7 @@ ttt_trickster_credits_starting              0       // The number of credits a t
 // Turncoat
 ttt_turncoat_change_health                  10      // The amount of health to set the turncoat to when they change teams
 ttt_turncoat_change_max_health              1       // Whether to change the turncoat's max health when they change teams
+ttt_turncoat_change_innocent_kill           0       // Whether to change the turncoat's team when they kill a member of the innocent team
 
 // ----------------------------------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.6.6 (Beta)
 **Released:**
 
+### Additions
+- Added option to have turncoat automatically change teams when they kill a innocent team member (disabled by default)
+
 ### Fixes
 - Fixed traitors seeing the deputy role icon on the scoreboard for promoted deputies instead of the detective icon
 - Fixed traitors seeing the detective role icon on the scoreboard for impersonators who haven't been promoted yet when `ttt_impersonator_use_detective_icon` is enabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - Fixed error rendering the weapon switch and HUD with certain workshop weapons
 - Fixed traitors not being awarded credits if `ttt_credits_award_repeat` is disabled and something caused the first credit award amount to be 0
 - Fixed error switching tabs in the equipment window if shop tab wasn't displaying any items (Thanks @Callum!)
+- Fixed beggar sometimes being shown duplicate team join notifications depending on the `ttt_beggar_reveal_*` convars
 
 ### Changes
 - Changed turncoat's announcement message to say explicitly that they joined the traitors

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - Fixed traitors seeing the deputy role icon on the scoreboard for promoted deputies instead of the detective icon
 - Fixed traitors seeing the detective role icon on the scoreboard for impersonators who haven't been promoted yet when `ttt_impersonator_use_detective_icon` is enabled
 - Fixed error rendering the weapon switch and HUD with certain workshop weapons
+- Fixed traitors not being awarded credits if `ttt_credits_award_repeat` is disabled and something caused the first credit award amount to be 0
 
 ### Changes
 - Changed turncoat's announcement message to say explicitly that they joined the traitors

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.6.6 (Beta)
+**Released:**
+
+### Changes
+- Changed turncoat's announcement message to say explicitly that they joined the traitors
+
 ## 1.6.5 (Beta)
 **Released: July 16th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 1.6.6 (Beta)
-**Released:**
+**Released: July 24th, 2022**
 
 ### Additions
 - Added option to have turncoat automatically change teams when they kill a innocent team member (disabled by default)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 - Fixed traitors seeing the detective role icon on the scoreboard for impersonators who haven't been promoted yet when `ttt_impersonator_use_detective_icon` is enabled
 - Fixed error rendering the weapon switch and HUD with certain workshop weapons
 - Fixed traitors not being awarded credits if `ttt_credits_award_repeat` is disabled and something caused the first credit award amount to be 0
+- Fixed error switching tabs in the equipment window if shop tab wasn't displaying any items (Thanks @Callum!)
 
 ### Changes
 - Changed turncoat's announcement message to say explicitly that they joined the traitors

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Fixes
 - Fixed traitors seeing the deputy role icon on the scoreboard for promoted deputies instead of the detective icon
 - Fixed traitors seeing the detective role icon on the scoreboard for impersonators who haven't been promoted yet when `ttt_impersonator_use_detective_icon` is enabled
+- Fixed error rendering the weapon switch and HUD with certain workshop weapons
 
 ### Changes
 - Changed turncoat's announcement message to say explicitly that they joined the traitors

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 
 ### Changes
 - Changed turncoat's announcement message to say explicitly that they joined the traitors
+- Changed so killing the old man does not award credits to anyone
 
 ## 1.6.5 (Beta)
 **Released: July 16th, 2022**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,10 @@
 ## 1.6.6 (Beta)
 **Released:**
 
+### Fixes
+- Fixed traitors seeing the deputy role icon on the scoreboard for promoted deputies instead of the detective icon
+- Fixed traitors seeing the detective role icon on the scoreboard for impersonators who haven't been promoted yet when `ttt_impersonator_use_detective_icon` is enabled
+
 ### Changes
 - Changed turncoat's announcement message to say explicitly that they joined the traitors
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tur_changer.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tur_changer.lua
@@ -64,8 +64,8 @@ function SWEP:PrimaryAttack()
 
             -- Announce the role change
             for _, ply in ipairs(GetAllPlayers()) do
-                ply:PrintMessage(HUD_PRINTTALK, owner:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has changed teams!")
-                ply:PrintMessage(HUD_PRINTCENTER, owner:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has changed teams!")
+                ply:PrintMessage(HUD_PRINTTALK, owner:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has joined the " .. ROLE_STRINGS_PLURAL[ROLE_TRAITOR] .. "!")
+                ply:PrintMessage(HUD_PRINTCENTER, owner:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has joined the " .. ROLE_STRINGS_PLURAL[ROLE_TRAITOR] .. "!")
             end
 
             -- Change health

--- a/gamemodes/terrortown/entities/weapons/weapon_tur_changer.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tur_changer.lua
@@ -31,8 +31,6 @@ SWEP.Primary.Cone           = 0
 SWEP.Primary.Ammo           = nil
 SWEP.Primary.Sound          = ""
 
-local GetAllPlayers = player.GetAll
-
 function SWEP:Initialize()
     self:SendWeaponAnim(ACT_SLAM_DETONATOR_DRAW)
 
@@ -59,23 +57,7 @@ function SWEP:PrimaryAttack()
     if SERVER then
         local owner = self:GetOwner()
         if IsPlayer(owner) then
-            -- Change team and broadcast to everyone
-            SetTurncoatTeam(owner, true)
-
-            -- Announce the role change
-            for _, ply in ipairs(GetAllPlayers()) do
-                ply:PrintMessage(HUD_PRINTTALK, owner:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has joined the " .. ROLE_STRINGS_PLURAL[ROLE_TRAITOR] .. "!")
-                ply:PrintMessage(HUD_PRINTCENTER, owner:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has joined the " .. ROLE_STRINGS_PLURAL[ROLE_TRAITOR] .. "!")
-            end
-
-            -- Change health
-            local health = GetConVar("ttt_turncoat_change_health"):GetInt()
-            -- Don't heal the owner if they already have less health that the convar
-            owner:SetHealth(math.Min(owner:Health(), health))
-            if GetConVar("ttt_turncoat_change_max_health"):GetBool() then
-                owner:SetMaxHealth(health)
-            end
-
+            owner:ChangeTurncoatTeam()
             self:Remove()
         end
     end

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -813,8 +813,11 @@ local function TraitorMenuPopup()
         dsheet.OnTabChanged = function(s, old, new)
             if not IsValid(new) then return end
 
+            local pnl = dlist.SelectedPanel
+            if not pnl or not pnl.item then return end
+
             if new:GetPanel() == dequip then
-                can_order = update_preqs(dlist.SelectedPanel.item)
+                can_order = update_preqs(pnl.item)
                 dconfirm:SetDisabled(not can_order)
             end
         end

--- a/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -175,8 +175,8 @@ local function GetAmmo(ply)
     local weap = ply:GetActiveWeapon()
     if not weap or not ply:Alive() then return -1 end
 
-    local ammo_inv = weap:Ammo1() or 0
-    local ammo_clip = weap:Clip1() or 0
+    local ammo_inv = weap.Ammo1 and weap:Ammo1() or 0
+    local ammo_clip = weap.Clip1 and weap:Clip1() or 0
     local ammo_max = weap.Primary.ClipSize or 0
 
     return ammo_clip, ammo_max, ammo_inv

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -114,7 +114,8 @@ function WSWITCH:DrawWeapon(x, y, c, wep)
     if not IsValid(wep) then return false end
 
     local name = TryTranslation(wep:GetPrintName() or wep.PrintName or "...")
-    local cl1, am1 = wep:Clip1(), wep:Ammo1()
+    local cl1 = wep.Clip1 and wep:Clip1() or -1
+    local am1 = wep.Ammo1 and wep:Ammo1() or false
     local ammo = false
 
     -- Clip1 will be -1 if a melee weapon

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -648,10 +648,10 @@ local function CheckCreditAward(victim, attacker)
                         ply:AddCredits(amt)
                     end
                 end
-            end
 
-            GAMEMODE.AwardedCredits = true
-            GAMEMODE.AwardedCreditsDead = inno_dead + GAMEMODE.AwardedCreditsDead
+                GAMEMODE.AwardedCredits = true
+                GAMEMODE.AwardedCreditsDead = inno_dead + GAMEMODE.AwardedCreditsDead
+            end
         end
     end
 end

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -64,7 +64,7 @@ hook.Add("WeaponEquip", "Beggar_WeaponEquip", function(wep, ply)
         timer.Simple(0.5, function() SendFullStateUpdate() end) -- Slight delay to avoid flickering from beggar to the new role and back to beggar
 
         for _, v in ipairs(GetAllPlayers()) do
-            if beggarMode == BEGGAR_REVEAL_ALL or (v:IsActiveTraitorTeam() and beggarMode == BEGGAR_REVEAL_TRAITORS) or (not v:IsActiveTraitorTeam() and beggarMode == BEGGAR_REVEAL_INNOCENTS) then
+            if v ~= ply and (beggarMode == BEGGAR_REVEAL_ALL or (v:IsActiveTraitorTeam() and beggarMode == BEGGAR_REVEAL_TRAITORS) or (not v:IsActiveTraitorTeam() and beggarMode == BEGGAR_REVEAL_INNOCENTS)) then
                 v:PrintMessage(HUD_PRINTTALK, "The beggar has joined the " .. ROLE_STRINGS[role] .. " team")
                 v:PrintMessage(HUD_PRINTCENTER, "The beggar has joined the " .. ROLE_STRINGS[role] .. " team")
             end

--- a/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
@@ -195,3 +195,17 @@ hook.Add("TTTKarmaShouldGivePenalty", "OldMan_TTTKarmaShouldGivePenalty", functi
         return not attacker:GetNWBool("AdrenalineRush", false)
     end
 end)
+
+-------------
+-- CREDITS --
+-------------
+
+local function OldManCreditLogic(victim, attacker, amt)
+    if victim:IsOldMan() then
+        return 0
+    end
+end
+
+-- Nobody should be rewarded for killing the old man
+hook.Add("TTTRewardDetectiveTraitorDeathAmount", "OldMan_TTTRewardDetectiveTraitorDeathAmount", OldManCreditLogic)
+hook.Add("TTTRewardTraitorInnocentDeathAmount", "OldMan_TTTRewardTraitorInnocentDeathAmount", OldManCreditLogic)

--- a/gamemodes/terrortown/gamemode/roles/turncoat/cl_turncoat.lua
+++ b/gamemodes/terrortown/gamemode/roles/turncoat/cl_turncoat.lua
@@ -51,10 +51,14 @@ hook.Add("TTTTutorialRoleText", "Turncoat_TTTTutorialRoleText", function(role, t
         local roleColor = ROLE_COLORS[ROLE_INNOCENT]
         local html = "The " .. ROLE_STRINGS[ROLE_TURNCOAT] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span>."
 
-        roleColor = ROLE_COLORS[ROLE_TRAITOR]
-        html = html .. "<span style='display: block; margin-top: 10px;'>They are given a one-time-use Team Changer device which moves them to the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>traitor team</span> and <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>announces their role to everyone</span>.</span>"
+        local traitorColor = ROLE_COLORS[ROLE_TRAITOR]
+        html = html .. "<span style='display: block; margin-top: 10px;'>They are given a one-time-use Team Changer device which moves them to the <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>traitor team</span> and <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>announces their role to everyone</span>.</span>"
+
+        if GetGlobalBool("ttt_turncoat_change_innocent_kill", false) then
+            html = html .. "<span style='display: block; margin-top: 10px;'>If they kill a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> then they will change teams automatically.</span>"
+        end
 
         local health = GetGlobalInt("ttt_turncoat_change_health", 10)
-        return html .. "<span style='display: block; margin-top: 10px;'>At the same time, their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>health is changed to</span> " .. health .. ".</span>"
+        return html .. "<span style='display: block; margin-top: 10px;'>At the same time, their <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>health is changed to</span> " .. health .. ".</span>"
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/turncoat/cl_turncoat.lua
+++ b/gamemodes/terrortown/gamemode/roles/turncoat/cl_turncoat.lua
@@ -6,7 +6,7 @@ local hook = hook
 
 hook.Add("Initialize", "Turncoat_Translations_Initialize", function()
     -- Events
-    LANG.AddToLanguage("english", "ev_turncoat", "{nick} is {role} and changed teams")
+    LANG.AddToLanguage("english", "ev_turncoat", "{nick} is {role} and has joined the {traitors}")
 
     -- Weapons
     LANG.AddToLanguage("english", "tur_changer", "Team Changer")
@@ -26,11 +26,16 @@ end)
 hook.Add("Initialize", "Turncoat_Scoring_Initialize", function()
     local traitor_icon = Material("icon16/user_red.png")
     local Event = CLSCORE.DeclareEventDisplay
+    local T = LANG.GetTranslation
     local PT = LANG.GetParamTranslation
 
     Event(EVENT_TURNCOATCHANGED, {
         text = function(e)
-            return PT("ev_turncoat", {nick = e.nic, role = ROLE_STRINGS_EXT[ROLE_TURNCOAT]})
+            return PT("ev_turncoat", {
+                nick = e.nic,
+                role = ROLE_STRINGS_EXT[ROLE_TURNCOAT],
+                traitors = T("traitors")
+            })
         end,
         icon = function(e)
             return traitor_icon, "Changed Teams"

--- a/gamemodes/terrortown/gamemode/roles/turncoat/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/turncoat/shared.lua
@@ -55,3 +55,7 @@ table.insert(ROLE_CONVARS[ROLE_TURNCOAT], {
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 0
 })
+table.insert(ROLE_CONVARS[ROLE_TURNCOAT], {
+    cvar = "ttt_turncoat_change_innocent_kill",
+    type = ROLE_CONVAR_TYPE_BOOL
+})

--- a/gamemodes/terrortown/gamemode/roles/turncoat/turncoat.lua
+++ b/gamemodes/terrortown/gamemode/roles/turncoat/turncoat.lua
@@ -1,25 +1,72 @@
 AddCSLuaFile()
 
+local plymeta = FindMetaTable("Player")
+
 local hook = hook
+local player = player
 local util = util
 
+local GetAllPlayers = player.GetAll
+
 util.AddNetworkString("TTT_TurncoatTeamChange")
+
 -------------
 -- CONVARS --
 -------------
 
 local turncoat_change_health = CreateConVar("ttt_turncoat_change_health", "10", FCVAR_NONE, "The amount of health to set the turncoat to when they change teams", 1, 200)
-CreateConVar("ttt_turncoat_change_max_health", "1", FCVAR_NONE, "Whether to change the turncoat's max health when they change teams", 0, 1)
+local turncoat_change_max_health = CreateConVar("ttt_turncoat_change_max_health", "1", FCVAR_NONE, "Whether to change the turncoat's max health when they change teams", 0, 1)
+local turncoat_change_innocent_kill = CreateClientConVar("ttt_turncoat_change_innocent_kill", "0", FCVAR_NONE, "Whether to change the turncoat's team when they kill a member of the innocent team", 0, 1)
 
 hook.Add("TTTSyncGlobals", "Turncoat_TTTSyncGlobals", function()
     SetGlobalInt("ttt_turncoat_change_health", turncoat_change_health:GetInt())
+    SetGlobalBool("ttt_turncoat_change_innocent_kill", turncoat_change_innocent_kill:GetBool())
 end)
 
 -------------------
 -- ROLE FEATURES --
 -------------------
 
+function plymeta:ChangeTurncoatTeam(extra)
+    if not self:IsTurncoat() then return end
+    if self:IsTraitorTeam() then return end
+
+    -- Change team and broadcast to everyone
+    SetTurncoatTeam(self, true)
+
+    -- Announce the role change
+    local message = self:Nick() .. " is " .. ROLE_STRINGS_EXT[ROLE_TURNCOAT] .. " and has joined the " .. ROLE_STRINGS_PLURAL[ROLE_TRAITOR]
+    if extra then
+        message = message .. extra
+    end
+    message = message .. "!"
+    for _, ply in ipairs(GetAllPlayers()) do
+        ply:PrintMessage(HUD_PRINTTALK, message)
+        ply:PrintMessage(HUD_PRINTCENTER, message)
+    end
+
+    -- Change health
+    local health = turncoat_change_health:GetInt()
+    -- Don't heal the owner if they already have less health that the convar
+    self:SetHealth(math.Min(self:Health(), health))
+    if turncoat_change_max_health:GetBool() then
+        self:SetMaxHealth(health)
+    end
+end
+
 -- Reset the role back to the innocent team
 hook.Add("TTTPrepareRound", "Turncoat_PrepareRound", function()
     SetTurncoatTeam(nil, false)
+end)
+
+-- Change the turncoat's team automatically if they kill an innocent and that setting is enabled
+hook.Add("DoPlayerDeath", "Turncoat_DoPlayerDeath", function(ply, attacker, dmginfo)
+    if not turncoat_change_innocent_kill:GetBool() then return end
+    if not IsPlayer(attacker) then return end
+    if not ply:IsInnocentTeam() then return end
+    if not attacker:IsTurncoat() then return end
+    if attacker:IsTraitorTeam() then return end
+
+    attacker:ChangeTurncoatTeam(" by killing " .. ROLE_STRINGS_EXT[ROLE_INNOCENT])
+    attacker:StripWeapon("weapon_tur_changer")
 end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -19,7 +19,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.6.5"
+CR_VERSION = "1.6.6"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -244,15 +244,20 @@ function PANEL:Paint(width, height)
                 role = glitch_role
                 if color_role then
                     color = ROLE_COLORS_SCOREBOARD[color_role]
+                else
+                    color = ROLE_COLORS_SCOREBOARD[role]
                 end
             elseif ply:IsImpersonator() then
-                if GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
+                if ply:IsRoleActive() and GetGlobalBool("ttt_impersonator_use_detective_icon", true) then
                     role = ROLE_DETECTIVE
                 end
                 color = ROLE_COLORS_SCOREBOARD[ROLE_IMPERSONATOR]
             end
+        end
+
         -- Swap the deputy/impersonator icons depending on which settings are enabled
-        elseif ply:IsDetectiveLike() then
+        -- Only do this if we haven't set a value above
+        if not color and ply:IsDetectiveLike() then
             if ply:IsDetectiveTeam() then
                 local disp_role, changed = ply:GetDisplayedRole()
                 -- If the displayed role was changed, use it for the color but use the question mark for the icon


### PR DESCRIPTION
**Additions**
- Added option to have turncoat automatically change teams when they kill a innocent team member (disabled by default)

**Fixes**
- Fixed traitors seeing the deputy role icon on the scoreboard for promoted deputies instead of the detective icon
- Fixed traitors seeing the detective role icon on the scoreboard for impersonators who haven't been promoted yet when `ttt_impersonator_use_detective_icon` is enabled
- Fixed error rendering the weapon switch and HUD with certain workshop weapons
- Fixed traitors not being awarded credits if `ttt_credits_award_repeat` is disabled and something caused the first credit award amount to be 0
- Fixed beggar sometimes being shown duplicate team join notifications depending on the `ttt_beggar_reveal_*` convars

**Changes**
- Changed turncoat's announcement message to say explicitly that they joined the traitors
- Changed so killing the old man does not award credits to anyone