### PR TITLE
Misc. changes and fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,9 @@
 - Changed usages of `IsAdmin` to check `IsSuperAdmin` as well to work around the rare case where `IsAdmin` was `false` where `IsSuperAdmin` was `true`
   - Fixes locking SuperAdmins out of the Role Weapons system in certain circumstances
 
+### Fixes
+- Fixed Old Man not dying when taking damage from something other than a player
+
 ## 1.6.13
 **Released: September 10th, 2022**\
 Includes all beta updates from [1.6.5](#165-beta) to [1.6.12](#1612-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Fixed Old Man not dying when taking damage from something other than a player
+- Fixed error in the weapon switch HUD when dropping weapons that use the base GMod weapon instead of the base TTT weapon
 
 ## 1.6.13
 **Released: September 10th, 2022**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.6.14
+**Released:**
+
+### Changes
+- Changed usages of `IsAdmin` to check `IsSuperAdmin` as well to work around the rare case where `IsAdmin` was `false` where `IsSuperAdmin` was `true`
+  - Fixes locking SuperAdmins out of the Role Weapons system in certain circumstances
+
 ## 1.6.13
 **Released: September 10th, 2022**\
 Includes all beta updates from [1.6.5](#165-beta) to [1.6.12](#1612-beta).

--- a/gamemodes/terrortown/gamemode/cl_roleweapons.lua
+++ b/gamemodes/terrortown/gamemode/cl_roleweapons.lua
@@ -26,7 +26,7 @@ local function DoesValueMatch(item, data, value)
 end
 
 local function OpenDialog(client)
-    if not client:IsAdmin() then
+    if not client:IsAdmin() and not client:IsSuperAdmin() then
         ErrorNoHalt("ERROR: You must be an administrator to open the Role Weapons Configuration dialog\n")
         return
     end

--- a/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -694,7 +694,7 @@ local function GetDrainRate()
     local ply = LocalPlayer()
     if (not IsValid(ply)) or ply:IsSpec() then return 0 end
 
-    if ply:IsAdmin() or ply:IsDetectiveTeam() then
+    if ply:IsAdmin() or ply:IsSuperAdmin() or ply:IsDetectiveTeam() then
         return GetGlobalFloat("ttt_voice_drain_admin", 0)
     else
         return GetGlobalFloat("ttt_voice_drain_normal", 0)

--- a/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -114,8 +114,8 @@ function WSWITCH:DrawWeapon(x, y, c, wep)
     if not IsValid(wep) then return false end
 
     local name = TryTranslation(wep:GetPrintName() or wep.PrintName or "...")
-    local cl1 = wep.Clip1 and wep:Clip1() or -1
-    local am1 = wep.Ammo1 and wep:Ammo1() or false
+    local cl1 = wep.Clip1 and IsValid(wep:GetOwner()) and wep:Clip1() or -1
+    local am1 = wep.Ammo1 and IsValid(wep:GetOwner()) and wep:Ammo1() or false
     local ammo = false
 
     -- Clip1 will be -1 if a melee weapon

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -19,7 +19,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.6.13"
+CR_VERSION = "1.6.14"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -124,7 +124,7 @@ function GM:TTTScoreboardColorForPlayer(ply)
 
     if ply:SteamID() == "STEAM_0:0:1963640" then
         return namecolor.dev
-    elseif ply:IsAdmin() and GetGlobalBool("ttt_highlight_admins", true) then
+    elseif (ply:IsAdmin() or ply:IsSuperAdmin()) and GetGlobalBool("ttt_highlight_admins", true) then
         return namecolor.admin
     end
     return namecolor.default

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -739,7 +739,9 @@ function WEPS.ForcePrecache()
 end
 
 net.Receive("TTT_ConfigureRoleWeapons", function(len, ply)
-    if not IsPlayer(ply) or not ply:IsAdmin() then
+    if not IsPlayer(ply) then return end
+
+    if not ply:IsAdmin() and not ply:IsSuperAdmin() then
         ErrorNoHalt("Player without admin access attempted to configure role weapons: " .. ply:Nick() .. " (" .. ply:SteamID() .. ")\n")
         return
     end


### PR DESCRIPTION
**Changes**
- Changed usages of `IsAdmin` to check `IsSuperAdmin` as well to work around the rare case where `IsAdmin` was `false` where `IsSuperAdmin` was `true`
  - Fixes locking SuperAdmins out of the Role Weapons system in certain circumstances

**Fixes**
- Fixed Old Man not dying when taking damage from something other than a player
- Fixed error in the weapon switch HUD when dropping weapons that use the base GMod weapon instead of the base TTT weapon