### PR TITLE
Hotfixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ### Changes
 - Ported "Translatability improvements and fixes" from base TTT
+- Changed jesters to be able to do damage after the round ends (if `ttt_postround_dm` is enabled)
 
 ### Fixes
 - Fixed checkboxes not being accurate in the `ttt_roleweapons` configuration window when an equipment item's name wasn't translated and had capitol letters (e.g. Bruh Bunker)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
 - Fixed checkboxes not being accurate in the `ttt_roleweapons` configuration window when an equipment item's name wasn't translated and had capitol letters (e.g. Bruh Bunker)
 - Fixed minor plurality issue in the server log message when the killer wins
 - Fixed independents being able to see each other's Target ID (icon, target ring, role text) information
+- Fixed target ID ring and role text for deputies showing detective when `ttt_deputy_use_detective_icon` was disabled
 
 ## 1.8.0
 **Released: February 15th, 2023**\

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -483,7 +483,10 @@ function GM:HUDDrawTargetID()
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_TRAITOR])
         elseif target_special_traitor or target_unknown_special_traitor then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_TRAITOR, "radar"))
-        elseif target_detective or target_unknown_detective then
+        elseif target_detective then
+            local detective_role = GetDetectiveIconRole(client:IsTraitorTeam())
+            surface.SetDrawColor(ROLE_COLORS_RADAR[detective_role])
+        elseif target_unknown_detective then
             surface.SetDrawColor(ROLE_COLORS_RADAR[ROLE_DETECTIVE])
         elseif target_special_detective then
             surface.SetDrawColor(GetRoleTeamColor(ROLE_TEAM_DETECTIVE, "radar"))
@@ -637,8 +640,9 @@ function GM:HUDDrawTargetID()
         text = StringUpper(ROLE_STRINGS[bluff])
         col = ROLE_COLORS_RADAR[bluff]
     elseif target_detective then
-        text = StringUpper(ROLE_STRINGS[ROLE_DETECTIVE])
-        col = ROLE_COLORS_RADAR[ROLE_DETECTIVE]
+        local detective_role = GetDetectiveIconRole(client:IsTraitorTeam())
+        text = StringUpper(ROLE_STRINGS[detective_role])
+        col = ROLE_COLORS_RADAR[detective_role]
     elseif target_special_detective then
         local role = ent:GetRole()
         text = StringUpper(ROLE_STRINGS[role])

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -922,8 +922,8 @@ function GM:ScalePlayerDamage(ply, hitgroup, dmginfo)
 
     local att = dmginfo:GetAttacker()
     if IsPlayer(att) then
-        -- Only apply damage scaling after the round starts
-        if GetRoundState() >= ROUND_ACTIVE then
+        -- Only apply damage scaling while the round is active
+        if GetRoundState() == ROUND_ACTIVE then
             -- Jesters can't deal damage
             if att:ShouldActLikeJester() then
                 dmginfo:ScaleDamage(0)
@@ -978,7 +978,7 @@ local fallsounds = {
 };
 
 function GM:OnPlayerHitGround(ply, in_water, on_floater, speed)
-    if ply:ShouldActLikeJester() and GetRoundState() >= ROUND_ACTIVE then
+    if ply:ShouldActLikeJester() and GetRoundState() == ROUND_ACTIVE then
         -- Jester team don't take fall damage
         return
     else


### PR DESCRIPTION
- Changed jesters to be able to do damage after the round ends (if `ttt_postround_dm` is enabled). Fixes #275
- Fixed target ID ring and role text for deputies showing detective when `ttt_deputy_use_detective_icon` was disabled. Fixes #276 