### PR TITLE
Misc. additions and changes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
   - There are now three options: 0 - Do nothing, 1 - Reflect damage on to attacker, 2 - Negate damage
   - Setting renamed from `ttt_vampire_prime_reflect_friendly_fire` to `ttt_vampire_prime_friendly_fire`
 - Changed quack's station bomb to be on a different sub-slot so it can be bought at the same time as the health station
+- Changed player state overrides (like movement speed) to be set on each player spawn to ensure other addons don't leave players in a broken state
 
 ## 1.6.9 (Beta)
 **Released: August 13th, 2022**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,14 @@
 ## 1.6.10 (Beta)
 **Released:**
 
+### Additions
+- Added ability to change how zombie-to-zombie friendly-fire is handled
+  - There are three options: 0 - Do nothing, 1 - Reflect damage on to attacker, 2 - Negate damage
+  - Defaults to negating damage which was the previous behavior
+
 ### Changes
-- Changed vampire (thrall -> prime) friendly-fire handling to allow damage negation instead of reflection (disabled by default)
+- Changed vampire (thrall -> prime) friendly-fire handling to allow damage negation instead of reflection (disabled by default) (Thanks @neon_leitz!)
+  - There are now three options: 0 - Do nothing, 1 - Reflect damage on to attacker, 2 - Negate damage
   - Setting renamed from `ttt_vampire_prime_reflect_friendly_fire` to `ttt_vampire_prime_friendly_fire`
 
 ## 1.6.9 (Beta)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 - Changed vampire (thrall -> prime) friendly-fire handling to allow damage negation instead of reflection (disabled by default) (Thanks @neon_leitz!)
   - There are now three options: 0 - Do nothing, 1 - Reflect damage on to attacker, 2 - Negate damage
   - Setting renamed from `ttt_vampire_prime_reflect_friendly_fire` to `ttt_vampire_prime_friendly_fire`
+- Changed quack's station bomb to be on a different sub-slot so it can be bought at the same time as the health station
 
 ## 1.6.9 (Beta)
 **Released: August 13th, 2022**

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_station_bomb.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_station_bomb.lua
@@ -53,7 +53,7 @@ local hum = Sound("items/nvg_on.wav")
 local zap = Sound("weapons/c4_initiate.mp3")
 
 -- This is special equipment
-SWEP.Kind = WEAPON_EQUIP
+SWEP.Kind = WEAPON_EQUIP2
 SWEP.CanBuy = { ROLE_QUACK }
 SWEP.LimitedStock = true
 SWEP.WeaponID = AMMO_STATIONBOMB

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -624,7 +624,7 @@ L.target_unconfirmed_role = "UNCONFIRMED {targettype}"
 -- Traitor buttons (HUD buttons with hand icons that only traitors can see)
 L.tbut_single = "Single use"
 L.tbut_reuse = "Reusable"
-L.tbut_retime = "Reusable after {num} sec"
+L.tbut_retime = "Reusable after {num} seconds"
 L.tbut_help = "Press {key} to activate"
 
 -- Equipment info lines (on the left above the health/ammo panel)

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -184,6 +184,14 @@ function plymeta:ResetRoundFlags()
 
     self:ResetBought()
 
+    -- Change some gmod defaults
+    self:SetCanZoom(false)
+    self:SetJumpPower(160)
+    self:SetCrouchedWalkSpeed(0.3)
+    self:SetRunSpeed(220)
+    self:SetWalkSpeed(220)
+    self:SetMaxSpeed(220)
+
     -- equipment stuff
     self.bomb_wire = nil
     self.radar_charge = 0
@@ -379,14 +387,6 @@ function plymeta:InitialSpawn()
 
     -- The team the player spawns on depends on the round state
     self:SetTeam(GetRoundState() == ROUND_PREP and TEAM_TERROR or TEAM_SPEC)
