### PR TITLE
Misc. changes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -491,6 +491,14 @@ Called before players are assigned a traitor role, allowing the available roles 
 - *detectives* - The table of available player choices that will be (or have already been) assigned a detective role. Manipulating this table will have no effect
 - *detectiveCount* - The number of players that will be (or have already been) assigned a detective role
 
+### TTTShopRandomBought(client, item)
+Called when a player buys a random item from the shop.\
+*Realm:* Client\
+*Added in:* 1.6.16\
+*Parameters:*
+- *client* - The player who is buying a random item
+- *item* - The random item that was selected
+
 ### TTTSmokeGrenadeExtinguish(ent_class, ent_pos)
 Called when a smoke grenade extinguishes a fire entity.\
 *Realm:* Server\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -134,6 +134,7 @@ Called for each player who is alive during the `Tick` hook.\
 Called after a player has been resurrected by a device that also changes their role.\
 *Realm:* Server\
 *Added in:* 1.3.1\
+*Deprecated in:* 1.6.16\
 *Parameters:*
 - *ply* - The player using the resurrection device
 - *tgt* - The target player being resurrected
@@ -146,6 +147,15 @@ Called after a player's role has changed.\
 - *ply* - The player whose role is being changed
 - *oldRole* - The role the player had before this change
 - *newRole* - The role the player is changing to
+
+### TTTPlayerRoleChangedByItem(ply, tgt, item)
+Called after a player's role has been changed by a weapon or item.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The player using the resurrection device
+- *tgt* - The target player being resurrected
+- *item* - The weapon or item used to change the target's role
 
 ### TTTPlayerSpawnForRound(ply, deadOnly)
 Called before a player is spawned for a round. Also used when reviving a player (via a defib, zombie conversion, etc.).\
@@ -706,6 +716,14 @@ Called before a ragdoll's name (shown when you look at a ragdoll) is rendered.\
 *Return:*
 - *text* - The new text value to use or the original passed into the hook. Return `false` to not show text at all
 - *clr* - The new clr value to use or the original passed into the hook
+
+### TTTTurncoatTeamChanged(ply, traitor)
+Called when a turncoat's team is changed
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The player who triggered the turncoat team change (most likely would be the turncoat themselves)
+- *traitor* - Whether the turncoat is changing to the traitor team
 
 ### TTTTutorialRoleEnabled(role)
 Called before a role's tutorial page is rendered. This can be used to allow a page to be shown when it normally would not be because the role is disabled. Useful for situations like showing the Zombie tutorial page when the Mad Scientist is enabled (because the Mad Scientist creates Zombies).\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -94,6 +94,15 @@ Called after player information such as role, health, and ammo and equipment inf
 - *labelY* - The Y value representing the first clear space to add information
 - *activeLabels* - The list of current active additional labels. Used to determine the labelY offset to use via: `labelY = labelY + (20 * #activeLabels)`. Be sure to insert an entry when you add your own label so other addons can space appropriately. *(Added in 1.6.11)*
 
+### TTTInformantScanStageChanged(ply, tgt, stage)
+Called when an informant has scanned additional information from a target player.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The informant performing the scan
+- *tgt* - The player being scanned
+- *stage* - The new scan stage
+
 ### TTTKarmaGiveReward(ply, reward, victim)
 Called before a player is rewarded with karma. Used to block a player's karma reward.\
 *Realm:* Server\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -784,6 +784,24 @@ Called after globals are synced but but before role colors and strings are set. 
 *Realm:* Client and Server\
 *Added in:* 1.2.7
 
+### TTTVampireBodyEaten(ply, ent, living, healed)
+Called after a vampire eats a body.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The vampire eating the body
+- *ent* - The target entity. Generally either a player or a ragdoll
+- *living* - Whether the target entity was living at the time they were eaten
+- *healed* - The amount of health the player gained from eating the body
+
+### TTTVampireInvisibilityChange(ply, invisible)
+Called when a vampire starts or ends their invisibility.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The vampire changing invisibility state
+- *ent* - The target entity. Generally either a player or a ragdoll
+
 ### TTTWinCheckBlocks(winBlocks)
 Called after the `TTTCheckForWins` has already been called, allowing for an addon to block a win. Used for roles like the clown and the drunk to have them activate when the round would normally end the first time.\
 *Realm:* Server\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -115,6 +115,14 @@ Called before a player's karma effect is decided. Used to determine if a player 
 
 *Return:* `true` if the attacker should be penalized or `false` if they should not. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
 
