### PR TITLE
Informant - Conflict with things that change roles externally when there used to be an informant

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@
 - Fixed tips and idle warning messages not using the new config tab name
 - Fixed cupid & lovers not winning with jesters or roles with passive wins were left in the round
 - Fixed missing space before "YOUR TARGET" scoreboard marker for shadow
+- Fixed some player role information showing on the scoreboard when there was an informant at the start of the round but then roles were switched by something external, like a Randomat event
 
 ### Developer
 - Added new `TTTParasiteRespawn` hook to detect when a parasite respawns

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -115,15 +115,14 @@ hook.Add("TTTPlayerRoleChanged", "Informant_TTTPlayerRoleChanged", function(ply,
         ply:SetNWFloat("TTTInformantScannerCooldown", -1)
     end
 
-    if HasInformant() then
-        if ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
-            local share = GetGlobalBool("ttt_informant_share_scans", true)
-            for _, v in pairs(GetAllPlayers()) do
-                if v:IsActiveInformant() then
-                    v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
-                elseif v:IsActiveTraitorTeam() and share then
-                    v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. The " .. ROLE_STRINGS[ROLE_INFORMANT] .. " will need to rescan them.")
-                end
+    -- Only notify if there is an informant and the player had some info being reset
+    if HasInformant() and ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
+        local share = GetGlobalBool("ttt_informant_share_scans", true)
+        for _, v in pairs(GetAllPlayers()) do
+            if v:IsActiveInformant() then
+                v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
+            elseif v:IsActiveTraitorTeam() and share then
+                v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. The " .. ROLE_STRINGS[ROLE_INFORMANT] .. " will need to rescan them.")
             end
         end
     end

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -115,15 +115,15 @@ hook.Add("TTTPlayerRoleChanged", "Informant_TTTPlayerRoleChanged", function(ply,
         ply:SetNWFloat("TTTInformantScannerCooldown", -1)
     end
 
-    if not HasInformant() then return end
-
-    if ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
-        local share = GetGlobalBool("ttt_informant_share_scans", true)
-        for _, v in pairs(GetAllPlayers()) do
-            if v:IsActiveInformant() then
-                v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
-            elseif v:IsActiveTraitorTeam() and share then
-                v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. The " .. ROLE_STRINGS[ROLE_INFORMANT] .. " will need to rescan them.")
+    if HasInformant() then
+        if ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED) > INFORMANT_UNSCANNED then
+            local share = GetGlobalBool("ttt_informant_share_scans", true)
+            for _, v in pairs(GetAllPlayers()) do
+                if v:IsActiveInformant() then
+                    v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
+                elseif v:IsActiveTraitorTeam() and share then
+                    v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. The " .. ROLE_STRINGS[ROLE_INFORMANT] .. " will need to rescan them.")
+                end
             end
         end
     end


### PR DESCRIPTION
- Fixed some player role information showing on the scoreboard when there was an informant at the start of the round but then roles were switched by something external, like a Randomat event