### PR TITLE
Add option for vampire friendly fire to negate thrall damage to prime

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -210,7 +210,7 @@ ttt_vampire_prime_death_mode                0       // What to do when the prime
 ttt_vampire_prime_only_convert              1       // Whether only prime vampires (e.g. players who spawn as vampire originally) are allowed to convert other players
 ttt_vampire_kill_credits                    1       // Whether the vampire receives credits when they kill another player
 ttt_vampire_loot_credits                    1       // Whether the vampire can loot credits from a dead player
-ttt_vampire_prime_reflect_friendly_fire     0       // Whether to reflect friendly fire by a thrall against a prime back onto the attacker
+ttt_vampire_prime_friendly_fire             0       // How to handle friendly fire damage to the prime vampire(s) from their thralls. 0 - Do nothing. 1 - Reflect damage back to the attacker (non-prime vampire). 2 - Negate damage to the prime vampire.
 ttt_vampire_credits_starting                1       // The number of credits a vampire should start with
 
 // Quack

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,14 @@
 # Release Notes
 
+## 1.6.10 (Beta)
+**Released:**
+
 ## 1.6.9 (Beta)
 **Released: August 13th, 2022**
+
+### Changes
+- Changed vampire (thrall -> prime) friendly-fire handling to allow damage negation instead of reflection (disabled by default)
+  - Setting renamed from `ttt_vampire_prime_reflect_friendly_fire` to `ttt_vampire_prime_friendly_fire`
 
 ### Fixes
 - Fixed paladin's damage reduction aura working even when they were dead

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,12 +3,12 @@
 ## 1.6.10 (Beta)
 **Released:**
 
-## 1.6.9 (Beta)
-**Released: August 13th, 2022**
-
 ### Changes
 - Changed vampire (thrall -> prime) friendly-fire handling to allow damage negation instead of reflection (disabled by default)
   - Setting renamed from `ttt_vampire_prime_reflect_friendly_fire` to `ttt_vampire_prime_friendly_fire`
+
+## 1.6.9 (Beta)
+**Released: August 13th, 2022**
 
 ### Fixes
 - Fixed paladin's damage reduction aura working even when they were dead

--- a/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
@@ -169,8 +169,9 @@ table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     decimal = 0
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
-    cvar = "ttt_vampire_prime_reflect_friendly_fire",
-    type = ROLE_CONVAR_TYPE_BOOL
+    cvar = "ttt_vampire_prime_friendly_fire",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     cvar = "ttt_vampire_show_target_icon",

--- a/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
@@ -9,6 +9,11 @@ VAMPIRE_DEATH_NONE = 0
 VAMPIRE_DEATH_KILL_CONVERTED = 1
 VAMPIRE_DEATH_REVERT_CONVERTED = 2
 
+-- Vampire thrall friendly fire modes
+VAMPIRE_THRALL_FF_MODE_NONE = 0
+VAMPIRE_THRALL_FF_MODE_REFLECT = 1
+VAMPIRE_THRALL_FF_MODE_IMMUNE = 2
+
 local function InitializeEquipment()
     if EquipmentItems then
         local mat_dir = "vgui/ttt/"

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -271,14 +271,14 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
 
     -- When enabled: If the target is the prime vampire and they are attacked by a non-prime vampire then reflect the damage
     local prime_friendly_fire_mode = vampire_prime_friendly_fire:GetInt()
-    if prime_friendly_fire_mode > 0 and ply:IsVampirePrime() and att:IsVampire() and not att:IsVampirePrime() then
+    if prime_friendly_fire_mode > VAMPIRE_THRALL_FF_MODE_NONE and ply:IsVampirePrime() and att:IsVampire() and not att:IsVampirePrime() then
         local infl = dmginfo:GetInflictor()
         if not IsValid(infl) then
             infl = game.GetWorld()
         end
 
-        if prime_friendly_fire_mode == 1 then
-            -- Copy the original damage info and send it back on the attacker
+        -- Copy the original damage info and send it back on the attacker
+        if prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_REFLECT then
             local newinfo = DamageInfo()
             newinfo:SetDamage(dmginfo:GetDamage())
             newinfo:SetDamageType(dmginfo:GetDamageType())
@@ -292,8 +292,8 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
             -- Remove the damage dealt to the prime
             dmginfo:ScaleDamage(0)
             dmginfo:SetDamage(0)
-        elseif prime_friendly_fire_mode == 2 then
-            -- Remove the damage dealt to the prime
+        -- Remove the damage dealt to the prime
+        elseif prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_IMMUNE then
             dmginfo:ScaleDamage(0)
             dmginfo:SetDamage(0)
         end

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -288,6 +288,10 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
             newinfo:SetDamagePosition(dmginfo:GetDamagePosition())
             newinfo:SetReportedPosition(dmginfo:GetReportedPosition())
             att:TakeDamageInfo(newinfo)
+
+            -- Remove the damage dealt to the prime
+            dmginfo:ScaleDamage(0)
+            dmginfo:SetDamage(0)
         -- Remove the damage dealt to the prime
         elseif prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_IMMUNE then
             dmginfo:ScaleDamage(0)

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -288,10 +288,6 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
             newinfo:SetDamagePosition(dmginfo:GetDamagePosition())
             newinfo:SetReportedPosition(dmginfo:GetReportedPosition())
             att:TakeDamageInfo(newinfo)
-
-            -- Remove the damage dealt to the prime
-            dmginfo:ScaleDamage(0)
-            dmginfo:SetDamage(0)
         -- Remove the damage dealt to the prime
         elseif prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_IMMUNE then
             dmginfo:ScaleDamage(0)

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -272,13 +272,13 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
     -- When enabled: If the target is the prime vampire and they are attacked by a non-prime vampire then reflect the damage
     local prime_friendly_fire_mode = vampire_prime_friendly_fire:GetInt()
     if prime_friendly_fire_mode > VAMPIRE_THRALL_FF_MODE_NONE and ply:IsVampirePrime() and att:IsVampire() and not att:IsVampirePrime() then
-        local infl = dmginfo:GetInflictor()
-        if not IsValid(infl) then
-            infl = game.GetWorld()
-        end
-
         -- Copy the original damage info and send it back on the attacker
         if prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_REFLECT then
+            local infl = dmginfo:GetInflictor()
+            if not IsValid(infl) then
+                infl = game.GetWorld()
+            end
+
             local newinfo = DamageInfo()
             newinfo:SetDamage(dmginfo:GetDamage())
             newinfo:SetDamageType(dmginfo:GetDamageType())


### PR DESCRIPTION
I think it makes sense to allow the vampire friendly fire option to select between
1. Reflecting damage back to the vampire thrall to penalize them and
2. Damage negation to the prime vampire from their thralls
That way you don't have to strictly penalize a thrall for accidentally attacking their prime.