+### TTTMadScientistZombifyBegin(ply, tgt)
+Called when a mad scientist begins zombifying a target.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The mad scientist doing the zombifying
+- *tgt* - The target being zombified
+
 ### TTTPaladinAuraHealed(ply, tgt, healed)
 Called when a paladin heals a target.\
 *Realm:* Server\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -115,6 +115,15 @@ Called before a player's karma effect is decided. Used to determine if a player 
 
 *Return:* `true` if the attacker should be penalized or `false` if they should not. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
 
+### TTTPaladinAuraHealed(ply, tgt, healed)
+Called when a paladin heals a target.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ply* - The paladin doing the healing
+- *tgt* - The target being healed
+- *healed* - The amount healed
+
 ### TTTPlayerAliveClientThink(client, ply)
 Called for each player who is alive during the `Think` hook.\
 *Realm:* Client\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -465,6 +465,14 @@ Called before players are assigned a traitor role, allowing the available roles 
 - *detectives* - The table of available player choices that will be (or have already been) assigned a detective role. Manipulating this table will have no effect
 - *detectiveCount* - The number of players that will be (or have already been) assigned a detective role
 
+### TTTSmokeGrenadeExtinguish(ent_class, ent_pos)
+Called when a smoke grenade extinguishes a fire entity.\
+*Realm:* Server\
+*Added in:* 1.6.16\
+*Parameters:*
+- *ent_class* - The class of fire entity that was extinguished
+- *ent_pos* - The position of the fire entity that was extinguished
+
 ### TTTSpectatorHUDKeyPress(ply, tgt, powers)
 Called when a player who is being shown a role-specific spectator HUD presses a button, allowing the hook to intercept that button press and perform specific logic if necessary.\
 *Realm:* Server\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Developer
 - Deprecated `TTTPlayerDefibRoleChange`
+- Added `TTTPaladinAuraHealed` which is called when a paladin heals a target with their aura
 - Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
 - Added `TTTSmokeGrenadeExtinguish` which is called when a smoke grenade extinguishes a fire entity
 - Added `TTTTurncoatTeamChanged` which is called when the turncoat changes teams

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Developer
 - Deprecated `TTTPlayerDefibRoleChange`
+- Added `TTTMadScientistZombifyBegin` which is called when a mad scientist begins to zombify a target
 - Added `TTTPaladinAuraHealed` which is called when a paladin heals a target with their aura
 - Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
 - Added `TTTSmokeGrenadeExtinguish` which is called when a smoke grenade extinguishes a fire entity

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - Added `TTTMadScientistZombifyBegin` which is called when a mad scientist begins to zombify a target
 - Added `TTTPaladinAuraHealed` which is called when a paladin heals a target with their aura
 - Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
+- Added `TTTShopRandomBought` which is called when a player buys a random item from the shop
 - Added `TTTSmokeGrenadeExtinguish` which is called when a smoke grenade extinguishes a fire entity
 - Added `TTTTurncoatTeamChanged` which is called when the turncoat changes teams
 - Added `TTTVampireBodyEaten` and `TTTVampireInvisibilityChange` to help track vampire ability usage

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 1.6.16
+**Released: November 26th, 2022**
+
+### Developer
+- Deprecated `TTTPlayerDefibRoleChange`
+- Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
+- Added `TTTTurncoatTeamChanged` which is called when the turncoat changes teams
+
 ## 1.6.15
 **Released: November 12th, 2022**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Developer
 - Deprecated `TTTPlayerDefibRoleChange`
+- Added `TTTInformantScanStageChanged` which is called when an informant has scanned additional information from a target player
 - Added `TTTMadScientistZombifyBegin` which is called when a mad scientist begins to zombify a target
 - Added `TTTPaladinAuraHealed` which is called when a paladin heals a target with their aura
 - Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Developer
 - Deprecated `TTTPlayerDefibRoleChange`
 - Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
+- Added `TTTSmokeGrenadeExtinguish` which is called when a smoke grenade extinguishes a fire entity
 - Added `TTTTurncoatTeamChanged` which is called when the turncoat changes teams
 - Added `TTTVampireBodyEaten` and `TTTVampireInvisibilityChange` to help track vampire ability usage
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - Deprecated `TTTPlayerDefibRoleChange`
 - Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
 - Added `TTTTurncoatTeamChanged` which is called when the turncoat changes teams
+- Added `TTTVampireBodyEaten` and `TTTVampireInvisibilityChange` to help track vampire ability usage
 
 ## 1.6.15
 **Released: November 12th, 2022**

