### PR TITLE
Misc. fixes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -84,6 +84,15 @@ Called before the event icon for the "round finished" event is rendered in the e
 - *winString* - The new winString value to use or the original passed into the hook
 - *roleString* - The new roleString value to use or the original passed into the hook
 
+### TTTEquipmentTabs(dsheet)
+Allows creation of new tabs for the equipment (shop) menu.\
+*Realm:* Client\
+*Added in:* 1.0.0\
+*Parameters:*
+- *dsheet* - The [DPropertySheet](https://wiki.facepunch.com/gmod/DPropertySheet) used by the equipment window
+
+*Return:* If `true`, the equipment window will show even if the player doesn't have any of the default tabs. *(Added in 1.7.3)*
+
 ### TTTHUDInfoPaint(client, labelX, labelY, activeLabels)
 Called after player information such as role, health, and ammo and equipment information such as radar cooldown and disguiser activation are drawn on the screen. Used to write additional persistent text on the screen for player reference.\
 *Realm:* Client\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -524,6 +524,21 @@ Called before players are assigned a traitor role, allowing the available roles 
 - *detectives* - The table of available player choices that will be (or have already been) assigned a detective role. Manipulating this table will have no effect
 - *detectiveCount* - The number of players that will be (or have already been) assigned a detective role
 
+### TTTSettingsConfigTabFields(sectionName, parentForm)
+Called after each section of the help menu's Config tab has been created, allowing developers to add controls to that section.\
+*Realm:* Client\
+*Added in:* 1.7.3\
+*Parameters:*
+- *sectionName* - The name of the section of the help menu's Settings tab that is being created. Expected values: Interface, Gameplay, Color, Language, BEM, Hitmarkers
+- *parentForm* - The parent [DForm](https://wiki.facepunch.com/gmod/DForm) for the section being processed
+
+### TTTSettingsConfigTabSections(parentPanel)
+Called after the Config tab of the help menu has been created, allowing developers to add sections to it.\
+*Realm:* Client\
+*Added in:* 1.7.3\
+*Parameters:*
+- *parentPanel* - The parent [DScrollPanel](https://wiki.facepunch.com/gmod/DScrollPanel) for the tab
+
 ### TTTShopRandomBought(client, item)
 Called when a player buys a random item from the shop.\
 *Realm:* Client\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -539,6 +539,17 @@ Called after the Config tab of the help menu has been created, allowing develope
 *Parameters:*
 - *parentPanel* - The parent [DScrollPanel](https://wiki.facepunch.com/gmod/DScrollPanel) for the tab
 
+### TTTSettingsRolesTabSections(role, parentForm)
+Called for each role, allowing developers to add a configuration section for it.\
+*Realm:* Client\
+*Added in:* 1.7.3\
+*Parameters:*
+- *role* - The ID of the role whose setting section is being added
+- *parentForm* - The parent [DForm](https://wiki.facepunch.com/gmod/DForm) for the role being processed
+
+*Return:*
+- *add_section* - Return `true` to add this role config section to the dialog. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
+
 ### TTTShopRandomBought(client, item)
 Called when a player buys a random item from the shop.\
 *Realm:* Client\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -400,9 +400,24 @@ Called before the round summary screen is shown. Used to modify the color, posit
 - *label* - The label to use when pairing the name and otherName together (see above) *(Added in 1.6.17)*
 
 ### TTTScoringWinTitle(wintype, wintitles, title)
-Called multiple times before the round end screen is shown with the winning team. For each tab of the round end screen that shows the winning team, this hook is first called with `WIN_INNOCENT` to get the default value and then called with the actual winning team. Return a new win title object to override what would normally be shown on the round end screen.\
+Called multiple times before the round end screen is shown with the winning team. For each tab of the round end screen that shows the winning team, this hook is first called with `WIN_INNOCENT` to get the default value and then called with the actual winning team. Return a new win title object to override what would normally be shown on the round end screen. This should be used by roles to customize what is shown on the round summary screen.\
 *Realm:* Client\
 *Added in:* 1.0.14\
+*Parameters:*
+- *wintype* - The round win type
+- *wintitles* - Table of default win title parameters
+- *title* - The currently selected win title
+
+*Return:*
+- *newTitle*
+  - *txt* - The translation string to use to get the winning team text
+  - *c* - The background [Color](https://wiki.facepunch.com/gmod/Color) to use
+  - *params* - Any parameters to use when translating `txt`
+
+### TTTScoringWinTitleOverride(wintype, wintitles, title)
+Called multiple times before the round end screen is shown with the winning team. For each tab of the round end screen that shows the winning team this is called with the winning team. Return a new win title object to override what would normally be shown on the round end screen. This should be used by external addons to change the look of the round summary screen, *not* by roles to set their custom win titles. For a role's custom win title, use `TTTScoringWinTitle` instead.\
+*Realm:* Client\
+*Added in:* 1.7.3\
 *Parameters:*
 - *wintype* - The round win type
 - *wintitles* - Table of default win title parameters

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -597,6 +597,8 @@ ttt_zombie_thrall_speed_bonus               0.15    // The amount of bonus speed
 ttt_zombie_respawn_health                   100     // The amount of health a player should respawn with when they are converted to a zombie thrall
 ttt_zombie_prime_convert_chance             1.0     // The chance that a prime zombie (e.g. player who spawned as a zombie originally) will convert other players who are killed by their claws to be zombies as well. Set to 0 to disable
 ttt_zombie_thrall_convert_chance            1.0     // The chance that a zombie thrall (e.g. non-prime zombie) will convert other players who are killed by their claws to be zombies as well. Set to 0 to disable
+ttt_zombie_friendly_fire                    2       // How to handle friendly fire damage between zombies. 0 - Do nothing. 1 - Reflect the damage back to the attacker. 2 - Negate the damage.
+ttt_zombie_respawn_block_win                0       // Whether a player respawning as a zombie blocks the round from ending, allowing them to join the winning team
 
 // Mad Scientist
 ttt_madscientist_is_monster                 0       // Whether the mad scientist should be treated as a member of the monster team (rather than the independent team)

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -47,6 +47,7 @@ ttt_jester_chance                           0.5     // The chance that a single 
 ttt_multiple_jesters_independents           0       // Whether more than one jester/independent should be allowed to spawn in each round. Enabling this will ignore ttt_independent_chance, ttt_jester_chance, ttt_single_jester_independent, and ttt_single_jester_independent_max_players
 ttt_jester_independent_pct                  0.13    // Percentage of players, rounded up, that can spawn as a jester or independent. Only used if ttt_multiple_jesters_independents is enabled
 ttt_jester_independent_max                  2       // The maximum number of players that can spawn as a jester or independent. Only used if ttt_multiple_jesters_independents is enabled
+ttt_jester_independent_chance               0.5     // The chance that a jester or independent will spawn in a round. Only used if ttt_multiple_jesters_independents is enabled
 // (Note: Only one independent or jester can spawn per round by default.)
 
 // Enable/Disable Individual Roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,10 @@
 # Release Notes
+
 ## 1.7.3 (Beta)
 **Released:**
+
+### Additions
+- Added `ttt_jester_independent_chance` convar to control the chance of a jester or independent when `ttt_multiple_jesters_independents` is enabled
 
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,7 @@
 - Added new return value to the `TTTEquipmentTabs` hook, allowing addons to add new tabs that open the dialog even if none of the default tabs normally would
 - Added new `TTTSettingsConfigTabFields` hook to make it easier to add to the existing help menu's Config tab sections
 - Added new `TTTSettingsConfigTabSections` hook to make it easier to add new sections to the help menu's Config tab
+- Added new `TTTSettingsRolesTabSections` hook to allow developers to add a configuration section for a role to the help menu's Roles tab
 - Changed the help menu's Config tab to use `DScrollPanel` instead of the deprecated `DPanelList`
 - Fixed `plymeta:IsZombieAlly` returning `true` for all independent roles rather than just other zombies and the mad scientist
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,9 @@
 # Release Notes
+## 1.7.3 (Beta)
+**Released:**
+
+### Fixes
+- Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
 
 ## 1.7.2 (Beta)
 **Released: January 21st, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Additions
 - Added `ttt_jester_independent_chance` convar to control the chance of a jester or independent when `ttt_multiple_jesters_independents` is enabled
+- Added `ttt_zombie_respawn_block_win` convar to control whether a player respawning as a zombie will block the end of the round (defaults to disabled)
 
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
 - Fixed `ttt_vampire_drain_mute_target` only blocking messages the first time
+- Fixed all independent roles seeing each other on the scoreboard
 
 ### Developer
 - Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,9 @@
 - Added `ttt_jester_independent_chance` convar to control the chance of a jester or independent when `ttt_multiple_jesters_independents` is enabled
 - Added `ttt_zombie_respawn_block_win` convar to control whether a player respawning as a zombie will block the end of the round (defaults to disabled)
 
+### Changes
+- Changed BEM and Hitmarkers settings to be in the Settings tabs instead of in their own tabs
+
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
 - Fixed `ttt_vampire_drain_mute_target` only blocking messages the first time

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ### Developer
 - Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens
 - Added new return value to the `TTTEquipmentTabs` hook, allowing addons to add new tabs that open the dialog even if none of the default tabs normally would
+- Fixed `plymeta:IsZombieAlly` returning `true` for all independent roles rather than just other zombies and the mad scientist
 
 ## 1.7.2 (Beta)
 **Released: January 21st, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 
 ### Changes
 - Changed BEM and Hitmarkers settings to be in the Settings tabs instead of in their own tabs
+- Renamed the "Settings" tab of the Help/Settings dialog to "Config" to make it slightly less confusing
 
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
@@ -18,6 +19,9 @@
 ### Developer
 - Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens
 - Added new return value to the `TTTEquipmentTabs` hook, allowing addons to add new tabs that open the dialog even if none of the default tabs normally would
+- Added new `TTTSettingsConfigTabFields` hook to make it easier to add to the existing help menu's Config tab sections
+- Added new `TTTSettingsConfigTabSections` hook to make it easier to add new sections to the help menu's Config tab
+- Changed the help menu's Config tab to use `DScrollPanel` instead of the deprecated `DPanelList`
 - Fixed `plymeta:IsZombieAlly` returning `true` for all independent roles rather than just other zombies and the mad scientist
 
 ## 1.7.2 (Beta)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
+- Fixed `ttt_vampire_drain_mute_target` only blocking messages the first time
 
 ### Developer
 - Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 
 ### Developer
 - Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens
+- Added new return value to the `TTTEquipmentTabs` hook, allowing addons to add new tabs that open the dialog even if none of the default tabs normally would
 
 ## 1.7.2 (Beta)
 **Released: January 21st, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,9 @@
 ### Fixes
 - Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
 
+### Developer
+- Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens
+
 ## 1.7.2 (Beta)
 **Released: January 21st, 2023**
 

--- a/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
@@ -85,6 +85,7 @@ SWEP.WorldModel = "models/weapons/w_c4.mdl"
 
 SWEP.AutoSpawnable = false
 SWEP.NoSights = true
+SWEP.BlockShopRandomization = true
 
 local DEFIB_IDLE = 0
 local DEFIB_BUSY = 1

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_bomb_station.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_bomb_station.lua
@@ -50,6 +50,7 @@ SWEP.WeaponID = AMMO_HEALTHSTATION
 
 SWEP.AllowDrop = false
 SWEP.NoSights = true
+SWEP.BlockShopRandomization = true
 
 function SWEP:OnDrop()
     self:Remove()

--- a/gamemodes/terrortown/entities/weapons/weapon_qua_station_bomb.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_qua_station_bomb.lua
@@ -59,6 +59,7 @@ SWEP.WeaponID = AMMO_STATIONBOMB
 
 SWEP.AllowDrop = false
 SWEP.NoSights = true
+SWEP.BlockShopRandomization = true
 
 -- settings
 local maxdist = 64

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -110,22 +110,24 @@ function SWEP:Initialize()
         if GetConVar("ttt_vampire_drain_mute_target"):GetBool() then
             hook.Add("PlayerCanSeePlayersChat", "Vampire_PlayerCanSeePlayersChat_" .. self:EntIndex(), function(text, team_only, listener, speaker)
                 if not IsPlayer(listener) or not IsPlayer(speaker) then return end
-                if self.TargetEntityChatWarned then return end
 
                 if speaker == self.TargetEntity then
-                    self.TargetEntityChatWarned = true
-                    speaker:PrintMessage(HUD_PRINTTALK, "You cannot speak while " .. ROLE_STRINGS_EXT[ROLE_VAMPIRE]  .. " is draining your blood.")
+                    if not self.TargetEntityChatWarned then
+                        self.TargetEntityChatWarned = true
+                        speaker:PrintMessage(HUD_PRINTTALK, "You cannot speak while " .. ROLE_STRINGS_EXT[ROLE_VAMPIRE]  .. " is draining your blood.")
+                    end
                     return false
                 end
             end)
 
             hook.Add("PlayerCanHearPlayersVoice", "Vampire_PlayerCanHearPlayersVoice_" .. self:EntIndex(), function(listener, speaker)
                 if not IsPlayer(listener) or not IsPlayer(speaker) then return end
-                if self.TargetEntityVoiceWarned then return end
 
                 if speaker == self.TargetEntity then
-                    self.TargetEntityVoiceWarned = true
-                    speaker:PrintMessage(HUD_PRINTTALK, "You cannot speak while " .. ROLE_STRINGS_EXT[ROLE_VAMPIRE]  .. " is draining your blood.")
+                    if not self.TargetEntityVoiceWarned then
+                        self.TargetEntityVoiceWarned = true
+                        speaker:PrintMessage(HUD_PRINTTALK, "You cannot speak while " .. ROLE_STRINGS_EXT[ROLE_VAMPIRE]  .. " is draining your blood.")
+                    end
                     return false, false
                 end
             end)

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -960,7 +960,8 @@ local function TraitorMenuPopup()
         show = true
     end
 
-    hook.Run("TTTEquipmentTabs", dsheet)
+    local new_show = hook.Run("TTTEquipmentTabs", dsheet)
+    if new_show then show = new_show end
 
     dframe:MakePopup()
     dframe:SetKeyboardInputEnabled(false)

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -105,13 +105,12 @@ function HELPSCRN:Show()
     dtabs:AddSheet(GetTranslation("help_tut"), tutparent, "icon16/book_open.png", false, false, GetTranslation("help_tut_tip"))
 
     -- Settings
-    local dsettings = vgui.Create("DPanelList", dtabs)
+    local dsettings = vgui.Create("DScrollPanel", dtabs)
     dsettings:StretchToParent(0, 0, padding, 0)
-    dsettings:EnableVerticalScrollbar()
     dsettings:SetPadding(10)
-    dsettings:SetSpacing(10)
 
-    self:CreateSettings(dsettings)
+    self:CreateConfig(dsettings)
+    hook.Call("TTTSettingsConfigTabSections", nil, dsettings)
 
     dtabs:AddSheet(GetTranslation("help_settings"), dsettings, "icon16/wrench.png", false, false, GetTranslation("help_settings_tip"))
 
@@ -666,10 +665,12 @@ function HELPSCRN:CreateTutorial(parent)
     end
 end
 
-function HELPSCRN:CreateSettings(dsettings)
+function HELPSCRN:CreateConfig(dsettings)
     --- Interface area
 
     local dgui = vgui.Create("DForm", dsettings)
+    dgui:Dock(TOP)
+    dgui:DockMargin(0, 0, 5, 10)
     dgui:SetName(GetTranslation("set_title_gui"))
 
     local cb = nil
@@ -739,11 +740,15 @@ function HELPSCRN:CreateSettings(dsettings)
     cb = dgui:CheckBox(GetTranslation("set_bypass_culling"), "ttt_bypass_culling")
     cb:SetTooltip(GetTranslation("set_bypass_culling_tip"))
 
+    hook.Call("TTTSettingsConfigTabFields", nil, "Interface", dgui)
+
     dsettings:AddItem(dgui)
 
     --- Gameplay area
 
     local dplay = vgui.Create("DForm", dsettings)
+    dplay:Dock(TOP)
+    dplay:DockMargin(0, 0, 5, 10)
     dplay:SetName(GetTranslation("set_title_play"))
 
     cb = dplay:CheckBox(GetPTranslation("set_avoid_det", {detective = ROLE_STRINGS[ROLE_DETECTIVE]}), "ttt_avoid_detective")
@@ -758,11 +763,15 @@ function HELPSCRN:CreateSettings(dsettings)
     mute:SetValue(GetConVar("ttt_mute_team_check"):GetBool())
     mute:SetTooltip(GetTranslation("set_mute_tip"))
 
+    hook.Call("TTTSettingsConfigTabFields", nil, "Gameplay", dplay)
+
     dsettings:AddItem(dplay)
 
     -- Color area
 
     local dcolor = vgui.Create("DForm", dsettings)
+    dcolor:Dock(TOP)
+    dcolor:DockMargin(0, 0, 5, 10)
     dcolor:DoExpansion(false)
     dcolor:SetName(GetTranslation("set_color_mode"))
 
@@ -917,11 +926,15 @@ function HELPSCRN:CreateSettings(dsettings)
 
     dcolor:AddItem(dcolmon)
 
+    hook.Call("TTTSettingsConfigTabFields", nil, "Color", dcolor)
+
     dsettings:AddItem(dcolor)
 
     --- Language area
 
     local dlanguage = vgui.Create("DForm", dsettings)
+    dlanguage:Dock(TOP)
+    dlanguage:DockMargin(0, 0, 5, 10)
     dlanguage:DoExpansion(false)
     dlanguage:SetName(GetTranslation("set_title_lang"))
 
@@ -941,11 +954,15 @@ function HELPSCRN:CreateSettings(dsettings)
     dlanguage:Help(GetTranslation("set_lang"))
     dlanguage:AddItem(dlang)
 
+    hook.Call("TTTSettingsConfigTabFields", nil, "Language", dlanguage)
+
     dsettings:AddItem(dlanguage)
 
     -- BEM settings
 
     local dbemsettings = vgui.Create("DForm", dsettings)
+    dbemsettings:Dock(TOP)
+    dbemsettings:DockMargin(0, 0, 5, 10)
     dbemsettings:DoExpansion(false)
     dbemsettings:SetName("BEM settings")
 
@@ -965,11 +982,15 @@ function HELPSCRN:CreateSettings(dsettings)
     dbemsettings:CheckBox("Sort alphabetically", "ttt_sort_alphabetically")
     dbemsettings:CheckBox("Sort by slot first", "ttt_sort_by_slot_first")
 
+    hook.Call("TTTSettingsConfigTabFields", nil, "BEM", dbemsettings)
+
     dsettings:AddItem(dbemsettings)
 
     -- Hitmarkers settings
 
     local dmarkers = vgui.Create("DForm", dsettings)
+    dmarkers:Dock(TOP)
+    dmarkers:DockMargin(0, 0, 5, 10)
     dmarkers:DoExpansion(false)
     dmarkers:SetName("Hitmarkers settings")
 
@@ -981,6 +1002,8 @@ function HELPSCRN:CreateSettings(dsettings)
     dmarkers:CheckBox("Enabled", "hm_enabled")
     dmarkers:CheckBox("Show criticals", "hm_showcrits")
     dmarkers:CheckBox("Play hit sound", "hm_hitsound")
+
+    hook.Call("TTTSettingsConfigTabFields", nil, "Hitmarkers", dmarkers)
 
     dsettings:AddItem(dmarkers)
 end

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -93,10 +93,9 @@ function HELPSCRN:Show()
     dtabs:SetPos(margin, margin * 2)
     dtabs:SetSize(w - margin * 2, h - margin * 3 - bh)
 
-    local padding = dtabs:GetPadding()
+    local padding = dtabs:GetPadding() * 2
 
-    padding = padding * 2
-
+    -- Tutorial
     local tutparent = vgui.Create("DPanel", dtabs)
     tutparent:SetPaintBackground(false)
     tutparent:StretchToParent(margin, 0, 0, 0)
@@ -105,355 +104,16 @@ function HELPSCRN:Show()
 
     dtabs:AddSheet(GetTranslation("help_tut"), tutparent, "icon16/book_open.png", false, false, GetTranslation("help_tut_tip"))
 
+    -- Settings
     local dsettings = vgui.Create("DPanelList", dtabs)
     dsettings:StretchToParent(0, 0, padding, 0)
     dsettings:EnableVerticalScrollbar()
     dsettings:SetPadding(10)
     dsettings:SetSpacing(10)
 
-    --- Interface area
-
-    local dgui = vgui.Create("DForm", dsettings)
-    dgui:SetName(GetTranslation("set_title_gui"))
-
-    local cb = nil
-
-    dgui:CheckBox(GetTranslation("set_tips"), "ttt_tips_enable")
-
-    cb = dgui:NumSlider(GetTranslation("set_startpopup"), "ttt_startpopup_duration", 0, 60, 0)
-    if cb.Label then
-        cb.Label:SetWrap(true)
-    end
-    cb:SetTooltip(GetTranslation("set_startpopup_tip"))
-
-    cb = dgui:NumSlider(GetTranslation("set_cross_opacity"), "ttt_ironsights_crosshair_opacity", 0, 1, 1)
-    if cb.Label then
-        cb.Label:SetWrap(true)
-    end
-    cb:SetTooltip(GetTranslation("set_cross_opacity"))
-
-    cb = dgui:NumSlider(GetTranslation("set_cross_brightness"), "ttt_crosshair_brightness", 0, 1, 1)
-    if cb.Label then
-        cb.Label:SetWrap(true)
-    end
-
-    cb = dgui:NumSlider(GetTranslation("set_cross_size"), "ttt_crosshair_size", 0.1, 3, 1)
-    if cb.Label then
-        cb.Label:SetWrap(true)
-    end
-
-    dgui:CheckBox(GetTranslation("set_cross_disable"), "ttt_disable_crosshair")
-
-    dgui:CheckBox(GetTranslation("set_minimal_id"), "ttt_minimal_targetid")
-
-    dgui:CheckBox(GetTranslation("set_healthlabel"), "ttt_health_label")
-
-    cb = dgui:CheckBox(GetTranslation("set_lowsights"), "ttt_ironsights_lowered")
-    cb:SetTooltip(GetTranslation("set_lowsights_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_fastsw"), "ttt_weaponswitcher_fast")
-    cb:SetTooltip(GetTranslation("set_fastsw_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_fastsw_menu"), "ttt_weaponswitcher_displayfast")
-    cb:SetTooltip(GetTranslation("set_fastswmenu_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_wswitch"), "ttt_weaponswitcher_stay")
-    cb:SetTooltip(GetTranslation("set_wswitch_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_swselect"), "ttt_weaponswitcher_close")
-    cb:SetTooltip(GetTranslation("set_swselect_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_cues"), "ttt_cl_soundcues")
-
-    cb = dgui:CheckBox(GetTranslation("set_raw_karma"), "ttt_show_raw_karma_value")
-    cb:SetTooltip(GetTranslation("set_raw_karma_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_karma_total_pct"), "ttt_show_karma_total_pct")
-    cb:SetTooltip(GetTranslation("set_karma_total_pct_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_hide_role"), "ttt_hide_role")
-    cb:SetTooltip(GetTranslation("set_hide_role_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_hide_ammo"), "ttt_hide_ammo")
-    cb:SetTooltip(GetTranslation("set_hide_ammo_tip"))
-
-    cb = dgui:TextEntry(GetTranslation("set_radio_button"), "ttt_radio_button")
-    cb:SetTooltip(GetTranslation("set_radio_button_tip"))
-
-    cb = dgui:CheckBox(GetTranslation("set_bypass_culling"), "ttt_bypass_culling")
-    cb:SetTooltip(GetTranslation("set_bypass_culling_tip"))
-
-    dsettings:AddItem(dgui)
-
-    local dcolor = vgui.Create("DForm", dsettings)
-    dcolor:SetName(GetTranslation("set_color_mode"))
-    dcolor:DoExpansion(false)
-
-    local dcol = vgui.Create("DComboBox", dcolor)
-    dcol:SetConVar("ttt_color_mode")
-    dcol:SetSortItems(false)
-    dcol:AddChoice("Default", "default")
-    dcol:AddChoice("Simplified", "simple")
-    dcol:AddChoice("Protanomaly", "protan")
-    dcol:AddChoice("Deuteranomaly", "deutan")
-    dcol:AddChoice("Tritanomaly", "tritan")
-    dcol:AddChoice("Custom", "custom")
-
-    dcol.OnSelect = function(idx, val, data)
-        local mode = data -- For some reason it grabs the name and not the actual data so fix that here
-        if mode == "Default" then mode = "default"
-        elseif mode == "Simplified" then mode = "simple"
-        elseif mode == "Protanomaly" then mode = "protan"
-        elseif mode == "Deuteranomaly" then mode = "deutan"
-        elseif mode == "Tritanomaly" then mode = "tritan"
-        elseif mode == "Custom" then mode = "custom"
-        end
-        RunConsoleCommand("ttt_color_mode", mode)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcol)
-
-    local dcolinn = vgui.Create("DColorMixer", dcolor)
-    dcolinn:SetAlphaBar(false)
-    dcolinn:SetWangs(false)
-    dcolinn:SetPalette(false)
-    dcolinn:SetLabel("Custom innocent color:")
-    dcolinn:SetConVarR("ttt_custom_inn_color_r")
-    dcolinn:SetConVarG("ttt_custom_inn_color_g")
-    dcolinn:SetConVarB("ttt_custom_inn_color_b")
-    dcolinn.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcolinn)
-
-    local dcolspecinn = vgui.Create("DColorMixer", dcolor)
-    dcolspecinn:SetAlphaBar(false)
-    dcolspecinn:SetWangs(false)
-    dcolspecinn:SetPalette(false)
-    dcolspecinn:SetLabel("Custom special innocent color:")
-    dcolspecinn:SetConVarR("ttt_custom_spec_inn_color_r")
-    dcolspecinn:SetConVarG("ttt_custom_spec_inn_color_g")
-    dcolspecinn:SetConVarB("ttt_custom_spec_inn_color_b")
-    dcolspecinn.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcolspecinn)
-
-    local dcoltra = vgui.Create("DColorMixer", dcolor)
-    dcoltra:SetAlphaBar(false)
-    dcoltra:SetWangs(false)
-    dcoltra:SetPalette(false)
-    dcoltra:SetLabel("Custom traitor color:")
-    dcoltra:SetConVarR("ttt_custom_tra_color_r")
-    dcoltra:SetConVarG("ttt_custom_tra_color_g")
-    dcoltra:SetConVarB("ttt_custom_tra_color_b")
-    dcoltra.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcoltra)
-
-    local dcolspectra = vgui.Create("DColorMixer", dcolor)
-    dcolspectra:SetAlphaBar(false)
-    dcolspectra:SetWangs(false)
-    dcolspectra:SetPalette(false)
-    dcolspectra:SetLabel("Custom special traitor color:")
-    dcolspectra:SetConVarR("ttt_custom_spec_tra_color_r")
-    dcolspectra:SetConVarG("ttt_custom_spec_tra_color_g")
-    dcolspectra:SetConVarB("ttt_custom_spec_tra_color_b")
-    dcolspectra.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcolspectra)
-
-    local dcoldet = vgui.Create("DColorMixer", dcolor)
-    dcoldet:SetAlphaBar(false)
-    dcoldet:SetWangs(false)
-    dcoldet:SetPalette(false)
-    dcoldet:SetLabel("Custom detective color:")
-    dcoldet:SetConVarR("ttt_custom_det_color_r")
-    dcoldet:SetConVarG("ttt_custom_det_color_g")
-    dcoldet:SetConVarB("ttt_custom_det_color_b")
-    dcoldet.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcoldet)
-
-    local dcolspecdet = vgui.Create("DColorMixer", dcolor)
-    dcolspecdet:SetAlphaBar(false)
-    dcolspecdet:SetWangs(false)
-    dcolspecdet:SetPalette(false)
-    dcolspecdet:SetLabel("Custom detective color:")
-    dcolspecdet:SetConVarR("ttt_custom_spec_det_color_r")
-    dcolspecdet:SetConVarG("ttt_custom_spec_det_color_g")
-    dcolspecdet:SetConVarB("ttt_custom_spec_det_color_b")
-    dcolspecdet.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcolspecdet)
-
-    local dcoljes = vgui.Create("DColorMixer", dcolor)
-    dcoljes:SetAlphaBar(false)
-    dcoljes:SetWangs(false)
-    dcoljes:SetPalette(false)
-    dcoljes:SetLabel("Custom jester color:")
-    dcoljes:SetConVarR("ttt_custom_jes_color_r")
-    dcoljes:SetConVarG("ttt_custom_jes_color_g")
-    dcoljes:SetConVarB("ttt_custom_jes_color_b")
-    dcoljes.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcoljes)
-
-    local dcolind = vgui.Create("DColorMixer", dcolor)
-    dcolind:SetAlphaBar(false)
-    dcolind:SetWangs(false)
-    dcolind:SetPalette(false)
-    dcolind:SetLabel("Custom independent color:")
-    dcolind:SetConVarR("ttt_custom_ind_color_r")
-    dcolind:SetConVarG("ttt_custom_ind_color_g")
-    dcolind:SetConVarB("ttt_custom_ind_color_b")
-    dcolind.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcolind)
-
-    local dcolmon = vgui.Create("DColorMixer", dcolor)
-    dcolmon:SetAlphaBar(false)
-    dcolmon:SetWangs(false)
-    dcolmon:SetPalette(false)
-    dcolmon:SetLabel("Custom monster color:")
-    dcolmon:SetConVarR("ttt_custom_mon_color_r")
-    dcolmon:SetConVarG("ttt_custom_mon_color_g")
-    dcolmon:SetConVarB("ttt_custom_mon_color_b")
-    dcolmon.ValueChanged = function(col)
-        timer.Simple(0.5, function() UpdateRoleColours() end)
-    end
-
-    dcolor:AddItem(dcolmon)
-
-    dsettings:AddItem(dcolor)
-
-    --- Gameplay area
-
-    local dplay = vgui.Create("DForm", dsettings)
-    dplay:SetName(GetTranslation("set_title_play"))
-
-    cb = dplay:CheckBox(GetPTranslation("set_avoid_det", {detective = ROLE_STRINGS[ROLE_DETECTIVE]}), "ttt_avoid_detective")
-    cb:SetTooltip(GetPTranslation("set_avoid_det_tip", {detective = ROLE_STRINGS[ROLE_DETECTIVE], traitor = ROLE_STRINGS[ROLE_TRAITOR]}))
-
-    cb = dplay:CheckBox(GetTranslation("set_specmode"), "ttt_spectator_mode")
-    cb:SetTooltip(GetTranslation("set_specmode_tip"))
-
-    -- For some reason this one defaulted to on, unlike other checkboxes, so
-    -- force it to the actual value of the cvar (which defaults to off)
-    local mute = dplay:CheckBox(GetTranslation("set_mute"), "ttt_mute_team_check")
-    mute:SetValue(GetConVar("ttt_mute_team_check"):GetBool())
-    mute:SetTooltip(GetTranslation("set_mute_tip"))
-
-    dsettings:AddItem(dplay)
-
-    --- Language area
-    local dlanguage = vgui.Create("DForm", dsettings)
-    dlanguage:SetName(GetTranslation("set_title_lang"))
-
-    local dlang = vgui.Create("DComboBox", dlanguage)
-    dlang:SetConVar("ttt_language")
-
-    dlang:AddChoice("Server default", "auto")
-    for _, lang in pairs(LANG.GetLanguages()) do
-        dlang:AddChoice(string.Capitalize(lang), lang)
-    end
-    -- Why is DComboBox not updating the cvar by default?
-    dlang.OnSelect = function(idx, val, data)
-        RunConsoleCommand("ttt_language", data)
-    end
-    dlang.Think = dlang.ConVarStringThink
-
-    dlanguage:Help(GetTranslation("set_lang"))
-    dlanguage:AddItem(dlang)
-
-    dsettings:AddItem(dlanguage)
+    self:CreateSettings(dsettings)
 
     dtabs:AddSheet(GetTranslation("help_settings"), dsettings, "icon16/wrench.png", false, false, GetTranslation("help_settings_tip"))
