### PR TITLE
Misc. changes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -185,6 +185,7 @@ ttt_impersonator_detective_chance           0       // The chance that a detecti
 ttt_single_deputy_impersonator              0       // Whether only a single deputy or impersonator should spawn in a round
 ttt_single_deputy_impersonator_chance       0.5     // The chance that a deputy should have an opportunity to spawn instead of an impersonator (e.g. 0.7 = 70% chance for deputy, 30% chance for impersonator. Only applies if ttt_single_deputy_impersonator is enabled)
 ttt_deputy_impersonator_promote_any_death   0       // Whether deputy/impersonator should be promoted when any detective dies rather than only after all detectives have died
+ttt_deputy_impersonator_start_promoted      0       // Whether deputy/impersonator should start the round promoted
 
 // Hypnotist
 ttt_hypnotist_credits_starting              1       // The number of credits a hypnotist should start with

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.8.1 (Beta)
+**Released:**
+
+### Changes
+- Ported "Translatability improvements and fixes" from base TTT
+
 ## 1.8.0
 **Released: February 15th, 2023**\
 Includes beta updates [1.7.2](#172-beta) and [1.7.3](#173-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - Fixed checkboxes not being accurate in the `ttt_roleweapons` configuration window when an equipment item's name wasn't translated and had capitol letters (e.g. Bruh Bunker)
+- Fixed minor plurality issue in the server log message when the killer wins
 
 ## 1.8.0
 **Released: February 15th, 2023**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 1.8.1 (Beta)
 **Released:**
 
+### Additions
+- Added ability for deputies and impersonators to start promoted (defaults to disabled)
+
 ### Changes
 - Ported "Translatability improvements and fixes" from base TTT
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 ### Changes
 - Ported "Translatability improvements and fixes" from base TTT
 
+### Fixes
+- Fixed checkboxes not being accurate in the `ttt_roleweapons` configuration window when an equipment item's name wasn't translated and had capitol letters (e.g. Bruh Bunker)
+
 ## 1.8.0
 **Released: February 15th, 2023**\
 Includes beta updates [1.7.2](#172-beta) and [1.7.3](#173-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 ### Fixes
 - Fixed checkboxes not being accurate in the `ttt_roleweapons` configuration window when an equipment item's name wasn't translated and had capitol letters (e.g. Bruh Bunker)
 - Fixed minor plurality issue in the server log message when the killer wins
+- Fixed independents being able to see each other's Target ID (icon, target ring, role text) information
 
 ## 1.8.0
 **Released: February 15th, 2023**\

--- a/gamemodes/terrortown/entities/weapons/weapon_mhl_badge.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_mhl_badge.lua
@@ -74,12 +74,6 @@ if SERVER then
     CreateConVar("ttt_marshal_badge_time", "8", FCVAR_NONE, "The amount of time (in seconds) the marshal's badge takes to use", 0, 60)
 end
 
-if CLIENT then
-    function SWEP:GetPrintName()
-        return ROLE_STRINGS[ROLE_DEPUTY] .. " Badge --TESTREMOVE"
-    end
-end
-
 function SWEP:Initialize()
     self:SendWeaponAnim(ACT_SLAM_DETONATOR_DRAW)
     if CLIENT then

--- a/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -347,7 +347,11 @@ local styledmessages = {
     chat_plain = {
         "body_call",
         "disg_turned_on",
-        "disg_turned_off"
+        "disg_turned_off",
+        "mute_all",
+        "mute_off",
+        "mute_specs",
+        "mute_living"
     },
 
     chat_warn = {

--- a/gamemodes/terrortown/gamemode/cl_roleweapons.lua
+++ b/gamemodes/terrortown/gamemode/cl_roleweapons.lua
@@ -342,7 +342,7 @@ local function OpenDialog(client)
     local function UpdateRadioButtonState(item)
         -- Update checkbox state based on tables
         if ItemIsWeapon(item) then
-            local weap_class = item.id
+            local weap_class = StringLower(item.id)
             if WEPS.BuyableWeapons[save_role] and table.HasValue(WEPS.BuyableWeapons[save_role], weap_class) then
                 dradioinclude:SetValue(true)
             elseif WEPS.ExcludeWeapons[save_role] and table.HasValue(WEPS.ExcludeWeapons[save_role], weap_class) then
@@ -353,7 +353,7 @@ local function OpenDialog(client)
 
             dradionorandom:SetValue(WEPS.BypassRandomWeapons[save_role] and table.HasValue(WEPS.BypassRandomWeapons[save_role], weap_class))
         else
-            local name = item.name
+            local name = StringLower(item.name)
             if WEPS.BuyableWeapons[save_role] and table.HasValue(WEPS.BuyableWeapons[save_role], name) then
                 dradioinclude:SetValue(true)
             elseif WEPS.ExcludeWeapons[save_role] and table.HasValue(WEPS.ExcludeWeapons[save_role], name) then

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -197,9 +197,6 @@ function GM:PostDrawTranslucentRenderables()
                         if showJester then
                             role = ROLE_NONE
                             color_role = ROLE_JESTER
-                        elseif v:IsIndependentTeam() then
-                            role = v:GetRole()
-                            noz = true
                         end
                     end
                 end
@@ -341,7 +338,6 @@ function GM:HUDDrawTargetID()
     local target_jester = false
 
     local target_monster = false
-    local target_independent = false
 
     local target_corpse = false
 
@@ -424,13 +420,6 @@ function GM:HUDDrawTargetID()
             elseif client:IsIndependentTeam() then
                 if showJester then
                     target_jester = showJester
-                elseif ent:IsIndependentTeam() then
-                    -- Only show other independent players if they are the same role or are "teamed"
-                    if ent:GetRole() == client:GetRole() or
-                        (ent:IsZombie() and client:IsMadScientist()) or
-                        (ent:IsMadScientist() and client:IsZombie()) then
-                        target_independent = ent:GetRole()
-                    end
                 end
             end
         end
@@ -480,7 +469,7 @@ function GM:HUDDrawTargetID()
 
     local w, h = 0, 0 -- text width/height, reused several times
 
-    local ring_visible = target_traitor or target_unknown_traitor or target_special_traitor or target_unknown_special_traitor or target_detective or target_unknown_detective or target_special_detective or target_glitch or target_jester or target_independent or target_monster
+    local ring_visible = target_traitor or target_unknown_traitor or target_special_traitor or target_unknown_special_traitor or target_detective or target_unknown_detective or target_special_detective or target_glitch or target_jester or target_monster
 
     local new_visible, color_override = CallHook("TTTTargetIDPlayerRing", nil, ent, client, ring_visible)
     if type(new_visible) == "boolean" then ring_visible = new_visible end
@@ -507,8 +496,6 @@ function GM:HUDDrawTargetID()
             end
         elseif target_monster then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_MONSTER, "radar"))
-        elseif target_independent then
-            surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_INDEPENDENT, "radar"))
         elseif target_jester then
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_JESTER])
         end
