### PR TITLE
Misc. additions and fixes

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,11 +8,12 @@ These documents aim to explain the things that we have added to Custom Roles for
 1. [Global Variables](API/GLOBAL_VARIABLES.md)
 1. [Global Enumerations](API/GLOBAL_ENUMERATIONS.md)
 1. Methods
+   1. [HUD](API/METHODS_HUD.md)
    1. [Global](API/METHODS_GLOBAL.md)
    1. [Player Object](API/METHODS_PLAYER_OBJECT.md)
    1. [Player Static](API/METHODS_PLAYER_STATIC.md)
    1. [Table](API/METHODS_TABLE.md)
-   1. [HUD](API/METHODS_HUD.md)
+   1. [Util](API/METHODS_UTIL.md)
 1. [Hooks](API/HOOKS.md)
 1. [SWEPs](API/SWEPS.md)
 1. [Commands](API/COMMANDS.md)

--- a/API/METHODS_UTIL.md
+++ b/API/METHODS_UTIL.md
@@ -1,0 +1,10 @@
+# Utility Methods
+Utility methods created to help with various common scenarios
+
+### util.ExecFile(filePath, errorIfMissing)
+Executes a file at the given path, relative to the root game location.\
+*Realm:* Server\
+*Added in:* 1.6.7
+*Parameters:*
+- *filePath* - The path to the file to be executed, relative to the root game location
+- *errorIfMissing* - Whether to throw an error if the file is missing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,9 @@
 - Fixed award for killing all innocents assuming the player was a traitor
 - Fixed award for killing all traitors assuming the player was an innocent
 
+### Developer
+- Added `util.ExecFile` for executing the contents of a file
+
 ## 1.6.6 (Beta)
 **Released: July 24th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 1.6.7 (Beta)
+**Released:**
+
+## Fixes
+- Fixed award for killing all monsters not using the translation for "monsters"
+- Fixed award for killing all innocents assuming the player was a traitor
+- Fixed award for killing all traitors assuming the player was an innocent
+
 ## 1.6.6 (Beta)
 **Released: July 24th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,11 @@
 ## 1.6.7 (Beta)
 **Released:**
 
-## Fixes
+### Additions
+- Added ability to have map-specific config files
+  - Create a `.cfg` file with the map's name (e.g. `ttt_lego.cfg`) in the `cfg` directory
+
+### Fixes
 - Fixed award for killing all monsters not using the translation for "monsters"
 - Fixed award for killing all innocents assuming the player was a traitor
 - Fixed award for killing all traitors assuming the player was an innocent

--- a/gamemodes/terrortown/gamemode/cl_awards.lua
+++ b/gamemodes/terrortown/gamemode/cl_awards.lua
@@ -200,7 +200,7 @@ local function AllKills(events, scores, players)
         if not TRAITOR_ROLES[role] then
             if not killer then return nil end
 
-            return {nick=killer, title=T("aw_all1_title"), text=PT("aw_all1_text", {innocent=ROLE_STRINGS_PLURAL[ROLE_INNOCENT]}), priority=math.random(0, table.Count(players))}
+            return {nick=killer, title=T("aw_all1_title"), text=PT("aw_all1_text", {traitor=ROLE_STRINGS[ROLE_TRAITOR]}), priority=math.random(0, table.Count(players))}
         end
     end
 
@@ -212,7 +212,7 @@ local function AllKills(events, scores, players)
         if not INNOCENT_ROLES[role] then
             if not killer then return nil end
 
-            return {nick=killer, title=T("aw_all2_title"), text=PT("aw_all2_text", {traitor=ROLE_STRINGS_EXT[ROLE_TRAITOR]}), priority=math.random(0, table.Count(players))}
+            return {nick=killer, title=T("aw_all2_title"), text=PT("aw_all2_text", {innocent=ROLE_STRINGS[ROLE_INNOCENT]}), priority=math.random(0, table.Count(players))}
         end
     end
 
@@ -224,7 +224,7 @@ local function AllKills(events, scores, players)
         if not MONSTER_ROLES[role] then
             if not killer then return nil end
 
-            return {nick=killer, title=T("aw_all3_title"), text=T("aw_all3_text"), priority=math.random(0, table.Count(players))}
+            return {nick=killer, title=T("aw_all3_title"), text=PT("aw_all3_text", {monster=T("monster")}), priority=math.random(0, table.Count(players))}
         end
     end
 