-
-    -- BEM settings
-
-    padding = dtabs:GetPadding()
-    padding = padding * 2
-
-    dsettings = vgui.Create("DPanelList", dtabs)
-    dsettings:StretchToParent(0, 0, padding, 0)
-    dsettings:EnableVerticalScrollbar()
-    dsettings:SetPadding(10)
-    dsettings:SetSpacing(10)
-
-    -- info text
-    local dlabel = vgui.Create("DLabel", dsettings)
-    dlabel:SetText("All changes made here are clientside and will only apply to your own menu!")
-    dlabel:SetTextColor(Color(0, 0, 0, 255))
-    dsettings:AddItem(dlabel)
-
-    -- layout section
-    local dlayout = vgui.Create("DForm", dsettings)
-    dlayout:SetName("Item List Layout")
-
-    dlayout:NumSlider("Number of columns (def. 4)", "ttt_bem_cols", 1, 20, 0)
-    dlayout:NumSlider("Number of rows (def. 5)", "ttt_bem_rows", 1, 20, 0)
-    dlayout:NumSlider("Icon size (def. 64)", "ttt_bem_size", 32, 128, 0)
-
-    dsettings:AddItem(dlayout)
-
-    -- marker section
-    local dmarker = vgui.Create("DForm", dsettings)
-    dmarker:SetName("Item Marker Settings")
-
-    dmarker:CheckBox("Show slot marker", "ttt_bem_marker_slot")
-    dmarker:CheckBox("Show custom item marker", "ttt_bem_marker_custom")
-    dmarker:CheckBox("Show favourite item marker", "ttt_bem_marker_fav")
-    dmarker:CheckBox("Show loadout items", "ttt_show_loadout_equipment")
-    dmarker:CheckBox("Sort alphabetically", "ttt_sort_alphabetically")
-    dmarker:CheckBox("Sort by slot first", "ttt_sort_by_slot_first")
-
-    dsettings:AddItem(dmarker)
-
-    dtabs:AddSheet("BEM settings", dsettings, "icon16/cog.png", false, false, "Better Equipment Menu Settings")
-
-    -- Hitmarkers Settings
-
-    padding = dtabs:GetPadding()
-    padding = padding * 2
-
-    dsettings = vgui.Create("DPanelList", dtabs)
-    dsettings:StretchToParent(0, 0, padding, 0)
-    dsettings:EnableVerticalScrollbar()
-    dsettings:SetPadding(10)
-    dsettings:SetSpacing(10)
-
-    dlabel = vgui.Create("DLabel", dsettings)
-    dlabel:SetText("All changes made here are clientside and will only apply to your own menu!\nUse the !hmcolor command in chat to change the marker colors.\nUse the !hmcritcolor command in chat to change the color of critical hit markers.")
-    dlabel:SetTextColor(Color(0, 0, 0, 255))
-    dlabel:SizeToContents()
-    dsettings:AddItem(dlabel)
-
-    local dmarkers = vgui.Create("DForm", dsettings)
-    dmarkers:SetName("Hitmarkers")
-
-    dmarkers:CheckBox("Enabled", "hm_enabled")
-    dmarkers:CheckBox("Show criticals", "hm_showcrits")
-    dmarkers:CheckBox("Play hit sound", "hm_hitsound")
-
-    dsettings:AddItem(dmarkers)
-
-    dtabs:AddSheet("HM settings", dsettings, "icon16/cross.png", false, false, "Hitmarker settings")
 
     hook.Call("TTTSettingsTabs", GAMEMODE, dtabs)
 