--- a/gamemodes/terrortown/entities/entities/ttt_smokegrenade_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_smokegrenade_proj.lua
@@ -77,9 +77,11 @@ function ENT:Explode(tr)
             local entities = ents.FindInSphere(pos, 100)
             local was_extinguished = false
             for _, e in ipairs(entities) do
-                if table.HasValue(target_ents, e:GetClass()) then
+                local ent_class = e:GetClass()
+                if table.HasValue(target_ents, ent_class) then
                     SafeRemoveEntity(e)
                     was_extinguished = true
+                    hook.Call("TTTSmokeGrenadeExtinguish", nil, ent_class, pos)
                 end
             end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -163,6 +163,7 @@ if SERVER then
         end
 
         local owner = self:GetOwner()
+        hook.Call("TTTPlayerRoleChangedByItem", nil, owner, owner, self)
 
         net.Start("TTT_Bodysnatched")
         net.Send(ply)
@@ -176,9 +177,7 @@ if SERVER then
         net.Broadcast()
 
         owner:SetRole(role)
-        if SERVER then
-            ply:MoveRoleState(owner, true)
-        end
+        ply:MoveRoleState(owner, true)
         owner:SelectWeapon("weapon_zm_carry")
         owner:SetNWBool("WasBodysnatcher", true)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
@@ -200,7 +200,9 @@ if SERVER then
         net.Send(ply)
 
         local owner = self:GetOwner()
+        -- DEPRECATED in 1.6.16
         hook.Call("TTTPlayerDefibRoleChange", nil, owner, ply)
+        hook.Call("TTTPlayerRoleChangedByItem", nil, owner, ply, self)
 
         net.Start("TTT_Hypnotised")
         net.WriteString(ply:Nick())

--- a/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_inf_scanner.lua
@@ -1,13 +1,6 @@
 AddCSLuaFile()
 
 local IsValid = IsValid
-local math = math
-local pairs = pairs
-local player = player
-local surface = surface
-local string = string
-
-local GetAllPlayers = player.GetAll
 
 DEFINE_BASECLASS "weapon_tttbase"
 
@@ -63,12 +56,13 @@ end
 
 function SWEP:Holster()
     if SERVER and IsValid(self:GetOwner()) then
-        self:GetOwner():SetNWInt("TTTInformantScannerState", INFORMANT_SCANNER_IDLE)
-        self:GetOwner():SetNWString("TTTInformantScannerTarget", "")
-        self:GetOwner():SetNWString("TTTInformantScannerMessage", "")
-        self:GetOwner():SetNWFloat("TTTInformantScannerStartTime", -1)
-        self:GetOwner():SetNWFloat("TTTInformantScannerTargetLostTime", -1)
-        self:GetOwner():SetNWFloat("TTTInformantScannerCooldown", -1)
+        local owner = self:GetOwner()
+        owner:SetNWInt("TTTInformantScannerState", INFORMANT_SCANNER_IDLE)
+        owner:SetNWString("TTTInformantScannerTarget", "")
+        owner:SetNWString("TTTInformantScannerMessage", "")
+        owner:SetNWFloat("TTTInformantScannerStartTime", -1)
+        owner:SetNWFloat("TTTInformantScannerTargetLostTime", -1)
+        owner:SetNWFloat("TTTInformantScannerCooldown", -1)
     end
     return true
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
@@ -232,6 +232,9 @@ if SERVER then
 
     function SWEP:Begin(body, bone)
         local ply = bodyply(body)
+        local owner = self:GetOwner()
+
+        hook.Call("TTTMadScientistZombifyBegin", nil, owner, ply)
 
         if not ply then
             self:Error("INVALID TARGET")
@@ -247,7 +250,7 @@ if SERVER then
         self:SetBegin(CurTime())
         self:SetMessage("ZOMBIFYING " .. string.upper(ply:Nick()))
 
-        self:GetOwner():EmitSound(hum, 75, math.random(98, 102), 1)
+        owner:EmitSound(hum, 75, math.random(98, 102), 1)
 
         self.Target = body
         self.Bone = bone

--- a/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_mad_zombificator.lua
@@ -195,7 +195,9 @@ if SERVER then
         net.Send(ply)
 
         local owner = self:GetOwner()
+        -- DEPRECATED in 1.6.16
         hook.Call("TTTPlayerDefibRoleChange", nil, owner, ply)
+        hook.Call("TTTPlayerRoleChangedByItem", nil, owner, ply, self)
 
         net.Start("TTT_Zombified")
         net.WriteString(ply:Nick())

