### PR TITLE
Loot goblin fix and addition

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -521,6 +521,7 @@ ttt_lootgoblin_regen_delay                  0       // The length of the delay (
 ttt_lootgoblin_radar_enabled                0       // Whether the radar ping for the loot goblin should be enabled or not
 ttt_lootgoblin_radar_timer                  15      // How often (in seconds) the radar ping for the loot goblin should update
 ttt_lootgoblin_radar_delay                  15      // How delayed (in seconds) the radar ping for the loot goblin should be
+ttt_lootgoblin_active_display               1       // Whether to show the loot goblin's information over their head and on the scoreboard once they are activated
 
 // Cupid
 ttt_cupids_are_independent                  0       // Whether cupids should be treated as members of the independent team (rather than the jester team)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ### 1.8.10 (Beta)
 **Released:**
 
+### Additions
+- Added new convar (`ttt_lootgoblin_active_display`) to control whether the loot goblin's role is revealed when they are activated (defaults to enabled to keep current behavior)
+
 ### Fixes
 - Fixed conflict between loot goblin and revenger radar timing convars
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+### 1.8.10 (Beta)
+**Released:**
+
+### Fixes
+- Fixed conflict between loot goblin and revenger radar timing convars
+
 ### 1.8.9 (Beta)
 **Released: May 28th, 2023**
 

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -106,7 +106,7 @@ local function UpdateLootGoblin()
     local active = net.ReadBool()
     if active then
         SetLootGoblinPosition()
-        timer.Create("updatelootgoblin", GetGlobalInt("ttt_revenger_radar_timer", 15), 0, SetLootGoblinPosition)
+        timer.Create("updatelootgoblin", GetGlobalInt("ttt_lootgoblin_radar_timer", 15), 0, SetLootGoblinPosition)
     else
         lootgoblins = {}
     end

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -33,19 +33,19 @@ end)
 
 -- Reveal the loot goblin to all players once activated
 hook.Add("TTTTargetIDPlayerRoleIcon", "LootGoblin_TTTTargetIDPlayerRoleIcon", function(ply, client, role, noz, colorRole, hideBeggar, showJester, hideBodysnatcher)
-    if ply:IsActiveLootGoblin() and ply:IsRoleActive() then
+    if ply:IsActiveLootGoblin() and ply:IsRoleActive() and GetGlobalBool("ttt_lootgoblin_active_display", true) then
         return ROLE_LOOTGOBLIN, false
     end
 end)
 
 hook.Add("TTTTargetIDPlayerRing", "LootGoblin_TTTTargetIDPlayerRing", function(ent, client, ringVisible)
-    if IsPlayer(ent) and ent:IsActiveLootGoblin() and ent:IsRoleActive() then
+    if IsPlayer(ent) and ent:IsActiveLootGoblin() and ent:IsRoleActive() and GetGlobalBool("ttt_lootgoblin_active_display", true) then
         return true, ROLE_COLORS_RADAR[ROLE_LOOTGOBLIN]
     end
 end)
 
 hook.Add("TTTTargetIDPlayerText", "LootGoblin_TTTTargetIDPlayerText", function(ent, client, text, clr, secondaryText)
-    if IsPlayer(ent) and ent:IsActiveLootGoblin() and ent:IsRoleActive() then
+    if IsPlayer(ent) and ent:IsActiveLootGoblin() and ent:IsRoleActive() and GetGlobalBool("ttt_lootgoblin_active_display", true) then
         return StringUpper(ROLE_STRINGS[ROLE_LOOTGOBLIN]), ROLE_COLORS_RADAR[ROLE_LOOTGOBLIN]
     end
 end)
@@ -54,6 +54,7 @@ ROLE_IS_TARGETID_OVERRIDDEN[ROLE_LOOTGOBLIN] = function(ply, target)
     if not IsPlayer(target) then return end
     if not target:IsActiveLootGoblin() then return end
     if not target:IsRoleActive() then return end
+    if not GetGlobalBool("ttt_lootgoblin_active_display", true) then return end
 
     ------ icon, ring, text
     return true, true, true