@@ -1004,4 +664,323 @@ function HELPSCRN:CreateTutorial(parent)
 
         pageSelect:ChooseOptionID(page)
     end
+end
+
+function HELPSCRN:CreateSettings(dsettings)
+    --- Interface area
+
+    local dgui = vgui.Create("DForm", dsettings)
+    dgui:SetName(GetTranslation("set_title_gui"))
+
+    local cb = nil
+
+    dgui:CheckBox(GetTranslation("set_tips"), "ttt_tips_enable")
+
+    cb = dgui:NumSlider(GetTranslation("set_startpopup"), "ttt_startpopup_duration", 0, 60, 0)
+    if cb.Label then
+        cb.Label:SetWrap(true)
+    end
+    cb:SetTooltip(GetTranslation("set_startpopup_tip"))
+
+    cb = dgui:NumSlider(GetTranslation("set_cross_opacity"), "ttt_ironsights_crosshair_opacity", 0, 1, 1)
+    if cb.Label then
+        cb.Label:SetWrap(true)
+    end
+    cb:SetTooltip(GetTranslation("set_cross_opacity"))
+
+    cb = dgui:NumSlider(GetTranslation("set_cross_brightness"), "ttt_crosshair_brightness", 0, 1, 1)
+    if cb.Label then
+        cb.Label:SetWrap(true)
+    end
+
+    cb = dgui:NumSlider(GetTranslation("set_cross_size"), "ttt_crosshair_size", 0.1, 3, 1)
+    if cb.Label then
+        cb.Label:SetWrap(true)
+    end
+
+    dgui:CheckBox(GetTranslation("set_cross_disable"), "ttt_disable_crosshair")
+
+    dgui:CheckBox(GetTranslation("set_minimal_id"), "ttt_minimal_targetid")
+
+    dgui:CheckBox(GetTranslation("set_healthlabel"), "ttt_health_label")
+
+    cb = dgui:CheckBox(GetTranslation("set_lowsights"), "ttt_ironsights_lowered")
+    cb:SetTooltip(GetTranslation("set_lowsights_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_fastsw"), "ttt_weaponswitcher_fast")
+    cb:SetTooltip(GetTranslation("set_fastsw_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_fastsw_menu"), "ttt_weaponswitcher_displayfast")
+    cb:SetTooltip(GetTranslation("set_fastswmenu_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_wswitch"), "ttt_weaponswitcher_stay")
+    cb:SetTooltip(GetTranslation("set_wswitch_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_swselect"), "ttt_weaponswitcher_close")
+    cb:SetTooltip(GetTranslation("set_swselect_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_cues"), "ttt_cl_soundcues")
+
+    cb = dgui:CheckBox(GetTranslation("set_raw_karma"), "ttt_show_raw_karma_value")
+    cb:SetTooltip(GetTranslation("set_raw_karma_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_karma_total_pct"), "ttt_show_karma_total_pct")
+    cb:SetTooltip(GetTranslation("set_karma_total_pct_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_hide_role"), "ttt_hide_role")
+    cb:SetTooltip(GetTranslation("set_hide_role_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_hide_ammo"), "ttt_hide_ammo")
+    cb:SetTooltip(GetTranslation("set_hide_ammo_tip"))
+
+    cb = dgui:TextEntry(GetTranslation("set_radio_button"), "ttt_radio_button")
+    cb:SetTooltip(GetTranslation("set_radio_button_tip"))
+
+    cb = dgui:CheckBox(GetTranslation("set_bypass_culling"), "ttt_bypass_culling")
+    cb:SetTooltip(GetTranslation("set_bypass_culling_tip"))
+
+    dsettings:AddItem(dgui)
+
+    --- Gameplay area
+
+    local dplay = vgui.Create("DForm", dsettings)
+    dplay:SetName(GetTranslation("set_title_play"))
+
+    cb = dplay:CheckBox(GetPTranslation("set_avoid_det", {detective = ROLE_STRINGS[ROLE_DETECTIVE]}), "ttt_avoid_detective")
+    cb:SetTooltip(GetPTranslation("set_avoid_det_tip", {detective = ROLE_STRINGS[ROLE_DETECTIVE], traitor = ROLE_STRINGS[ROLE_TRAITOR]}))
+
+    cb = dplay:CheckBox(GetTranslation("set_specmode"), "ttt_spectator_mode")
+    cb:SetTooltip(GetTranslation("set_specmode_tip"))
+
+    -- For some reason this one defaulted to on, unlike other checkboxes, so
+    -- force it to the actual value of the cvar (which defaults to off)
+    local mute = dplay:CheckBox(GetTranslation("set_mute"), "ttt_mute_team_check")
+    mute:SetValue(GetConVar("ttt_mute_team_check"):GetBool())
+    mute:SetTooltip(GetTranslation("set_mute_tip"))
+
+    dsettings:AddItem(dplay)
+
+    -- Color area
+
+    local dcolor = vgui.Create("DForm", dsettings)
+    dcolor:DoExpansion(false)
+    dcolor:SetName(GetTranslation("set_color_mode"))
+
+    local dcol = vgui.Create("DComboBox", dcolor)
+    dcol:SetConVar("ttt_color_mode")
+    dcol:SetSortItems(false)
+    dcol:AddChoice("Default", "default")
+    dcol:AddChoice("Simplified", "simple")
+    dcol:AddChoice("Protanomaly", "protan")
+    dcol:AddChoice("Deuteranomaly", "deutan")
+    dcol:AddChoice("Tritanomaly", "tritan")
+    dcol:AddChoice("Custom", "custom")
+
+    dcol.OnSelect = function(idx, val, data)
+        local mode = data -- For some reason it grabs the name and not the actual data so fix that here
+        if mode == "Default" then mode = "default"
+        elseif mode == "Simplified" then mode = "simple"
+        elseif mode == "Protanomaly" then mode = "protan"
+        elseif mode == "Deuteranomaly" then mode = "deutan"
+        elseif mode == "Tritanomaly" then mode = "tritan"
+        elseif mode == "Custom" then mode = "custom"
+        end
+        RunConsoleCommand("ttt_color_mode", mode)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcol)
+
+    local dcolinn = vgui.Create("DColorMixer", dcolor)
+    dcolinn:SetAlphaBar(false)
+    dcolinn:SetWangs(false)
+    dcolinn:SetPalette(false)
+    dcolinn:SetLabel("Custom innocent color:")
+    dcolinn:SetConVarR("ttt_custom_inn_color_r")
+    dcolinn:SetConVarG("ttt_custom_inn_color_g")
+    dcolinn:SetConVarB("ttt_custom_inn_color_b")
+    dcolinn.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcolinn)
+
+    local dcolspecinn = vgui.Create("DColorMixer", dcolor)
+    dcolspecinn:SetAlphaBar(false)
+    dcolspecinn:SetWangs(false)
+    dcolspecinn:SetPalette(false)
+    dcolspecinn:SetLabel("Custom special innocent color:")
+    dcolspecinn:SetConVarR("ttt_custom_spec_inn_color_r")
+    dcolspecinn:SetConVarG("ttt_custom_spec_inn_color_g")
+    dcolspecinn:SetConVarB("ttt_custom_spec_inn_color_b")
+    dcolspecinn.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcolspecinn)
+
+    local dcoltra = vgui.Create("DColorMixer", dcolor)
+    dcoltra:SetAlphaBar(false)
+    dcoltra:SetWangs(false)
+    dcoltra:SetPalette(false)
+    dcoltra:SetLabel("Custom traitor color:")
+    dcoltra:SetConVarR("ttt_custom_tra_color_r")
+    dcoltra:SetConVarG("ttt_custom_tra_color_g")
+    dcoltra:SetConVarB("ttt_custom_tra_color_b")
+    dcoltra.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcoltra)
+
+    local dcolspectra = vgui.Create("DColorMixer", dcolor)
+    dcolspectra:SetAlphaBar(false)
+    dcolspectra:SetWangs(false)
+    dcolspectra:SetPalette(false)
+    dcolspectra:SetLabel("Custom special traitor color:")
+    dcolspectra:SetConVarR("ttt_custom_spec_tra_color_r")
+    dcolspectra:SetConVarG("ttt_custom_spec_tra_color_g")
+    dcolspectra:SetConVarB("ttt_custom_spec_tra_color_b")
+    dcolspectra.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcolspectra)
+
+    local dcoldet = vgui.Create("DColorMixer", dcolor)
+    dcoldet:SetAlphaBar(false)
+    dcoldet:SetWangs(false)
+    dcoldet:SetPalette(false)
+    dcoldet:SetLabel("Custom detective color:")
+    dcoldet:SetConVarR("ttt_custom_det_color_r")
+    dcoldet:SetConVarG("ttt_custom_det_color_g")
+    dcoldet:SetConVarB("ttt_custom_det_color_b")
+    dcoldet.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcoldet)
+
+    local dcolspecdet = vgui.Create("DColorMixer", dcolor)
+    dcolspecdet:SetAlphaBar(false)
+    dcolspecdet:SetWangs(false)
+    dcolspecdet:SetPalette(false)
+    dcolspecdet:SetLabel("Custom detective color:")
+    dcolspecdet:SetConVarR("ttt_custom_spec_det_color_r")
+    dcolspecdet:SetConVarG("ttt_custom_spec_det_color_g")
+    dcolspecdet:SetConVarB("ttt_custom_spec_det_color_b")
+    dcolspecdet.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcolspecdet)
+
+    local dcoljes = vgui.Create("DColorMixer", dcolor)
+    dcoljes:SetAlphaBar(false)
+    dcoljes:SetWangs(false)
+    dcoljes:SetPalette(false)
+    dcoljes:SetLabel("Custom jester color:")
+    dcoljes:SetConVarR("ttt_custom_jes_color_r")
+    dcoljes:SetConVarG("ttt_custom_jes_color_g")
+    dcoljes:SetConVarB("ttt_custom_jes_color_b")
+    dcoljes.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcoljes)
+
+    local dcolind = vgui.Create("DColorMixer", dcolor)
+    dcolind:SetAlphaBar(false)
+    dcolind:SetWangs(false)
+    dcolind:SetPalette(false)
+    dcolind:SetLabel("Custom independent color:")
+    dcolind:SetConVarR("ttt_custom_ind_color_r")
+    dcolind:SetConVarG("ttt_custom_ind_color_g")
+    dcolind:SetConVarB("ttt_custom_ind_color_b")
+    dcolind.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcolind)
+
+    local dcolmon = vgui.Create("DColorMixer", dcolor)
+    dcolmon:SetAlphaBar(false)
+    dcolmon:SetWangs(false)
+    dcolmon:SetPalette(false)
+    dcolmon:SetLabel("Custom monster color:")
+    dcolmon:SetConVarR("ttt_custom_mon_color_r")
+    dcolmon:SetConVarG("ttt_custom_mon_color_g")
+    dcolmon:SetConVarB("ttt_custom_mon_color_b")
+    dcolmon.ValueChanged = function(col)
+        timer.Simple(0.5, function() UpdateRoleColours() end)
+    end
+
+    dcolor:AddItem(dcolmon)
+
+    dsettings:AddItem(dcolor)
+
+    --- Language area
+
+    local dlanguage = vgui.Create("DForm", dsettings)
+    dlanguage:DoExpansion(false)
+    dlanguage:SetName(GetTranslation("set_title_lang"))
+
+    local dlang = vgui.Create("DComboBox", dlanguage)
+    dlang:SetConVar("ttt_language")
+
+    dlang:AddChoice("Server default", "auto")
+    for _, lang in pairs(LANG.GetLanguages()) do
+        dlang:AddChoice(string.Capitalize(lang), lang)
+    end
+    -- Why is DComboBox not updating the cvar by default?
+    dlang.OnSelect = function(idx, val, data)
+        RunConsoleCommand("ttt_language", data)
+    end
+    dlang.Think = dlang.ConVarStringThink
+
+    dlanguage:Help(GetTranslation("set_lang"))
+    dlanguage:AddItem(dlang)
+
+    dsettings:AddItem(dlanguage)
+
+    -- BEM settings
+
+    local dbemsettings = vgui.Create("DForm", dsettings)
+    dbemsettings:DoExpansion(false)
+    dbemsettings:SetName("BEM settings")
+
+    local dlabel = vgui.Create("DLabel", dbemsettings)
+    dlabel:SetText("All changes made here are clientside and will only apply to your own menu!")
+    dlabel:SetTextColor(Color(0, 0, 0, 255))
+    dbemsettings:AddItem(dlabel)
+
+    dbemsettings:NumSlider("Number of columns (def. 4)", "ttt_bem_cols", 1, 20, 0)
+    dbemsettings:NumSlider("Number of rows (def. 5)", "ttt_bem_rows", 1, 20, 0)
+    dbemsettings:NumSlider("Icon size (def. 64)", "ttt_bem_size", 32, 128, 0)
+
+    dbemsettings:CheckBox("Show slot marker", "ttt_bem_marker_slot")
+    dbemsettings:CheckBox("Show custom item marker", "ttt_bem_marker_custom")
+    dbemsettings:CheckBox("Show favourite item marker", "ttt_bem_marker_fav")
+    dbemsettings:CheckBox("Show loadout items", "ttt_show_loadout_equipment")
+    dbemsettings:CheckBox("Sort alphabetically", "ttt_sort_alphabetically")
+    dbemsettings:CheckBox("Sort by slot first", "ttt_sort_by_slot_first")
+
+    dsettings:AddItem(dbemsettings)
+
+    -- Hitmarkers settings
+
+    local dmarkers = vgui.Create("DForm", dsettings)
+    dmarkers:DoExpansion(false)
+    dmarkers:SetName("Hitmarkers settings")
+
+    dlabel:SetText("All changes made here are clientside and will only apply to your own menu!\nUse the !hmcolor command in chat to change the marker colors.\nUse the !hmcritcolor command in chat to change the color of critical hit markers.")
+    dlabel:SetTextColor(Color(0, 0, 0, 255))
+    dlabel:SizeToContents()
+    dmarkers:AddItem(dlabel)
+
+    dmarkers:CheckBox("Enabled", "hm_enabled")
+    dmarkers:CheckBox("Show criticals", "hm_showcrits")
+    dmarkers:CheckBox("Play hit sound", "hm_hitsound")
+
+    dsettings:AddItem(dmarkers)
 end

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -297,7 +297,8 @@ local function GetWinTitle(wintype)
         end
     end
 
