### PR TITLE
1.8.2 Hotfix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 - Fixed cupid & lovers not winning with jesters or roles with passive wins were left in the round
 - Fixed missing space before "YOUR TARGET" scoreboard marker for shadow
 - Fixed some player role information showing on the scoreboard when there was an informant at the start of the round but then roles were switched by something external, like a Randomat event
+- Fixed glitch who was paired with a traitor by cupid's arrow having their role icon use the traitor color
 
 ### Developer
 - Added new `TTTParasiteRespawn` hook to detect when a parasite respawns

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -187,7 +187,7 @@ AddHook("TTTTargetIDPlayerRoleIcon", "Cupid_TTTTargetIDPlayerRoleIcon", function
     if ply:IsActiveCupid() and ply:SteamID64() == cli:GetNWString("TTTCupidShooter", "") then
         return ROLE_CUPID, true
     elseif ply:SteamID64() == cli:GetNWString("TTTCupidLover", "") then
-        return ply:GetRole(), true
+        return ply:GetRole(), true, ply:GetRole()
     end
 end)
 


### PR DESCRIPTION
- Fixed glitch who was paired with a traitor by cupid's arrow having their role icon use the traitor color