--- a/gamemodes/terrortown/gamemode/incompatible_addons.lua
+++ b/gamemodes/terrortown/gamemode/incompatible_addons.lua
@@ -61,6 +61,7 @@ local incompatible = {
     -- Glowing Traitors
     ["690007939"] = { reason = "Player outlines are included in Custom Roles for TTT." }, -- TTT Glowing Traitors by kuma7
     ["1821994127"] = { reason = "Player outlines are included in Custom Roles for TTT." }, -- [GM] Glowing Traitors [TTT]
+    ["1137493106"] = { reason = "Player outlines are included in Custom Roles for TTT." }, -- [TTT/2] Glowing Teammates by LillyPoh
 
     -- Killer Notifier
     ["167547072"] = { reason = "Death messages are included in Custom Roles for TTT." }, -- TTT Killer Notifier by StarFox

--- a/gamemodes/terrortown/gamemode/incompatible_addons.lua
+++ b/gamemodes/terrortown/gamemode/incompatible_addons.lua
@@ -42,7 +42,7 @@ local incompatible = {
     ["1818951122"] = { reason = "Overwrites core files required for Custom Roles for TTT." }, -- [GM] More Roles [TTT] by Selfridge
 
     -- Other Core File Overwrites
-    ["107658972"] = { reason = "Overwrites core files required for Custom Roles for TTT." }, -- TTT Round End Slowmotion by TheTrueLor
+    ["107658972"] = { reason = "Overwrites core files required for Custom Roles for TTT.", alt = "686457995" }, -- TTT Round End Slowmotion by TheTrueLor
     ["254779132"] = { reason = "Overwrites core files required for Custom Roles for TTT.", alt = "810154456" }, -- TTT DeadRinger by Porter
     ["367945571"] = { reason = "Overwrites core files required for Custom Roles for TTT." }, -- TTT: Advanced Body Search
     ["2520210407"] = { reason = "Overwrites core files required for Custom Roles for TTT." }, -- TTT Weapon Balance by Emzatin.

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -79,10 +79,12 @@ local util = util
 local CallHook = hook.Call
 local RunHook = hook.Run
 local GetAllPlayers = player.GetAll
+local StringFormat = string.format
 local StringLower = string.lower
 local StringUpper = string.upper
 local StringSub = string.sub
 local StringStartsWith = string.StartWith
+local StringTrim = string.Trim
 
 -- Round times
 CreateConVar("ttt_roundtime_minutes", "10", FCVAR_NOTIFY)
@@ -448,6 +450,23 @@ end
 -- point.
 function GM:InitCvars()
     MsgN("TTT initializing convar settings...")
+
+    local map_config = StringFormat("cfg/%s.cfg", game.GetMap())
+    if file.Exists(map_config, "GAME") then
+        MsgN("Loading map-specific config from " .. map_config)
+        local map_config_content = file.Read(map_config, "GAME")
+        local lines = string.Explode("\n", map_config_content)
+        for _, line in ipairs(lines) do
+            line = StringTrim(line)
+            if #line == 0 then continue end
+            if StringStartsWith(line, "exec") then
+                MsgN("Loading additional config files is not allowed, skipping: " .. line)
+                continue
+            end
+
+            game.ConsoleCommand(StringFormat("%s\n", line))
+        end
+    end
 
     -- Initialize game state that is synced with client
     SetGlobalInt("ttt_rounds_left", GetConVar("ttt_round_limit"):GetInt())

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -83,8 +83,7 @@ local StringFormat = string.format
 local StringLower = string.lower
 local StringUpper = string.upper
 local StringSub = string.sub
-local StringStartsWith = string.StartWith
-local StringTrim = string.Trim
+local StringStartWith = string.StartWith
 
 -- Round times
 CreateConVar("ttt_roundtime_minutes", "10", FCVAR_NOTIFY)
@@ -454,18 +453,7 @@ function GM:InitCvars()
     local map_config = StringFormat("cfg/%s.cfg", game.GetMap())
     if file.Exists(map_config, "GAME") then
         MsgN("Loading map-specific config from " .. map_config)
-        local map_config_content = file.Read(map_config, "GAME")
-        local lines = string.Explode("\n", map_config_content)
-        for _, line in ipairs(lines) do
-            line = StringTrim(line)
-            if #line == 0 then continue end
-            if StringStartsWith(line, "exec") then
-                MsgN("Loading additional config files is not allowed, skipping: " .. line)
-                continue
-            end
-
-            game.ConsoleCommand(StringFormat("%s\n", line))
-        end
+        util.ExecFile(map_config)
     end
 
     -- Initialize game state that is synced with client
@@ -1960,7 +1948,7 @@ hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, inflictor, att
     elseif attacker == victim then
         reason = "suicide"
     elseif IsValid(inflictor) then
-        if victim:IsPlayer() and (StringStartsWith(inflictor:GetClass(), "prop_physics") or inflictor:GetClass() == "prop_dynamic") then
+        if victim:IsPlayer() and (StringStartWith(inflictor:GetClass(), "prop_physics") or inflictor:GetClass() == "prop_dynamic") then
             -- If the killer is also a prop
             reason = "prop"
         elseif IsValid(attacker) then

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -453,7 +453,7 @@ function GM:InitCvars()
     local map_config = StringFormat("cfg/%s.cfg", game.GetMap())
     if file.Exists(map_config, "GAME") then
         MsgN("Loading map-specific config from " .. map_config)
-        util.ExecFile(map_config)
+        util.ExecFile(map_config, true)
     end
 
     -- Initialize game state that is synced with client

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -922,13 +922,13 @@ L.aw_fst4_title = "First Blow"
 L.aw_fst4_text = "struck the first blow for the {innocent} by making the first death {traitor}'s."
 
 L.aw_all1_title = "Deadliest Among Equals"
-L.aw_all1_text = "was responsible for every kill made by the {innocent} this round."
+L.aw_all1_text = "was responsible for killing every {traitor} this round."
 
 L.aw_all2_title = "Lone Wolf"
-L.aw_all2_text = "was responsible for every kill made by {traitor} this round."
+L.aw_all2_text = "was responsible for killing every {innocent} this round."
 
 L.aw_all3_title = "Van Helsing"
-L.aw_all3_text = "was responsible for every monster killed this round."
+L.aw_all3_text = "was responsible for every {monster} killed this round."
 
 L.aw_nkt1_title = "I Got One, Boss!"
 L.aw_nkt1_text = "managed to kill a single {innocent}. Sweet!"

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -19,7 +19,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.6.6"
+CR_VERSION = "1.6.7"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/util.lua
+++ b/gamemodes/terrortown/gamemode/util.lua
@@ -455,7 +455,7 @@ if SERVER then
     function util.ExecFile(filePath, errorIfMissing)
         if not file.Exists(filePath, "GAME") then
             if errorIfMissing then
-                ErrorNoHalt("File not found when trying to execute: " .. filePath)
+                ErrorNoHalt(StringFormat("File not found when trying to execute: %s\n", filePath))
             end
             return
         end

--- a/gamemodes/terrortown/gamemode/util.lua
+++ b/gamemodes/terrortown/gamemode/util.lua
@@ -18,6 +18,9 @@ local GetAllPlayers = player.GetAll
 local StringUpper = string.upper
 local StringFormat = string.format
 local StringSub = string.sub
+local StringStartWith = string.StartWith
+local StringTrim = string.Trim
+local StringTrimLeft = string.TrimLeft
 
 -- attempts to get the weapon used from a DamageInfo instance needed because the
 -- GetAmmoType value is useless and inflictor isn't properly set (yet)
@@ -446,4 +449,30 @@ function util.SimpleTime(seconds, fmt)
     local m = seconds % 60
 
     return StringFormat(fmt, m, s, ms)
+end
+
+if SERVER then
+    function util.ExecFile(filePath, errorIfMissing)
+        if not file.Exists(filePath, "GAME") then
+            if errorIfMissing then
+                ErrorNoHalt("File not found when trying to execute: " .. filePath)
+            end
+            return
+        end
+
+        local fileContent = file.Read(filePath, "GAME")
+        local lines = string.Explode("\n", fileContent)
+        for _, line in ipairs(lines) do
+            line = StringTrim(line)
+            if #line == 0 then continue end
+
+            if StringStartWith(line, "exec ") then
+                local subFile = StringTrimLeft(line, "exec ")
+                util.ExecFile(subFile)
+                continue
+            end
+
+            game.ConsoleCommand(StringFormat("%s\n", line))
+        end
+    end
 end

--- a/gamemodes/terrortown/gamemode/util.lua
+++ b/gamemodes/terrortown/gamemode/util.lua
@@ -468,7 +468,7 @@ if SERVER then
 
             if StringStartWith(line, "exec ") then
                 local subFile = StringTrimLeft(line, "exec ")
-                util.ExecFile(subFile)
+                util.ExecFile(subFile, errorIfMissing)
                 continue
             end
 


### PR DESCRIPTION
**Additions**
- Added ability to have map-specific config files
  - Create a `.cfg` file with the map's name (e.g. `ttt_lego.cfg`) in the `cfg` directory

**Fixes**
- Fixed award for killing all monsters not using the translation for "monsters"
- Fixed award for killing all innocents assuming the player was a traitor
- Fixed award for killing all traitors assuming the player was an innocent

**Developer**
- Added `util.ExecFile` for executing the contents of a file