-    return title
+    -- Let other addons override this after the roles have set their own win screens
+    return hook.Call("TTTScoringWinTitleOverride", nil, wintype, wintitles, title) or title
 end
 
 function GetFontForWinTitle(wintxt, width)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1264,13 +1264,6 @@ function GM:TTTCheckForWin()
             elseif v:IsInnocentTeam() then
                 innocent_alive = true
             end
-        -- Handle zombification differently because the player's original role should have no impact on this
-        elseif v:IsZombifying() then
-            if TRAITOR_ROLES[ROLE_ZOMBIE] then
-                traitor_alive = true
-            elseif MONSTER_ROLES[ROLE_ZOMBIE] then
-                monster_alive = true
-            end
         end
     end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -225,6 +225,7 @@ end
 CreateConVar("ttt_multiple_jesters_independents", "0")
 CreateConVar("ttt_jester_independent_pct", "0.13")
 CreateConVar("ttt_jester_independent_max", "2")
+CreateConVar("ttt_jester_independent_chance", "0.5")
 CreateConVar("ttt_single_deputy_impersonator", "0")
 CreateConVar("ttt_deputy_impersonator_promote_any_death", "0")
 CreateConVar("ttt_single_doctor_quack", "0")
@@ -1798,7 +1799,7 @@ function SelectRoles()
         end
 
         for _ = 1, jester_independent_count do