@@ -665,9 +652,6 @@ function GM:HUDDrawTargetID()
     elseif target_monster then
         text = StringUpper(ROLE_STRINGS[target_monster])
         col = GetRoleTeamColor(ROLE_TEAM_MONSTER, "radar")
-    elseif target_independent then
-        text = StringUpper(ROLE_STRINGS[target_independent])
-        col = GetRoleTeamColor(ROLE_TEAM_INDEPENDENT, "radar")
     elseif ent.sb_tag and ent.sb_tag.txt ~= nil then
         text = L[ent.sb_tag.txt]
         col = ent.sb_tag.color

--- a/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -342,6 +342,13 @@ local function TraitorGlobalVoice(ply, cmd, args)
 end
 concommand.Add("tvog", TraitorGlobalVoice)
 
+local MuteModes = {
+    [MUTE_NONE] = "mute_off",
+    [MUTE_TERROR] = "mute_living",
+    [MUTE_ALL] = "mute_all",
+    [MUTE_SPEC] = "mute_specs"
+ }
+
 local function MuteTeam(ply, cmd, args)
     if not IsValid(ply) then return end
     if not (#args == 1 and tonumber(args[1])) then return end
@@ -353,13 +360,7 @@ local function MuteTeam(ply, cmd, args)
     local t = tonumber(args[1])
     ply.mute_team = t
 
-    if t == MUTE_ALL then
-        ply:ChatPrint("All muted.")
-    elseif t == MUTE_NONE or t == TEAM_UNASSIGNED or not team.Valid(t) then
-        ply:ChatPrint("None muted.")
-    else
-        ply:ChatPrint(team.GetName(t) .. " muted.")
-    end
+    LANG.Msg(ply, MuteModes[t])
 end
 concommand.Add("ttt_mute_team", MuteTeam)
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -239,8 +239,8 @@ local paired_role_blocks = {
     {ROLE_JESTER, ROLE_SWAPPER}
 }
 
-for _, v in ipairs(paired_role_blocks) do
-    local cvar_name = "ttt_single_" .. ROLE_STRINGS_RAW[v[1]] .. "_" .. ROLE_STRINGS_RAW[v[2]]
+for _, r in ipairs(paired_role_blocks) do
+    local cvar_name = "ttt_single_" .. ROLE_STRINGS_RAW[r[1]] .. "_" .. ROLE_STRINGS_RAW[r[2]]
     CreateConVar(cvar_name, "0")
     CreateConVar(cvar_name .. "_chance", "0.5")
 end
@@ -1380,13 +1380,13 @@ function SelectRoles()
     -- special spawning cvars
     local blocked_roles = {}
 
-    for _, v in ipairs(paired_role_blocks) do
-        local cvar_name = "ttt_single_" .. ROLE_STRINGS_RAW[v[1]] .. "_" .. ROLE_STRINGS_RAW[v[2]]
+    for _, r in ipairs(paired_role_blocks) do
+        local cvar_name = "ttt_single_" .. ROLE_STRINGS_RAW[r[1]] .. "_" .. ROLE_STRINGS_RAW[r[2]]
         if GetConVar(cvar_name):GetBool() then
             if math.random() <= GetConVar(cvar_name .. "_chance"):GetFloat() then
-                blocked_roles[v[2]] = true
+                blocked_roles[r[2]] = true
             else
-                blocked_roles[v[1]] = true
+                blocked_roles[r[1]] = true
             end
         end
     end
@@ -1457,14 +1457,16 @@ function SelectRoles()
                     forcedMonsterCount = forcedMonsterCount + 1
                 end
 
-                for _, v in ipairs(paired_role_blocks) do
-                    if role == v[1] or role == v[2] then
-                        local cvar_name = "ttt_single_" .. ROLE_STRINGS_RAW[v[1]] .. "_" .. ROLE_STRINGS_RAW[v[2]]
+                for _, r in ipairs(paired_role_blocks) do
+                    local role_pair1 = r[1]
+                    local role_pair2 = r[2]
+                    if role == role_pair1 or role == role_pair2 then
+                        local cvar_name = "ttt_single_" .. ROLE_STRINGS_RAW[role_pair1] .. "_" .. ROLE_STRINGS_RAW[role_pair2]
                         if GetConVar(cvar_name):GetBool() then
-                            if role == v[1] then
-                                blocked_roles[v[2]] = true
+                            if role == role_pair1 then
+                                blocked_roles[role_pair2] = true
                             else
-                                blocked_roles[v[1]] = true
+                                blocked_roles[role_pair1] = true
                             end
                         end
                     end
@@ -1500,7 +1502,7 @@ function SelectRoles()
     -- Role exclusion logic also needs to be copied into the drunk role selection logic in drunk.lua -> plymeta:SoberDrunk
     local rolePredicates = {
         -- Innocents
-        [ROLE_DEPUTY] = function() return (detective_count > 0 or GetConVar("ttt_deputy_without_detective"):GetBool()) end,
+        [ROLE_DEPUTY] = function() return detective_count > 0 or GetConVar("ttt_deputy_without_detective"):GetBool() end,
         [ROLE_REVENGER] = function() return choice_count > 1 end,
         [ROLE_GLITCH] = function()
             local glitch_mode = GetConVar("ttt_glitch_mode"):GetInt()
@@ -1509,7 +1511,7 @@ function SelectRoles()
         end,
 
         -- Traitors
-        [ROLE_IMPERSONATOR] = function() return (detective_count > 0 or GetConVar("ttt_impersonator_without_detective"):GetBool()) end,
+        [ROLE_IMPERSONATOR] = function() return detective_count > 0 or GetConVar("ttt_impersonator_without_detective"):GetBool() end,
     }
 
     local function DoesRolePassPredicate(role)

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -227,6 +227,7 @@ CreateConVar("ttt_jester_independent_pct", "0.13")
 CreateConVar("ttt_jester_independent_max", "2")
 CreateConVar("ttt_jester_independent_chance", "0.5")
 CreateConVar("ttt_deputy_impersonator_promote_any_death", "0")
+CreateConVar("ttt_deputy_impersonator_start_promoted", "0")
 CreateConVar("ttt_single_jester_independent", "1")
 CreateConVar("ttt_single_jester_independent_max_players", "0")
 

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -228,7 +228,7 @@ hook.Add("DoPlayerDeath", "Assassin_DoPlayerDeath", function(ply, attacker, dmgi
 end)
 
 -- Clear the assassin target information when the next round starts
-hook.Add("TTTPrepareRound", "Assassin_Smoke_PrepareRound", function()
+hook.Add("TTTPrepareRound", "Assassin_Target_PrepareRound", function()
     for _, v in pairs(GetAllPlayers()) do
         v:SetNWString("AssassinTarget", "")
         v:SetNWBool("AssassinFailed", false)

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -193,7 +193,7 @@ end
 hook.Add("TTTPlayerRoleChanged", "Assassin_Target_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
     if not ply:Alive() or ply:IsSpec() then return end
 
-    -- If this player is not longer an assassin, clear out thier target
+    -- If this player is no longer an assassin, clear out thier target
     if oldRole == ROLE_ASSASSIN and oldRole ~= newRole then
         ply:SetNWString("AssassinTarget", "")
         ply:SetNWBool("AssassinFailed", false)

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -37,9 +37,9 @@ end)
 
 -- Centralize this so it can be handled on round start and on player death
 local function AssignAssassinTarget(ply, start, delay)
-    -- Don't let dead players, spectators, non-assassins, failed assassins, or assassins who already received their "final target" get another target
+    -- Don't let non-players, non-assassins, failed assassins, or assassins who already received their "final target" get another target
     -- And don't assign targets if the round isn't currently running
-    if not IsValid(ply) or GetRoundState() > ROUND_ACTIVE or
+    if not IsPlayer(ply) or GetRoundState() > ROUND_ACTIVE or
         not ply:IsAssassin() or ply:GetNWBool("AssassinFailed", false) or ply:GetNWBool("AssassinComplete", false)
     then
         return

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -40,8 +40,8 @@ players fall in love so that they win/die together.]])
 players fall in love so that they win/die together.]])
 end)
 