--- a/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
@@ -182,7 +182,9 @@ if SERVER then
         net.Send(ply)
 
         local owner = self:GetOwner()
+        -- DEPRECATED in 1.6.16
         hook.Call("TTTPlayerDefibRoleChange", nil, owner, ply)
+        hook.Call("TTTPlayerRoleChangedByItem", nil, owner, ply, self)
 
         ply:SpawnForRound(true)
         ply:SetCredits(credits)

--- a/gamemodes/terrortown/entities/weapons/weapon_mhl_badge.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_mhl_badge.lua
@@ -164,6 +164,7 @@ if SERVER then
         SendFullStateUpdate()
 
         local owner = self:GetOwner()
+        hook.Call("TTTPlayerRoleChangedByItem", nil, owner, ply, self)
 
         -- Broadcast the event
         net.Start("TTT_Deputized")

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -340,7 +340,7 @@ function SWEP:DoHeal(living)
     local owner = self:GetOwner()
     local health = math.min(owner:Health() + vamheal, owner:GetMaxHealth() + vamoverheal)
     hook.Call("TTTVampireBodyEaten", nil, owner, self.TargetEntity, living, health - owner:Health())
-    owner:SetHealth(healh)
+    owner:SetHealth(health)
 end
 
 function SWEP:UnfreezeTarget()

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -337,7 +337,10 @@ function SWEP:DoHeal(living)
     end
 
     local vamheal = vampire_fang_heal:GetInt()
-    self:GetOwner():SetHealth(math.min(self:GetOwner():Health() + vamheal, self:GetOwner():GetMaxHealth() + vamoverheal))
+    local owner = self:GetOwner()
+    local health = math.min(owner:Health() + vamheal, owner:GetMaxHealth() + vamoverheal)
+    hook.Call("TTTVampireBodyEaten", nil, owner, self.TargetEntity, living, health - owner:Health())
+    owner:SetHealth(healh)
 end
 
 function SWEP:UnfreezeTarget()
@@ -412,11 +415,13 @@ function SWEP:Think()
         owner:SetColor(Color(255, 255, 255, 0))
         owner:SetMaterial("sprites/heatwave")
         owner:EmitSound("weapons/ttt/fade.wav")
+        hook.Call("TTTVampireInvisibilityChange", nil, owner, true)
     elseif self:Clip1() >= 40 and self.fading then
         self.fading = false
         owner:SetColor(COLOR_WHITE)
         owner:SetMaterial("models/glass")
         owner:EmitSound("weapons/ttt/unfade.wav")
+        hook.Call("TTTVampireInvisibilityChange", nil, owner, false)
     end
 
     if self:GetState() >= STATE_EAT then

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -286,6 +286,9 @@ function SWEP:DoConvert()
     ply:SetVampirePrime(false)
     ply:PrintMessage(HUD_PRINTCENTER, "You have become a Vampire! Use your fangs to suck blood or fade from view")
 
+    local owner = self:GetOwner()
+    hook.Call("TTTPlayerRoleChangedByItem", nil, owner, ply, self)
+
     net.Start("TTT_Vampified")
     net.WriteString(ply:Nick())
     net.Broadcast()

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -160,6 +160,7 @@ function SWEP:PrimaryAttack()
             if hitEnt:Health() <= self.Primary.Damage and self:ShouldConvert() then
                 owner:AddCredits(1)
                 LANG.Msg(owner, "credit_all", { role = ROLE_STRINGS[ROLE_ZOMBIE], num = 1 })
+                hook.Call("TTTPlayerRoleChangedByItem", nil, owner, hitEnt, self)
                 hitEnt:RespawnAsZombie()
             end
 

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -876,8 +876,10 @@ local function TraitorMenuPopup()
 
             if #buyable_items == 0 then return end
 