-            if #independentRoles ~= 0 and #choices > 0 then
+            if #independentRoles ~= 0 and math.random() <= GetConVar("ttt_jester_independent_chance"):GetFloat() and #choices > 0 then
                 local plyPick = math.random(1, #choices)
                 local ply = table.remove(choices, plyPick)
                 local rolePick = math.random(1, #independentRoles)

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -242,6 +242,9 @@ L.help_tut_find_role = "Find my role"
 L.help_settings = "Config"
 L.help_settings_tip = "Client-side configuration"
 
+L.help_roles = "Roles"
+L.help_roles_tip = "Client-side role configuration"
+
 -- Settings
 L.set_title_gui = "Interface settings"
 

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -239,8 +239,8 @@ L.help_tut = "Tutorial"
 L.help_tut_tip = "How TTT works, in just a few steps"
 L.help_tut_find_role = "Find my role"
 
-L.help_settings = "Settings"
-L.help_settings_tip = "Client-side settings"
+L.help_settings = "Config"
+L.help_settings_tip = "Client-side configuration"
 
 -- Settings
 L.set_title_gui = "Interface settings"

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -59,6 +59,18 @@ ROLE_IS_TARGETID_OVERRIDDEN[ROLE_ZOMBIE] = function(ply, target, showJester)
     return show, false, false
 end
 
+----------------
+-- SCOREBOARD --
+----------------
+
+hook.Add("TTTScoreboardPlayerRole", "Zombie_TTTScoreboardPlayerRole", function(ply, client, color, roleFileName)
+    if client:IsActiveZombie() and ply:IsZombieAlly() then
+        return ROLE_COLORS_SCOREBOARD[ply:GetRole()], ROLE_STRINGS_SHORT[ply:GetRole()]
+    elseif client:IsZombieAlly() and ply:IsActiveZombie() then
+        return ROLE_COLORS_SCOREBOARD[ROLE_ZOMBIE], ROLE_STRINGS_SHORT[ROLE_ZOMBIE]
+    end
+end)
+
 -------------
 -- SCORING --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -85,7 +85,7 @@ function plymeta:GetZombieAlly()
     elseif TRAITOR_ROLES[ROLE_ZOMBIE] then
         return TRAITOR_ROLES[role]
     end
-    return INDEPENDENT_ROLES[role]
+    return role == ROLE_ZOMBIE or role == ROLE_MADSCIENTIST
 end
 
 plymeta.IsZombiePrime = plymeta.GetZombiePrime

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -214,3 +214,7 @@ table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 0
 })