@@ -122,7 +123,7 @@ end)
 ----------------
 
 hook.Add("TTTScoreboardPlayerRole", "LootGoblin_TTTScoreboardPlayerRole", function(ply, client, color, roleFileName)
-    if ply:IsActiveLootGoblin() and ply:IsRoleActive() then
+    if ply:IsActiveLootGoblin() and ply:IsRoleActive() and GetGlobalBool("ttt_lootgoblin_active_display", true) then
         return ROLE_COLORS_SCOREBOARD[ROLE_LOOTGOBLIN], ROLE_STRINGS_SHORT[ROLE_LOOTGOBLIN]
     end
 end)
@@ -131,6 +132,7 @@ ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_LOOTGOBLIN] = function(ply, target)
     if not IsPlayer(target) then return end
     if not target:IsActiveLootGoblin() then return end
     if not target:IsRoleActive() then return end
+    if not GetGlobalBool("ttt_lootgoblin_active_display", true) then return end
 
     ------ name,  role
     return false, true

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -63,7 +63,7 @@ hook.Add("TTTSyncGlobals", "LootGoblin_TTTSyncGlobals", function()
     SetGlobalFloat("ttt_lootgoblin_sprint_recovery", lootgoblin_sprint_recovery:GetFloat())
     SetGlobalInt("ttt_lootgoblin_regen_mode", lootgoblin_regen_mode:GetInt())
     SetGlobalInt("ttt_lootgoblin_regen_delay", lootgoblin_regen_delay:GetInt())
-    SetGlobalInt("ttt_revenger_radar_timer", lootgoblin_radar_timer:GetInt())
+    SetGlobalInt("ttt_lootgoblin_radar_timer", lootgoblin_radar_timer:GetInt())
 end)
 
 -----------

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -56,7 +56,8 @@ local lootgoblin_regen_rate = CreateConVar("ttt_lootgoblin_regen_rate", "3", FCV
 local lootgoblin_regen_delay = CreateConVar("ttt_lootgoblin_regen_delay", "0", FCVAR_NONE, "The length of the delay (in seconds) before the loot goblin's health will start to regenerate", 0, 60)
 local lootgoblin_radar_enabled = CreateConVar("ttt_lootgoblin_radar_enabled", "0", FCVAR_NONE, "Whether the radar ping for the loot goblin should be enabled or not", 0, 1)
 local lootgoblin_radar_timer = CreateConVar("ttt_lootgoblin_radar_timer", "15", FCVAR_NONE, "How often (in seconds) the radar ping for the loot goblin should update", 1, 60)
-local lootgoblin_radar_delay = CreateConVar("ttt_lootgoblin_radar_delay", "15", FCVAR_NONE, "How dealyed (in seconds) the radar ping for the loot goblin should be", 1, 60)
+local lootgoblin_radar_delay = CreateConVar("ttt_lootgoblin_radar_delay", "15", FCVAR_NONE, "How delayed (in seconds) the radar ping for the loot goblin should be", 1, 60)
+local lootgoblin_active_display = CreateConVar("ttt_lootgoblin_active_display", "1", FCVAR_NONE, "Whether to show the loot goblin's information over their head and on the scoreboard once they are activated", 0, 1)
 
 hook.Add("TTTSyncGlobals", "LootGoblin_TTTSyncGlobals", function()
     SetGlobalFloat("ttt_lootgoblin_speed_mult", lootgoblin_speed_mult:GetFloat())
@@ -64,6 +65,7 @@ hook.Add("TTTSyncGlobals", "LootGoblin_TTTSyncGlobals", function()
     SetGlobalInt("ttt_lootgoblin_regen_mode", lootgoblin_regen_mode:GetInt())
     SetGlobalInt("ttt_lootgoblin_regen_delay", lootgoblin_regen_delay:GetInt())
     SetGlobalInt("ttt_lootgoblin_radar_timer", lootgoblin_radar_timer:GetInt())
+    SetGlobalBool("ttt_lootgoblin_active_display", lootgoblin_active_display:GetBool())
 end)
 
 -----------

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
@@ -125,3 +125,7 @@ table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 0
 })
+table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
+    cvar = "ttt_lootgoblin_active_display",
+    type = ROLE_CONVAR_TYPE_BOOL,
+})

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -27,7 +27,7 @@ end
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.8.9"
+CR_VERSION = "1.8.10"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
**Additions**
- Added new convar (`ttt_lootgoblin_active_display`) to control whether the loot goblin's role is revealed when they are activated (defaults to enabled to keep current behavior)

**Fixes**
- Fixed conflict between loot goblin and revenger radar timing convars