-            dlist:SelectPanel(buyable_items[math.random(1, #buyable_items)])
+            local random_panel = buyable_items[math.random(1, #buyable_items)]
+            dlist:SelectPanel(random_panel)
             dconfirm.DoClick()
+            hook.Call("TTTShopRandomBought", nil, LocalPlayer(), random_panel.item)
         end
 
         FillEquipmentList(GetEquipmentForRole(ply:GetRole(), ply:IsDetectiveLike() and not ply:IsDetectiveTeam(), false))

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -227,6 +227,7 @@ local function Scan(ply, target)
                 ply:SetNWString("TTTInformantScannerMessage", "")
                 ply:SetNWFloat("TTTInformantScannerStartTime", -1)
             end
+            hook.Call("TTTInformantScanStageChanged", nil, ply, target, stage)
             target:SetNWInt("TTTInformantScanStage", stage)
         end
     else

--- a/gamemodes/terrortown/gamemode/roles/paladin/paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/paladin.lua
@@ -37,6 +37,7 @@ hook.Add("TTTBeginRound", "Paladin_RoleFeatures_TTTBeginRound", function()
                 for _, v in pairs(GetAllPlayers()) do
                     if v:IsActive() and (not v:IsPaladin() or paladinHealSelf) and v:GetPos():Distance(p:GetPos()) <= paladinRadius and v:Health() < v:GetMaxHealth() then
                         local health = math.min(v:GetMaxHealth(), v:Health() + paladinHeal)
+                        hook.Call("TTTPaladinAuraHealed", nil, p, v, health - v:Health())
                         v:SetHealth(health)
                     end
                 end

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -77,7 +77,7 @@ hook.Add("TTTPlayerSpawnForRound", "Parasite_TTTPlayerSpawnForRound", function(p
 end)
 
 -- Un-haunt the device owner if they used their device on the parasite
-hook.Add("TTTPlayerDefibRoleChange", "Parasite_TTTPlayerDefibRoleChange", function(ply, tgt)
+hook.Add("TTTPlayerRoleChangedByItem", "Parasite_TTTPlayerRoleChangedByItem", function(ply, tgt, item)
     if tgt:IsParasite() and tgt:GetNWString("ParasiteInfectingTarget", nil) == ply:SteamID64() then
         ply:SetNWBool("ParasiteInfected", false)
     end

--- a/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
@@ -89,7 +89,7 @@ hook.Add("TTTPlayerSpawnForRound", "Phantom_TTTPlayerSpawnForRound", function(pl
 end)
 
 -- Un-haunt the device owner if they used their device on the phantom
-hook.Add("TTTPlayerDefibRoleChange", "Phantom_TTTPlayerDefibRoleChange", function(ply, tgt)
+hook.Add("TTTPlayerRoleChangedByItem", "Phantom_TTTPlayerRoleChangedByItem", function(ply, tgt, item)
     if tgt:IsPhantom() and tgt:GetNWString("HauntingTarget", nil) == ply:SteamID64() then
         ply:SetNWBool("Haunted", false)
     end

--- a/gamemodes/terrortown/gamemode/roles/turncoat/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/turncoat/shared.lua
@@ -11,6 +11,11 @@ ROLE_IS_ACTIVE[ROLE_TURNCOAT] = function(ply)
 end
 
 function SetTurncoatTeam(ply, traitor)
+    TRAITOR_ROLES[ROLE_TURNCOAT] = traitor
+    INNOCENT_ROLES[ROLE_TURNCOAT] = not traitor
+
+    UpdateRoleColours()
+
     if SERVER then
         net.Start("TTT_TurncoatTeamChange")
         net.WriteBool(traitor)
@@ -22,12 +27,8 @@ function SetTurncoatTeam(ply, traitor)
         if IsPlayer(ply) then
             UpdateAssassinTargets(ply)
         end
+        hook.Call("TTTTurncoatTeamChanged", nil, ply, traitor)
     end
-
-    TRAITOR_ROLES[ROLE_TURNCOAT] = traitor
-    INNOCENT_ROLES[ROLE_TURNCOAT] = not traitor
-
-    UpdateRoleColours()
 end
 
 if CLIENT then

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -19,7 +19,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.6.15"
+CR_VERSION = "1.6.16"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
**Developer**
- Deprecated `TTTPlayerDefibRoleChange`
- Added `TTTInformantScanStageChanged` which is called when an informant has scanned additional information from a target player
- Added `TTTMadScientistZombifyBegin` which is called when a mad scientist begins to zombify a target
- Added `TTTPaladinAuraHealed` which is called when a paladin heals a target with their aura
- Added `TTTPlayerRoleChangedByItem` to replace `TTTPlayerDefibRoleChange` and implemented it for bodysnatcher, hypnotist, mad scientist, marshal, paramedic, vampire, and zombie
- Added `TTTShopRandomBought` which is called when a player buys a random item from the shop
- Added `TTTSmokeGrenadeExtinguish` which is called when a smoke grenade extinguishes a fire entity
- Added `TTTTurncoatTeamChanged` which is called when the turncoat changes teams
- Added `TTTVampireBodyEaten` and `TTTVampireInvisibilityChange` to help track vampire ability usage