### PR TITLE
Misc. changes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -33,7 +33,11 @@ Add any of the following that you want to change to your server.cfg (for dedicat
 
 // ROLE SPAWN REQUIREMENTS
 ttt_traitor_pct                             0.25    // Percentage of players, rounded up, that can spawn as a traitor or "special traitor"
-ttt_detective_pct                           0.13    // Percentage of players, rounded up, that can spawn as a detective
+ttt_traitor_max                             32      // The maximum number of players that can spawn as a traitor or "special traitor"
+ttt_detective_pct                           0.13    // Percentage of players, rounded up, that can spawn as a detective role
+ttt_detective_max                           32      // The maximum number of players that can spawn as a detective role
+ttt_detective_min_players                   8       // The minimum number of players required to spawn a detective role
+ttt_detective_karma_min                     600     // The minimum amount of karma required for a player to be selected to spawn as a detective role
 ttt_special_traitor_pct                     0.33    // Percentage of traitors, rounded up, that can spawn as a "special traitor" (e.g. hypnotist, impersonator, etc.)
 ttt_special_traitor_chance                  0.5     // The chance that a "special traitor" will spawn in each available slot made by "ttt_special_traitor_pct"
 ttt_special_innocent_pct                    0.33    // Percentage of innocents, rounded up, that can spawn as a "special innocent" (e.g. glitch, phantom, etc.)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Changes
 - Changed players who are in a lovers pair due to cupid's arrow to not be killed if their lover is converting to a zombie
+- Changed shop and player loadout retry timers to stop retrying after 60 seconds or when a new round is being prepared, whichever comes first
 
 ### Fixes
 - Fixed tips and idle warning messages not using the new config tab name

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Changes
 - Changed players who are in a lovers pair due to cupid's arrow to not be killed if their lover is converting to a zombie
 - Changed shop and player loadout retry timers to stop retrying after 60 seconds or when a new round is being prepared, whichever comes first
+- Changed round start popups to close at the start of the next round if they are still around
 
 ### Fixes
 - Fixed tips and idle warning messages not using the new config tab name

--- a/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -123,28 +123,40 @@ local function GetTextForLocalPlayer()
     end
 end
 
+local popupframe = nil
+local function RoundStartPopupClose()
+    if IsValid(popupframe) then
+        popupframe:Remove()
+        popupframe = nil
+    end
+end
+
 local startshowtime = CreateConVar("ttt_startpopup_duration", "17", FCVAR_ARCHIVE)
 -- shows info about goal and fellow traitors (if any)
 local function RoundStartPopup()
     -- based on Derma_Message
 
+    -- close last round's if it's still there
+    RoundStartPopupClose()
+    timer.Remove("roundstartpopupclose")
+
     if startshowtime:GetInt() <= 0 then return end
 
     if not LocalPlayer() then return end
 
-    local dframe = vgui.Create("Panel")
-    dframe:SetDrawOnTop(true)
-    dframe:SetMouseInputEnabled(false)
-    dframe:SetKeyboardInputEnabled(false)
+    popupframe = vgui.Create("Panel")
+    popupframe:SetDrawOnTop(true)
+    popupframe:SetMouseInputEnabled(false)
+    popupframe:SetKeyboardInputEnabled(false)
 
     local color = Color(0, 0, 0, 200)
-    dframe.Paint = function(s)
+    popupframe.Paint = function(s)
         draw.RoundedBox(8, 0, 0, s:GetWide(), s:GetTall(), color)
     end
 
     local text = GetTextForLocalPlayer()
 
-    local dtext = vgui.Create("DLabel", dframe)
+    local dtext = vgui.Create("DLabel", popupframe)
     dtext:SetFont("TabLarge")
     dtext:SetText(text)
     dtext:SizeToContents()
@@ -156,12 +168,12 @@ local function RoundStartPopup()
 
     dtext:SetPos(m, m)
 
-    dframe:SetSize(w + m * 2, h + m * 2)
-    dframe:Center()
+    popupframe:SetSize(w + m * 2, h + m * 2)
+    popupframe:Center()
 
-    dframe:AlignBottom(10)
+    popupframe:AlignBottom(10)
 
-    timer.Simple(startshowtime:GetInt(), function() dframe:Remove() end)
+    timer.Create("roundstartpopupclose", startshowtime:GetInt(), 1, RoundStartPopupClose)
 end
 concommand.Add("ttt_cl_startpopup", RoundStartPopup)
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -786,6 +786,7 @@ function PrepareRound()
 
     WEPS.ResetWeaponsCache()
     WEPS.ResetRoleWeaponCache()
+    WEPS.ClearRetryTimers()
 
     -- New look. Random if no forced model set.
     GAMEMODE.playermodel = GAMEMODE.force_plymodel == "" and GetRandomPlayerModel() or GAMEMODE.force_plymodel

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -201,7 +201,7 @@ end
 local function ClearLateLoadoutTimer(id)
     local timer_id = "lateloadout" .. id
     timer.Remove(timer_id)
-    table.remove(retry_timers, timer_id)
+    retry_timers[timer_id] = nil
 end
 
 -- Sometimes, in cramped map locations, giving players weapons fails. A timer
@@ -394,7 +394,7 @@ local function GiveEquipmentWeapon(sid, cls)
     else
         -- can stop retrying, if we were
         timer.Remove(tmr)
-        table.remove(retry_timers, tmr)
+        retry_timers[tmr] = nil
 
         if w.WasBought then
             -- some weapons give extra ammo after being bought, etc


### PR DESCRIPTION
**Changes**
- Changed shop and player loadout retry timers to stop retrying after 60 seconds or when a new round is being prepared, whichever comes first
- Changed round start popups to close at the start of the next round if they are still around