-
-    -- Change some gmod defaults
-    self:SetCanZoom(false)
-    self:SetJumpPower(160)
-    self:SetCrouchedWalkSpeed(0.3)
-    self:SetRunSpeed(220)
-    self:SetWalkSpeed(220)
-    self:SetMaxSpeed(220)
 
     -- Always spawn innocent initially, traitor will be selected later
     self:ResetStatus()

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -32,7 +32,7 @@ local vampire_prime_death_mode = CreateConVar("ttt_vampire_prime_death_mode", "0
 local vampire_vision_enable = CreateConVar("ttt_vampire_vision_enable", "0")
 local vampire_kill_credits = CreateConVar("ttt_vampire_kill_credits", "1")
 local vampire_loot_credits = CreateConVar("ttt_vampire_loot_credits", "1")
-local vampire_prime_friendly_fire = CreateConVar("ttt_vampire_prime_friendly_fire", "0", FCVAR_NONE, "How to handle friendly fire damage to the prime vampire(s) from their thralls. 0 - Do nothing. 1 - Reflect damage back to the attacker (non-prime vampire). 2 - Negate damage to the prime vampire. ", 0, 2)
+local vampire_prime_friendly_fire = CreateConVar("ttt_vampire_prime_friendly_fire", "0", FCVAR_NONE, "How to handle friendly fire damage to the prime vampire(s) from their thralls. 0 - Do nothing. 1 - Reflect damage back to the attacker (non-prime vampire). 2 - Negate damage to the prime vampire.", 0, 2)
 
 hook.Add("TTTSyncGlobals", "Vampire_TTTSyncGlobals", function()
     SetGlobalBool("ttt_vampires_are_monsters", vampires_are_monsters:GetBool())
@@ -288,15 +288,12 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
             newinfo:SetDamagePosition(dmginfo:GetDamagePosition())
             newinfo:SetReportedPosition(dmginfo:GetReportedPosition())
             att:TakeDamageInfo(newinfo)
-
-            -- Remove the damage dealt to the prime
-            dmginfo:ScaleDamage(0)
-            dmginfo:SetDamage(0)
-        -- Remove the damage dealt to the prime
-        elseif prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_IMMUNE then
-            dmginfo:ScaleDamage(0)
-            dmginfo:SetDamage(0)
         end
+
+        -- In either case, remove the damage dealt to the prime
+        -- This is used by both VAMPIRE_THRALL_FF_MODE_REFLECT and VAMPIRE_THRALL_FF_MODE_IMMUNE
+        dmginfo:ScaleDamage(0)
+        dmginfo:SetDamage(0)
     -- Otherwise apply damage scaling
     elseif dmginfo:IsBulletDamage() then
         local reduction = vampire_damage_reduction:GetFloat()

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -272,6 +272,10 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
     -- When enabled: If the target is the prime vampire and they are attacked by a non-prime vampire then reflect the damage
     local prime_friendly_fire_mode = vampire_prime_friendly_fire:GetInt()
     if prime_friendly_fire_mode > VAMPIRE_THRALL_FF_MODE_NONE and ply:IsVampirePrime() and att:IsVampire() and not att:IsVampirePrime() then
+        local custom_damage = dmginfo:GetDamageCustom()
+        -- If this is set, assume that we're the ones that set it and don't check this damage info
+        if custom_damage == DMG_AIRBOAT then return end
+
         -- Copy the original damage info and send it back on the attacker
         if prime_friendly_fire_mode == VAMPIRE_THRALL_FF_MODE_REFLECT then
             local infl = dmginfo:GetInflictor()
@@ -280,6 +284,8 @@ hook.Add("ScalePlayerDamage", "Vampire_ScalePlayerDamage", function(ply, hitgrou
             end
 
             local newinfo = DamageInfo()
+            -- Set this so that we can check for it since it is not normally used in GMod
+            newinfo:SetDamageCustom(DMG_AIRBOAT)
             newinfo:SetDamage(dmginfo:GetDamage())
             newinfo:SetDamageType(dmginfo:GetDamageType())
             newinfo:SetAttacker(att)

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -4,6 +4,11 @@ local hook = hook
 local IsValid = IsValid
 local table = table
 
+-- Zombie friendly fire modes
+ZOMBIE_FF_MODE_NONE = 0
+ZOMBIE_FF_MODE_REFLECT = 1
+ZOMBIE_FF_MODE_IMMUNE = 2
+
 -- Initialize role features
 ROLE_SHOULD_NOT_DROWN[ROLE_ZOMBIE] = true
 
@@ -203,4 +208,9 @@ table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
     cvar = "ttt_zombie_thrall_attack_delay",
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 2
+})
+table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
+    cvar = "ttt_zombie_friendly_fire",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })


### PR DESCRIPTION
**Additions**
- Added ability to change how zombie-to-zombie friendly-fire is handled
  - There are three options: 0 - Do nothing, 1 - Reflect damage on to attacker, 2 - Negate damage
  - Defaults to negating damage which was the previous behavior
- Added sanity check against infinite recursion in vampire damage reflection

**Changes**
- Changed quack's station bomb to be on a different sub-slot so it can be bought at the same time as the health station
- Changed player state overrides (like movement speed) to be set on each player spawn to ensure other addons don't leave players in a broken state