### PR TITLE
Fix an issue with the equipment shop.

### DIFF
--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -814,7 +814,9 @@ local function TraitorMenuPopup()
             if not IsValid(new) then return end
 
             if new:GetPanel() == dequip then
-                can_order = update_preqs(dlist.SelectedPanel.item)
+                if pnl and pnl.item then
+                    can_order = update_preqs(pnl.item)
+                end
                 dconfirm:SetDisabled(not can_order)
             end
         end

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -813,10 +813,11 @@ local function TraitorMenuPopup()
         dsheet.OnTabChanged = function(s, old, new)
             if not IsValid(new) then return end
 
+            local pnl = dlist.SelectedPanel
+            if not pnl or not pnl.item then return end
+
             if new:GetPanel() == dequip then
-                if pnl and pnl.item then
-                    can_order = update_preqs(pnl.item)
-                end
+                can_order = update_preqs(pnl.item)
                 dconfirm:SetDisabled(not can_order)
             end
         end


### PR DESCRIPTION
When you search in the equipment shop and there are no results, you then change to another tab such as radar or transfer credits tab, and then try to switch back to the order equipment tab, it gives you an error.

```
[custom roles] addons/custom roles/gamemodes/terrortown/gamemode/cl_equip.lua:817: attempt to index field 'SelectedPanel' (a nil value)
  1. OnTabChanged - addons/custom roles/gamemodes/terrortown/gamemode/cl_equip.lua:817
   2. SetActiveTab - addons/custom roles/gamemodes/terrortown/gamemode/cl_equip.lua:493
    3. DoClick - lua/vgui/dpropertysheet.lua:40
     4. unknown - lua/vgui/dlabel.lua:237
```

This PR has a simple check which fixes that error.