+table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
+    cvar = "ttt_zombie_respawn_block_win",
+    type = ROLE_CONVAR_TYPE_BOOL
+})

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -33,6 +33,7 @@ local zombie_thrall_speed_bonus = CreateConVar("ttt_zombie_thrall_speed_bonus", 
 local zombie_vision_enable = CreateConVar("ttt_zombie_vision_enable", "0")
 local zombie_respawn_health = CreateConVar("ttt_zombie_respawn_health", "100", FCVAR_NONE, "The amount of health a player should respawn with when they are converted to a zombie thrall", 1, 200)
 local zombie_friendly_fire = CreateConVar("ttt_zombie_friendly_fire", "2", FCVAR_NONE, "How to handle friendly fire damage between zombies. 0 - Do nothing. 1 - Reflect the damage back to the attacker. 2 - Negate the damage.", 0, 2)
+local zombie_respawn_block_win = CreateConVar("ttt_zombie_respawn_block_win", "0")
 
 hook.Add("TTTSyncGlobals", "Zombie_TTTSyncGlobals", function()
     SetGlobalBool("ttt_zombies_are_monsters", zombies_are_monsters:GetBool())
@@ -108,6 +109,18 @@ end
 ----------------
 -- WIN CHECKS --
 ----------------
+
+hook.Add("TTTWinCheckBlocks", "Zombie_TTTWinCheckBlocks", function(win_blocks)
+    if not zombie_respawn_block_win:GetBool() then return end
+
+    table.insert(win_blocks, function(win)
+        for _, v in ipairs(GetAllPlayers()) do
+            if v:IsZombifying() then
+                return WIN_NONE
+            end
+        end
+    end)
+end)
 
 hook.Add("TTTCheckForWin", "Zombie_TTTCheckForWin", function()
     -- Only run the win check if the zombies win by themselves (or with the Mad Scientist)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -19,7 +19,7 @@ local StringSplit = string.Split
 local StringSub = string.sub
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.7.2"
+CR_VERSION = "1.7.3"
 CR_BETA = true
 
 function CRVersion(version)

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -181,8 +181,6 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
     elseif client:IsIndependentTeam() then
         if showJester then
             return ROLE_JESTER
-        elseif ply:IsIndependentTeam() then
-            return ply:GetRole()
         end
     elseif client:IsMonsterTeam() then
         if showJester then


### PR DESCRIPTION
**Additions**
* Added `ttt_jester_independent_chance` convar to control the chance of a jester or independent when `ttt_multiple_jesters_independents` is enabled
* Added `ttt_zombie_respawn_block_win` convar to control whether a player respawning as a zombie will block the end of the round (defaults to disabled)

**Changes**
- Changed BEM and Hitmarkers settings to be in the Settings tabs instead of in their own tabs
- Renamed the "Settings" tab of the Help/Settings dialog to "Config" to make it slightly less confusing

**Fixes**
* Fixed some traitor role weapons being randomly removed from the shop when shop randomization is enabled
* Fixed `ttt_vampire_drain_mute_target` only blocking messages the first time
* Fixed all independent roles seeing each other on the scoreboard

**Developer**
- Added new `TTTScoringWinTitleOverride` hook for non-role addons to override the title and color shown on round summary screens
- Added new return value to the TTTEquipmentTabs hook, allowing addons to add new tabs that open the dialog even if none of the default tabs normally would
- Added new `TTTSettingsConfigTabFields` hook to make it easier to add to the existing help menu's Config tab sections
- Added new `TTTSettingsConfigTabSections` hook to make it easier to add new sections to the help menu's Config tab
- Added new `TTTSettingsRolesTabSections` hook to allow developers to add a configuration section for a role to the help menu's Roles tab
- Changed the help menu's Config tab to use `DScrollPanel` instead of the deprecated `DPanelList`
- Fixed `plymeta:IsZombieAlly` returning `true` for all independent roles rather than just other zombies and the mad scientist

Closes #253
Closes #254 
Closes #255 
Closes #256 
Fixes #258