-hook.Add("TTTRolePopupRoleStringOverride", "Cupid_TTTRolePopupRoleStringOverride", function(client, roleString)
-    if not IsPlayer(client) or not client:IsCupid() then return end
+AddHook("TTTRolePopupRoleStringOverride", "Cupid_TTTRolePopupRoleStringOverride", function(cli, roleString)
+    if not IsPlayer(cli) or not cli:IsCupid() then return end
 
     if GetGlobalBool("ttt_cupids_are_independent", false) then
         return roleString .. "_indep"
@@ -113,7 +113,7 @@ AddHook("TTTEndRound", "Cupid_SecondaryWinEvent_TTTEndRound", function()
 end)
 
 -- Register the scoring events for cupid
-hook.Add("Initialize", "Cupid_Scoring_Initialize", function()
+AddHook("Initialize", "Cupid_Scoring_Initialize", function()
     local heart_icon = Material("icon16/heart.png")
     local Event = CLSCORE.DeclareEventDisplay
     local PT = LANG.GetParamTranslation
@@ -183,39 +183,47 @@ end)
 -- TARGET ID --
 ---------------
 
-AddHook("TTTTargetIDPlayerRoleIcon", "Cupid_TTTTargetIDPlayerRoleIcon", function(ply, client, role, noz, colorRole, hideBeggar, showJester, hideCupid)
-    if ply:IsActiveCupid() and ply:SteamID64() == client:GetNWString("TTTCupidShooter", "") then
+AddHook("TTTTargetIDPlayerRoleIcon", "Cupid_TTTTargetIDPlayerRoleIcon", function(ply, cli, role, noz, colorRole, hideBeggar, showJester, hideCupid)
+    if ply:IsActiveCupid() and ply:SteamID64() == cli:GetNWString("TTTCupidShooter", "") then
         return ROLE_CUPID, true
-    elseif ply:SteamID64() == client:GetNWString("TTTCupidLover", "") then
+    elseif ply:SteamID64() == cli:GetNWString("TTTCupidLover", "") then
         return ply:GetRole(), true
     end
 end)
 
-AddHook("TTTTargetIDPlayerRing", "Cupid_TTTTargetIDPlayerRing", function(ent, client, ringVisible)
-    if IsPlayer(ent) then
-        if ent:IsActiveCupid() and ent:SteamID64() == client:GetNWString("TTTCupidShooter", "") then
-            return true, ROLE_COLORS_RADAR[ROLE_CUPID]
-        elseif ent:SteamID64() == client:GetNWString("TTTCupidLover", "") then
-            return true, ROLE_COLORS_RADAR[ent:GetRole()]
-        end
+AddHook("TTTTargetIDPlayerRing", "Cupid_TTTTargetIDPlayerRing", function(ent, cli, ringVisible)
+    if not IsPlayer(ent) then return end
+
+    if ent:IsActiveCupid() and ent:SteamID64() == cli:GetNWString("TTTCupidShooter", "") then
+        return true, ROLE_COLORS_RADAR[ROLE_CUPID]
+    elseif ent:SteamID64() == cli:GetNWString("TTTCupidLover", "") then
+        return true, ROLE_COLORS_RADAR[ent:GetRole()]
     end
 end)
 
-AddHook("TTTTargetIDPlayerText", "Cupid_TTTTargetIDPlayerText", function(ent, client, text, clr, secondaryText)
-    if IsPlayer(ent) then
-        if ent:IsActiveCupid() and ent:SteamID64() == client:GetNWString("TTTCupidShooter", "") then
-            return StringUpper(ROLE_STRINGS[ROLE_CUPID]), ROLE_COLORS_RADAR[ROLE_CUPID]
-        elseif ent:SteamID64() == client:GetNWString("TTTCupidLover", "") then
-            return StringUpper(ROLE_STRINGS[ent:GetRole()]), ROLE_COLORS_RADAR[ent:GetRole()], LANG.GetTranslation("scoreboard_cupid_lover"), Color(230, 90, 200, 255)
-        end
+AddHook("TTTTargetIDPlayerText", "Cupid_TTTTargetIDPlayerText", function(ent, cli, text, clr, secondaryText)
+    if not IsPlayer(ent) then return end
+
+    if ent:IsActiveCupid() and ent:SteamID64() == cli:GetNWString("TTTCupidShooter", "") then
+        return StringUpper(ROLE_STRINGS[ROLE_CUPID]), ROLE_COLORS_RADAR[ROLE_CUPID]
+    elseif ent:SteamID64() == cli:GetNWString("TTTCupidLover", "") then
+        return StringUpper(ROLE_STRINGS[ent:GetRole()]), ROLE_COLORS_RADAR[ent:GetRole()], LANG.GetTranslation("scoreboard_cupid_lover"), Color(230, 90, 200, 255)
     end
 end)
+
+ROLE_IS_TARGETID_OVERRIDDEN[ROLE_CUPID] = function(ply, target, showJester)
+    if (target:IsActiveCupid() and target:SteamID64() == ply:GetNWString("TTTCupidShooter", "")) or
+        (target:SteamID64() == ply:GetNWString("TTTCupidLover", "")) then
+        ------ icon, ring, text
+        return true, true, true
+    end
+end
 
 ----------------
 -- SCOREBOARD --
 ----------------
 
-hook.Add("TTTScoreboardPlayerRole", "Cupid_TTTScoreboardPlayerRole", function(ply, cli, c, roleStr)
+AddHook("TTTScoreboardPlayerRole", "Cupid_TTTScoreboardPlayerRole", function(ply, cli, c, roleStr)
     if ply:IsActiveCupid() and ply:SteamID64() == cli:GetNWString("TTTCupidShooter", "") then
         return ROLE_COLORS_SCOREBOARD[ROLE_CUPID], ROLE_STRINGS_SHORT[ROLE_CUPID]
     elseif ply:SteamID64() == cli:GetNWString("TTTCupidLover", "") then
@@ -225,13 +233,29 @@ hook.Add("TTTScoreboardPlayerRole", "Cupid_TTTScoreboardPlayerRole", function(pl
     end
 end)
 
-hook.Add("TTTScoreboardPlayerName", "Cupid_TTTScoreboardPlayerName", function(ply, cli, nickTxt)
+AddHook("TTTScoreboardPlayerName", "Cupid_TTTScoreboardPlayerName", function(ply, cli, nickTxt)
     if ply:SteamID64() == cli:GetNWString("TTTCupidLover", "") then
         return ply:Nick() .. " (" .. LANG.GetTranslation("scoreboard_cupid_your_lover") .. ")"
     elseif ply:SteamID64() == cli:GetNWString("TTTCupidTarget1", "") or ply:SteamID64() == cli:GetNWString("TTTCupidTarget2", "") then
         return ply:Nick() .. " (" .. LANG.GetTranslation("scoreboard_cupid_lover") .. ")"
     end
 end)
+
+ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_CUPID] = function(ply, target, showJester)
+    local name = false
+    -- Cupid itself only gets the role info shown
+    local role = target:IsActiveCupid() and target:SteamID64() == ply:GetNWString("TTTCupidShooter", "")
+
+    -- The lovers get role and color shown
+    if (target:SteamID64() == ply:GetNWString("TTTCupidLover", "")) or
+        (target:SteamID64() == ply:GetNWString("TTTCupidTarget1", "") or target:SteamID64() == ply:GetNWString("TTTCupidTarget2", "")) then
+        name = true
+        role = true
+    end
+
+    ------ name, role
+    return name, role
+end
 
 ------------------
 -- HIGHLIGHTING --

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
@@ -27,6 +27,11 @@ end)
 -------------------
 
 function ShouldPromoteDetectiveLike()
+    -- Promote immediately
+    if GetConVar("ttt_deputy_impersonator_start_promoted"):GetBool() then
+        return true
+    end
+
     local alive, dead = 0, 0
     for _, p in ipairs(GetAllPlayers()) do
         if p:IsDetectiveTeam() then

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -349,7 +349,7 @@ end)
 
 hook.Add("TTTPrintResultMessage", "Killer_TTTPrintResultMessage", function(type)
     if type == WIN_KILLER then
-        LANG.Msg("win_killer", { role = ROLE_STRINGS_PLURAL[ROLE_KILLER] })
+        LANG.Msg("win_killer", { role = ROLE_STRINGS[ROLE_KILLER] })
         ServerLog("Result: " .. ROLE_STRINGS[ROLE_KILLER] .. " wins.\n")
         return true
     end

--- a/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
@@ -18,13 +18,13 @@ Survive until the end of the round to win.]])
     -- HUD
     LANG.AddToLanguage("english", "shadow_find_target", "FIND YOUR TARGET - {time}")
     LANG.AddToLanguage("english", "shadow_return_target", "RETURN TO YOUR TARGET - {time}")
-    
+
     -- Target ID
     LANG.AddToLanguage("english", "shadow_target", "YOUR TARGET")
-    
+
     -- Win conditions
     LANG.AddToLanguage("english", "ev_win_shadow","The {role} stayed close to their target and also won the round!")
-    
+
     -- Scoreboard
     LANG.AddToLanguage("english", "score_shadow_following", "Following")
 end)
@@ -204,13 +204,13 @@ end)
 -- PARTICLES --
 ---------------
 
-local function DrawRadius(client, ent, r)
+local function DrawRadius(ply, ent, r)
     if not ent.RadiusEmitter then ent.RadiusEmitter = ParticleEmitter(ent:GetPos()) end
     if not ent.RadiusNextPart then ent.RadiusNextPart = CurTime() end
     if not ent.RadiusDir then ent.RadiusDir = 0 end
     local pos = ent:GetPos() + Vector(0, 0, 30)
     if ent.RadiusNextPart < CurTime() then
-        if client:GetPos():Distance(pos) <= 3000 then
+        if ply:GetPos():Distance(pos) <= 3000 then
             for _ = 1, 24 do
                 ent.RadiusEmitter:SetPos(pos)
                 ent.RadiusNextPart = CurTime() + 0.02
@@ -226,7 +226,7 @@ local function DrawRadius(client, ent, r)
                 particle:SetRoll(math.Rand(0, math.pi))
                 particle:SetRollDelta(0)
                 local color = ROLE_COLORS[ROLE_TRAITOR]
-                if client:GetPos():Distance(ent:GetPos()) <= r then
+                if ply:GetPos():Distance(ent:GetPos()) <= r then
                     color = ROLE_COLORS[ROLE_INNOCENT]
                 end
                 particle:SetColor(color.r, color.g, color.b)
@@ -245,11 +245,11 @@ local function RemoveRadius(ent)
     end
 end
 
-local function DrawLink(client, ent)
+local function DrawLink(ply, ent)
     if not ent.LinkEmitter then ent.LinkEmitter = ParticleEmitter(ent:GetPos()) end
     if not ent.LinkNextPart then ent.LinkNextPart = CurTime() end
     if not ent.LinkOffset then ent.LinkOffset = 0 end
-    local startPos = client:GetPos() + Vector(0, 0, 30)
+    local startPos = ply:GetPos() + Vector(0, 0, 30)
     local endPos = ent:GetPos() + Vector(0, 0, 30)
     local dir = endPos - startPos
     dir = dir:GetNormalized() * 50

--- a/gamemodes/terrortown/gamemode/roles/turncoat/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/turncoat/shared.lua
@@ -23,10 +23,6 @@ function SetTurncoatTeam(ply, traitor)
             net.WriteString(ply:Nick())
         end
         net.Broadcast()
-        -- Also update any assassin targets since this player isn't a threat anymore
-        if IsPlayer(ply) then
-            UpdateAssassinTargets(ply)
-        end
         hook.Call("TTTTurncoatTeamChanged", nil, ply, traitor)
     end
 end

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -7,8 +7,6 @@ local string = string
 local RemoveHook = hook.Remove
 local StringUpper = string.upper
 
-local client = nil
-
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -107,12 +105,9 @@ ROLE_IS_TARGETID_OVERRIDDEN[ROLE_ZOMBIE] = function(ply, target, showJester)
     -- Traitor logic is already handled elsewhere
     if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
 
-    if not client then
-        client = LocalPlayer()
-    end
-
     -- Override all three pieces for allies
-    if (client:IsActiveZombie() and ply:IsZombieAlly()) or (client:IsZombieAlly() and ply:IsActiveZombie()) then
+    if (ply:IsActiveZombie() and target:IsZombieAlly()) or
+        (ply:IsZombieAlly() and target:IsActiveZombie()) then
         ------ icon, ring, text
         return true, true, true
     end
@@ -139,11 +134,8 @@ ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_ZOMBIE] = function(ply, target)
     -- Traitor logic is already handled elsewhere
     if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
 
-    if not client then
-        client = LocalPlayer()
-    end
-
-    local show = (client:IsActiveZombie() and ply:IsZombieAlly()) or (client:IsZombieAlly() and ply:IsActiveZombie())
+    local show = (ply:IsActiveZombie() and target:IsZombieAlly()) or
+                    (ply:IsZombieAlly() and target:IsActiveZombie())
 
     ------ name,  role
     return false, show
@@ -220,6 +212,7 @@ local jesters_visible_to_traitors = false
 local jesters_visible_to_monsters = false
 local jesters_visible_to_independents = false
 local vision_enabled = false
+local client = nil
 
 local function EnableZombieHighlights()
     -- Handle zombie targeting and non-traitor team logic

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -6,6 +6,8 @@ local string = string
 
 local RemoveHook = hook.Remove
 
+local client = nil
+
 ------------------
 -- TRANSLATIONS --
 ------------------
@@ -63,13 +65,24 @@ end
 -- SCOREBOARD --
 ----------------
 
-hook.Add("TTTScoreboardPlayerRole", "Zombie_TTTScoreboardPlayerRole", function(ply, client, color, roleFileName)
-    if client:IsActiveZombie() and ply:IsZombieAlly() then
+hook.Add("TTTScoreboardPlayerRole", "Zombie_TTTScoreboardPlayerRole", function(ply, cli, color, roleFileName)
+    if cli:IsActiveZombie() and ply:IsZombieAlly() then
         return ROLE_COLORS_SCOREBOARD[ply:GetRole()], ROLE_STRINGS_SHORT[ply:GetRole()]
-    elseif client:IsZombieAlly() and ply:IsActiveZombie() then
+    elseif cli:IsZombieAlly() and ply:IsActiveZombie() then
         return ROLE_COLORS_SCOREBOARD[ROLE_ZOMBIE], ROLE_STRINGS_SHORT[ROLE_ZOMBIE]
     end
 end)
+
+ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_ZOMBIE] = function(ply, target)
+    if not client then
+        client = LocalPlayer()
+    end
+
+    local show = (client:IsActiveZombie() and ply:IsZombieAlly()) or (client:IsZombieAlly() and ply:IsActiveZombie())
+
+    ------ name,  role
+    return false, show
+end
 
 -------------
 -- SCORING --
@@ -142,7 +155,6 @@ local jesters_visible_to_traitors = false
 local jesters_visible_to_monsters = false
 local jesters_visible_to_independents = false
 local vision_enabled = false
-local client = nil
 
 local function EnableZombieHighlights()
     -- Handle zombie targeting and non-traitor team logic

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -5,6 +5,7 @@ local player = player
 local string = string
 
 local RemoveHook = hook.Remove
+local StringUpper = string.upper
 
 local client = nil
 
@@ -51,14 +52,70 @@ hook.Add("TTTTargetIDPlayerKillIcon", "Zombie_TTTTargetIDPlayerKillIcon", functi
     end
 end)
 
+-- Show the correct role icon for zombies and their allies
+hook.Add("TTTTargetIDPlayerRoleIcon", "Zombie_TTTTargetIDPlayerRoleIcon", function(ply, cli, role, noz, colorRole, hideBeggar, showJester, hideBodysnatcher)
+    -- This logic is not needed if zombies are traitors
+    -- Traitor logic is already handled elsewhere
+    if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
+
+    if cli:IsActiveZombie() and ply:IsZombieAlly() then
+        return ply:GetRole(), true
+    elseif cli:IsZombieAlly() and ply:IsActiveZombie() then
+        return ROLE_ZOMBIE, true
+    end
+end)
+
+-- Show the correct target ring for zombies and their allies
+hook.Add("TTTTargetIDPlayerRing", "Zombie_TTTTargetIDPlayerRing", function(ent, cli, ringVisible)
+    -- This logic is not needed if zombies are traitors
+    -- Traitor logic is already handled elsewhere
+    if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
+    if not IsPlayer(ent) then return end
+
+    if cli:IsActiveZombie() and ent:IsZombieAlly() then
+        return true, ROLE_COLORS_RADAR[ent:GetRole()]
+    elseif cli:IsZombieAlly() and ent:IsActiveZombie() then
+        return true, ROLE_COLORS_RADAR[ROLE_ZOMBIE]
+    end
+end)
+
+-- Show the correct role name for zombies and their allies
+hook.Add("TTTTargetIDPlayerText", "Zombie_TTTTargetIDPlayerText", function(ent, cli, text, col)
+    -- This logic is not needed if zombies are traitors
+    -- Traitor logic is already handled elsewhere
+    if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
+    if not IsPlayer(ent) then return end
+
+    if cli:IsActiveZombie() and ent:IsZombieAlly() then
+        local role = ent:GetRole()
+        return StringUpper(ROLE_STRINGS[role]), ROLE_COLORS_RADAR[role]
+    elseif cli:IsZombieAlly() and ent:IsActiveZombie() then
+        return StringUpper(ROLE_STRINGS[ROLE_ZOMBIE]), ROLE_COLORS_RADAR[ROLE_ZOMBIE]
+    end
+end)
+
 ROLE_IS_TARGETID_OVERRIDDEN[ROLE_ZOMBIE] = function(ply, target, showJester)
-    if not ply:IsZombie() then return end
     if not IsPlayer(target) then return end
 
-    local show = GetGlobalBool("ttt_zombie_show_target_icon", false) and ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_zom_claws" and not showJester
+    -- Overriding the icon to show "KILL"
+    if ply:IsZombie() and GetGlobalBool("ttt_zombie_show_target_icon", false) and ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_zom_claws" and not showJester then
+        ------ icon, ring,  text
+        return true, false, false
+    end
 
-    ------ icon, ring,  text
-    return show, false, false
+    -- The rest of this logic is not needed if zombies are traitors
+    -- Traitor logic is already handled elsewhere
+    if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
+
+    if not client then
+        client = LocalPlayer()
+    end
+
+    -- Override all three pieces for allies
+    if (client:IsActiveZombie() and ply:IsZombieAlly()) or (client:IsZombieAlly() and ply:IsActiveZombie()) then
+        ------ icon, ring, text
+        return true, true, true
+    end
 end
 
 ----------------
@@ -66,6 +123,10 @@ end
 ----------------
 
 hook.Add("TTTScoreboardPlayerRole", "Zombie_TTTScoreboardPlayerRole", function(ply, cli, color, roleFileName)
+    -- This logic is not needed if zombies are traitors
+    -- Traitor logic is already handled elsewhere
+    if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
+
     if cli:IsActiveZombie() and ply:IsZombieAlly() then
         return ROLE_COLORS_SCOREBOARD[ply:GetRole()], ROLE_STRINGS_SHORT[ply:GetRole()]
     elseif cli:IsZombieAlly() and ply:IsActiveZombie() then
@@ -74,6 +135,10 @@ hook.Add("TTTScoreboardPlayerRole", "Zombie_TTTScoreboardPlayerRole", function(p
 end)
 
 ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_ZOMBIE] = function(ply, target)
+    -- This logic is not needed if zombies are traitors
+    -- Traitor logic is already handled elsewhere
+    if TRAITOR_ROLES[ROLE_ZOMBIE] then return end
+
     if not client then
         client = LocalPlayer()
     end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ if not string.StartsWith then
 end
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.8.0"
+CR_VERSION = "1.8.1"
 CR_BETA = true
 
 function CRVersion(version)


### PR DESCRIPTION
### Additions
- Added ability for deputies and impersonators to start promoted (defaults to disabled)

**Changes**
- Ported "Translatability improvements and fixes" from base TTT

**Fixes**
- Fixed checkboxes not being accurate in the `ttt_roleweapons` configuration window when an equipment item's name wasn't translated and had capitol letters (e.g. Bruh Bunker)
- Fixed minor plurality issue in the server log message when the killer wins
- Fixed independents being able to see each other's Target ID (icon, target ring, role text) information. Fixes #273 

Requires https://github.com/NoxxFlame/TTT-Custom-Roles-ULX/pull/74