### PR TITLE
Misc. additions

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -197,6 +197,7 @@ ttt_vampire_vision_enable                   0       // Whether vampires have the
 ttt_vampire_drain_enable                    1       // Whether vampires have the ability to drain a living target's blood using their fangs
 ttt_vampire_drain_first                     0       // Whether vampires should drain a living target's blood first rather than converting first
 ttt_vampire_drain_credits                   0       // How many credits a vampire should get for draining a living target
+ttt_vampire_drain_mute_target               0       // Whether players being drained by a vampire should be muted
 ttt_vampire_convert_enable                  0       // Whether vampires have the ability to convert living targets to a vampire thrall using their fangs
 ttt_vampire_show_target_icon                0       // Whether vampires have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
 ttt_vampire_damage_reduction                0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a vampire

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -462,6 +462,7 @@ ttt_independents_update_scoreboard          0       // Whether all independent r
 // Drunk
 ttt_drunk_sober_time                        180     // Time in seconds for the drunk to remember their role
 ttt_drunk_innocent_chance                   0.7     // Chance that the drunk will become an innocent role when remembering their role
+ttt_drunk_traitor_chance                    0       // Chance that the drunk will become a traitor role when remembering their role and ttt_drunk_any_role is enabled. If disabled (0), player chance of becoming a traitor is equal to every other non-innocent role
 ttt_drunk_become_clown                      0       // Whether the drunk should become a clown (instead of joining the losing team) if the round would end before they sober up
 ttt_drunk_notify_mode                       0       // The logic to use when notifying players that a drunk has sobered up. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_drunk_any_role                          0       // Whether the drunk can become any enabled role (other than the drunk, the glitch, or roles that were already used this round). The ttt_drunk_can_be_* convars below can be used to prevent the drunk from becoming specific roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.6.12 (Beta)
+**Released:**
+
+### Additions
+- Added ability to set chance a drunk will become a traitor explicitly rather than the default logic where traitor roles have the same chance as all non-innocent roles (disabled by default)
+
 ## 1.6.11 (Beta)
 **Released: August 27th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Additions
 - Added ability to set chance a drunk will become a traitor explicitly rather than the default logic where traitor roles have the same chance as all non-innocent roles (disabled by default)
+- Added ability to mute a player being drained by a vampire (disabled by default)
 
 ## 1.6.11 (Beta)
 **Released: August 27th, 2022**

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -23,6 +23,7 @@ util.AddNetworkString("TTT_DrunkSober")
 local drunk_sober_time = CreateConVar("ttt_drunk_sober_time", "180", FCVAR_NONE, "Time in seconds for the drunk to remember their role", 0, 300)
 local drunk_notify_mode = CreateConVar("ttt_drunk_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the drunk sobers up", 0, 4)
 local drunk_innocent_chance = CreateConVar("ttt_drunk_innocent_chance", "0.7", FCVAR_NONE, "Chance that the drunk will become an innocent role when remembering their role", 0, 1)
+local drunk_traitor_chance = CreateConVar("ttt_drunk_traitor_chance", "0", FCVAR_NONE, "Chance that the drunk will become a traitor role when remembering their role and \"all roles\" logic is enabled. If disabled (0), player chance of becoming a traitor is equal to every other non-innocent role", 0, 1)
 local drunk_become_clown = CreateConVar("ttt_drunk_become_clown", "0")
 local drunk_any_role = CreateConVar("ttt_drunk_any_role", "0")
 
@@ -140,10 +141,12 @@ function plymeta:SoberDrunk(team)
             elseif team == ROLE_TEAM_DETECTIVE then
                 role_options = GetTeamRoles(DETECTIVE_ROLES, GetDetectiveTeamDrunkExcludes())
             end
-        -- Or build a list of the options based on what team is randomly chosen (innocent vs. everything else)
+        -- Or build a list of the options based on what team is randomly chosen (innocent vs. traitor vs. everything else)
         else
             if math.random() <= drunk_innocent_chance:GetFloat() then
                 role_options = GetTeamRoles(INNOCENT_ROLES, GetInnocentTeamDrunkExcludes())
+            elseif math.random() <= drunk_traitor_chance:GetFloat() then
+                role_options = GetTeamRoles(TRAITOR_ROLES, GetTraitorTeamDrunkExcludes())
             else
                 local excludes = GetIndependentTeamDrunkExcludes()
                 -- Add every non-innocent role (except those that are excluded)

--- a/gamemodes/terrortown/gamemode/roles/drunk/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/shared.lua
@@ -24,6 +24,11 @@ table.insert(ROLE_CONVARS[ROLE_DRUNK], {
     decimal = 2
 })
 table.insert(ROLE_CONVARS[ROLE_DRUNK], {
+    cvar = "ttt_drunk_traitor_chance",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 2
+})
+table.insert(ROLE_CONVARS[ROLE_DRUNK], {
     cvar = "ttt_drunk_become_clown",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
@@ -122,6 +122,10 @@ table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     decimal = 0
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
+    cvar = "ttt_vampire_drain_mute_target",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     cvar = "ttt_vampire_kill_credits",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -19,7 +19,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.6.11"
+CR_VERSION = "1.6.12"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Additions**
- Added ability to set chance a drunk will become a traitor explicitly rather than the default logic where traitor roles have the same chance as all non-innocent roles (Disabled by default)
- Added ability to mute a player being drained by a vampire (Disabled by default)