### PR TITLE
Stig shadow requests

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -660,12 +660,15 @@ ttt_shadow_target_buff_heal_amount          5       // The amount of health the 
 ttt_shadow_target_buff_heal_interval        10      // How often (in seconds) the shadow's target should be healed
 ttt_shadow_target_buff_respawn_delay        10      // How often (in seconds) before the shadow's target should respawn
 ttt_shadow_target_buff_damage_bonus         0.15    // Damage bonus the shadow's target should get (e.g. 0.15 = 15% extra damage)
+ttt_shadow_target_buff_role_copy            0       // Whether the shadow should instead copy the role of their target if the team join buff is enabled
 ttt_shadow_speed_mult                       1.1     // The minimum multiplier to use on the shadow's sprint speed when they are outside of their target radius (e.g. 1.1 = 110% normal speed)
 ttt_shadow_speed_mult_max                   1.5     // The maximum multiplier to use on the shadow's sprint speed when they are FAR outside of their target radius (e.g. 1.5 = 150% normal speed)
 ttt_shadow_sprint_recovery                  0.1     // The minimum amount of stamina to recover per tick when the shadow is outside of their target radius
 ttt_shadow_sprint_recovery_max              0.5     // The maximum amount of stamina to recover per tick when the shadow is FAR outside of their target radius
 ttt_shadow_target_jester                    1       // Whether the shadow should be able to target a member of the jester team
 ttt_shadow_target_independent               1       // Whether the shadow should be able to target an independent player
+ttt_shadow_soul_link                        0       // Whether the shadow should die when their target dies and vice-versa
+ttt_shadow_soul_link_kill_credit            0       // Whether a player responsible for killing a soul-linked player should get the credit for it (e.g. If a shadow and jester are separated and the shadow dies, the jester wins)
 
 // Arsonist
 ttt_arsonist_douse_time                     8       // The amount of time (in seconds) the arsonist takes to douse someone

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -653,7 +653,7 @@ ttt_shadow_start_timer                      30      // How much time (in seconds
 ttt_shadow_buffer_timer                     7       // How much time (in seconds) the shadow can stay of their target's radius without dying
 ttt_shadow_alive_radius                     8       // The radius (in meters) from the living target that the shadow has to stay within
 ttt_shadow_dead_radius                      3       // The radius (in meters) from the death target that the shadow has to stay within
-ttt_shadow_target_buff                      1       // The type of buff to shadow's target should get. 0 - None. 1 - Heal over time. 2 - Single respawn. 3 - Damage bonus. 4 - Team join
+ttt_shadow_target_buff                      4       // The type of buff to shadow's target should get. 0 - None. 1 - Heal over time. 2 - Single respawn. 3 - Damage bonus. 4 - Team join
 ttt_shadow_target_buff_notify               1       // Whether the shadow's target should be notified when they are buffed
 ttt_shadow_target_buff_delay                60      // How long (in seconds) the shadow needs to be near their target before the buff takes effect
 ttt_shadow_target_buff_heal_amount          5       // The amount of health the shadow's target should be healed per-interval

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -668,7 +668,6 @@ ttt_shadow_sprint_recovery_max              0.5     // The maximum amount of sta
 ttt_shadow_target_jester                    1       // Whether the shadow should be able to target a member of the jester team
 ttt_shadow_target_independent               1       // Whether the shadow should be able to target an independent player
 ttt_shadow_soul_link                        0       // Whether the shadow should die when their target dies and vice-versa
-ttt_shadow_soul_link_kill_credit            0       // Whether a player responsible for killing a soul-linked player should get the credit for it (e.g. If a shadow and jester are separated and the shadow dies, the jester wins)
 
 // Arsonist
 ttt_arsonist_douse_time                     8       // The amount of time (in seconds) the arsonist takes to douse someone

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,12 +3,16 @@
 ## 1.8.11 (Beta)
 **Released:**
 
-### Changes
-- Changed shadow buff to "team join" by default
-- Changed messages displayed to the shadow if the join team buff is active to be more accurate
+### Additions
 - Added `ttt_shadow_target_buff_role_copy` convar to control whether the shadow copies the role of the target player if the team join buff is active (disabled by default)
 - Added `ttt_shadow_soul_link` convar to control whether the shadow dies when their target dies and vice-versa (disabled by default)
 - Added description in the F1 help menu for the shadow's soul link, if it's turned on
+
+### Changes
+- Changed shadow buff to "team join" by default
+- Changed messages displayed to the shadow if the join team buff is active to be more accurate
+
+### Fixes
 - Fixed the shadow not dying if they kill their target
 
 ## 1.8.10 (Beta)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,17 @@
 # Release Notes
 
-### 1.8.10 (Beta)
+## 1.8.11 (Beta)
+**Released:**
+
+### Changes
+- Changed shadow buff to "team join" by default
+- Changed messages displayed to the shadow if the join team buff is active to be more accurate
+- Added `ttt_shadow_target_buff_role_copy` convar to control whether the shadow copies the role of the target player if the team join buff is active (disabled by default)
+- Added `ttt_shadow_soul_link` convar to control whether the shadow dies when their target dies and vice-versa (disabled by default)
+- Added `ttt_shadow_soul_link_kill_credit` convar to control whether a player responsible for killing a soul-linked player should get the credit for it, e.g. if a shadow and jester are separated and the shadow dies, the jester wins (disabled by default)
+- Added description in the F1 help menu for the shadow's soul link, if it's turned on
+
+## 1.8.10 (Beta)
 **Released: June 25th, 2023**
 
 ### Additions
@@ -27,7 +38,7 @@
 - Fixed roles promoted by the marshal not having their health adjusted
 - Fixed `ttt_impersonator_detective_chance` not working
 
-### 1.8.9 (Beta)
+## 1.8.9 (Beta)
 **Released: May 28th, 2023**
 
 ### Additions
@@ -41,7 +52,7 @@
 - Fixed beggar client config section showing when traitor scans are not enabled
 - Fixed error in the shadow client code if a non-player ragdoll exists
 
-### 1.8.8 (Beta)
+## 1.8.8 (Beta)
 **Released: May 20th, 2023**
 
 ### Additions
@@ -66,7 +77,7 @@
 - Added `TTTSprintStateChange` hook which runs when a player starts or stops sprinting
 - Added `plymeta:GetSprinting`, `plymeta:SetSprinting`, `plymeta:GetSprintStamina`, and `plymeta:SetSprintStamina`
 
-### 1.8.7 (Beta)
+## 1.8.7 (Beta)
 **Released: May 6th, 2023**
 
 ### Additions
@@ -78,7 +89,7 @@
 - Added `table.HasItemWithPropertyValue` static method
 - Added equipment frame as parameter to `TTTEquipmentTabs`
 
-### 1.8.6 (Beta)
+## 1.8.6 (Beta)
 **Released: April 30th, 2023**
 
 ### Additions

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - Added `ttt_shadow_target_buff_role_copy` convar to control whether the shadow copies the role of the target player if the team join buff is active (disabled by default)
 - Added `ttt_shadow_soul_link` convar to control whether the shadow dies when their target dies and vice-versa (disabled by default)
 - Added description in the F1 help menu for the shadow's soul link, if it's turned on
+- Fixed the shadow not dying if they kill their target
 
 ## 1.8.10 (Beta)
 **Released: June 25th, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,9 +12,6 @@
 - Changed shadow buff to "team join" by default
 - Changed messages displayed to the shadow if the join team buff is active to be more accurate
 
-### Fixes
-- Fixed the shadow not dying if they kill their target
-
 ## 1.8.10 (Beta)
 **Released: June 25th, 2023**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,6 @@
 - Changed messages displayed to the shadow if the join team buff is active to be more accurate
 - Added `ttt_shadow_target_buff_role_copy` convar to control whether the shadow copies the role of the target player if the team join buff is active (disabled by default)
 - Added `ttt_shadow_soul_link` convar to control whether the shadow dies when their target dies and vice-versa (disabled by default)
-- Added `ttt_shadow_soul_link_kill_credit` convar to control whether a player responsible for killing a soul-linked player should get the credit for it, e.g. if a shadow and jester are separated and the shadow dies, the jester wins (disabled by default)
 - Added description in the F1 help menu for the shadow's soul link, if it's turned on
 
 ## 1.8.10 (Beta)

--- a/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
@@ -437,7 +437,14 @@ end)
 hook.Add("TTTTutorialRoleText", "Shadow_TTTTutorialRoleText", function(role, titleLabel)
     if role == ROLE_SHADOW then
         local roleColor = ROLE_COLORS[ROLE_SHADOW]
-        local html = "The " .. ROLE_STRINGS[ROLE_SHADOW] .. " is an <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>independent</span> role that wins by staying close to their target without dying. If the shadow kills their target, they die instantly. If the shadow survives until the end of the round they win."
+        local soul_link = GetGlobalBool("ttt_shadow_soul_link", false)
+        local html = "The " .. ROLE_STRINGS[ROLE_SHADOW] .. " is an <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>independent</span> role that wins by staying close to their target without dying. "
+        if soul_link then
+            html = html .. "If the shadow dies, their target dies and vice-versa. "
+        else
+            html = html .. "If the shadow kills their target, they die instantly. "
+        end
+        html = html .. "If the shadow survives until the end of the round they win."
 
         local start_timer = GetGlobalInt("ttt_shadow_start_timer", 30)
         local buffer_timer = GetGlobalInt("ttt_shadow_buffer_timer", 7)

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -45,6 +45,7 @@ hook.Add("TTTSyncGlobals", "Shadow_TTTSyncGlobals", function()
     SetGlobalFloat("ttt_shadow_speed_mult_max", speed_mult_max:GetFloat())
     SetGlobalFloat("ttt_shadow_sprint_recovery", sprint_recovery:GetFloat())
     SetGlobalFloat("ttt_shadow_sprint_recovery_max", sprint_recovery_max:GetFloat())
+    SetGlobalBool("ttt_shadow_soul_link", soul_link:GetBool())
 end)
 
 -----------------------

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -349,7 +349,6 @@ end)
 hook.Add("PlayerDeath", "Shadow_KillCheck_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if not valid_kill then return end
-    if attacker:IsShadow() then return end
 
     if victim:SteamID64() == attacker:GetNWString("ShadowTarget", "") then
         attacker:Kill()

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -225,7 +225,7 @@ hook.Add("DoPlayerDeath", "Shadow_SoulLink_DoPlayerDeath", function(ply, attacke
     if ply:IsShadow() then
         local target = player.GetBySteamID64(ply:GetNWString("ShadowTarget", ""))
         if IsPlayer(target) and target:Alive() and not target:IsSpec() then
-            KillSoulLinkedPlayer(target, ply:Nick() .. " was your Shadow and died!")
+            KillSoulLinkedPlayer(target, ply:Nick() .. " was your " .. ROLE_STRINGS[ROLE_SHADOW] .. " and died!")
         end
     else
         -- Find the shadows that "belong" to this player, and kill them
@@ -349,6 +349,7 @@ end)
 hook.Add("PlayerDeath", "Shadow_KillCheck_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if not valid_kill then return end
+    if attacker:IsShadow() then return end
 
     if victim:SteamID64() == attacker:GetNWString("ShadowTarget", "") then
         attacker:Kill()

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -95,7 +95,7 @@ local function ClearBuffTimer(shadow, target, sendMessage)
     if buffTimers[timerId] then
         if sendMessage then
             local message = "You got too far from your target and "
-            if target_buff:GetInt() == 4 then
+            if target_buff:GetInt() == SHADOW_BUFF_TEAM_JOIN then
                 message = message .. "stopped joining their team!"
             else
                 message = message .. "stopped buffing them!"
@@ -127,7 +127,7 @@ local function CreateBuffTimer(shadow, target)
 
     local buffDelay = target_buff_delay:GetInt()
     local message = "Stay with your target for " .. buffDelay .. " seconds to "
-    if target_buff:GetInt() == 4 then
+    if target_buff:GetInt() == SHADOW_BUFF_TEAM_JOIN then
         message = message .. "join their team!"
     else
         message = message .. "give them a buff!"
@@ -252,7 +252,7 @@ hook.Add("DoPlayerDeath", "Shadow_SoulLink_DoPlayerDeath", function(ply, attacke
         end
     else
         -- Find the shadows that "belong" to this player, and kill them
-        for _, p in ipairs(player.GetAll()) do
+        for _, p in ipairs(GetAllPlayers()) do
             if p:IsShadow() then
                 local target = player.GetBySteamID64(ply:GetNWString("ShadowTarget", ""))
                 if IsPlayer(target) and target == ply and p:Alive() and not p:IsSpec() then

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -17,19 +17,22 @@ local start_timer = CreateConVar("ttt_shadow_start_timer", "30", FCVAR_NONE, "Ho
 local buffer_timer = CreateConVar("ttt_shadow_buffer_timer", "7", FCVAR_NONE, "How much time (in seconds) the shadow can stay of their target's radius", 1, 30)
 local alive_radius = CreateConVar("ttt_shadow_alive_radius", "8", FCVAR_NONE, "The radius (in meters) from the living target that the shadow has to stay within", 1, 15)
 local dead_radius = CreateConVar("ttt_shadow_dead_radius", "3", FCVAR_NONE, "The radius (in meters) from the death target that the shadow has to stay within", 1, 15)
-local target_buff = CreateConVar("ttt_shadow_target_buff", "1", FCVAR_NONE, "The type of buff to shadow's target should get. 0 - None. 1 - Heal over time. 2 - Single respawn. 3 - Damage bonus. 4 - Team join", 0, 4)
+local target_buff = CreateConVar("ttt_shadow_target_buff", "4", FCVAR_NONE, "The type of buff to shadow's target should get. 0 - None. 1 - Heal over time. 2 - Single respawn. 3 - Damage bonus. 4 - Team join", 0, 4)
 local target_buff_notify = CreateConVar("ttt_shadow_target_buff_notify", "1", FCVAR_NONE, "Whether the shadow's target should be notified when they are buffed", 0, 1)
 local target_buff_delay = CreateConVar("ttt_shadow_target_buff_delay", "60", FCVAR_NONE, "How long (in seconds) the shadow needs to be near their target before the buff takes effect", 1, 120)
 local target_buff_heal_amount = CreateConVar("ttt_shadow_target_buff_heal_amount", "5", FCVAR_NONE, "The amount of health the shadow's target should be healed per-interval", 1, 100)
 local target_buff_heal_interval = CreateConVar("ttt_shadow_target_buff_heal_interval", "10", FCVAR_NONE, "How often (in seconds) the shadow's target should be healed", 1, 100)
 local target_buff_respawn_delay = CreateConVar("ttt_shadow_target_buff_respawn_delay", "10", FCVAR_NONE, "How often (in seconds) before the shadow's target should respawn", 1, 120)
 local target_buff_damage_bonus = CreateConVar("ttt_shadow_target_buff_damage_bonus", "0.15", FCVAR_NONE, "Damage bonus the shadow's target should get (e.g. 0.15 = 15% extra damage)", 0.05, 1)
+local target_buff_role_copy = CreateConVar("ttt_shadow_target_buff_role_copy", "0", FCVAR_NONE, "Whether the shadow should instead copy the role of their target if the team join buff is enabled", 0, 1)
 local speed_mult = CreateConVar("ttt_shadow_speed_mult", "1.1", FCVAR_NONE, "The minimum multiplier to use on the shadow's sprint speed when they are outside of their target radius (e.g. 1.1 = 110% normal speed)", 1, 2)
 local speed_mult_max = CreateConVar("ttt_shadow_speed_mult_max", "1.5", FCVAR_NONE, "The maximum multiplier to use on the shadow's sprint speed when they are FAR outside of their target radius (e.g. 1.5 = 150% normal speed)", 1, 2)
 local sprint_recovery = CreateConVar("ttt_shadow_sprint_recovery", "0.1", FCVAR_NONE, "The minimum amount of stamina to recover per tick when the shadow is outside of their target radius", 0, 1)
 local sprint_recovery_max = CreateConVar("ttt_shadow_sprint_recovery_max", "0.5", FCVAR_NONE, "The maximum amount of stamina to recover per tick when the shadow is FAR outside of their target radius", 0, 1)
 local target_jester = CreateConVar("ttt_shadow_target_jester", "1", FCVAR_NONE, "Whether the shadow should be able to target a member of the jester team", 0, 1)
 local target_independent = CreateConVar("ttt_shadow_target_independent", "1", FCVAR_NONE, "Whether the shadow should be able to target an independent player", 0, 1)
+local soul_link = CreateConVar("ttt_shadow_soul_link", "0", FCVAR_NONE, "Whether the shadow should die when their target dies and vice-versa", 0, 1)
+local soul_link_kill_credit = CreateConVar("ttt_shadow_soul_link_kill_credit", "0", FCVAR_NONE, "Whether a player responsible for killing a soul-linked player should get the credit for it (e.g. If a shadow and jester are separated and the shadow dies, the jester wins)", 0, 1)
 
 hook.Add("TTTSyncGlobals", "Shadow_TTTSyncGlobals", function()
     SetGlobalInt("ttt_shadow_start_timer", start_timer:GetInt())
@@ -90,7 +93,12 @@ local function ClearBuffTimer(shadow, target, sendMessage)
     local timerId = "TTTShadowBuffTimer_" .. shadow:SteamID64() .. "_" .. target:SteamID64()
     if buffTimers[timerId] then
         if sendMessage then
-            local message = "You got too far from your target and stopped buffing them!"
+            local message = "You got too far from your target and "
+            if target_buff:GetInt() == 4 then
+                message = message .. "stopped joining their team!"
+            else
+                message = message .. "stopped buffing them!"
+            end
             shadow:PrintMessage(HUD_PRINTCENTER, message)
             shadow:PrintMessage(HUD_PRINTTALK, message)
         end
@@ -117,7 +125,12 @@ local function CreateBuffTimer(shadow, target)
     if buffTimers[timerId] then return end
 
     local buffDelay = target_buff_delay:GetInt()
-    local message = "Stay with your target for " .. buffDelay .. " seconds to give them a buff!"
+    local message = "Stay with your target for " .. buffDelay .. " seconds to "
+    if target_buff:GetInt() == 4 then
+        message = message .. "join their team!"
+    else
+        message = message .. "give them a buff!"
+    end
     shadow:PrintMessage(HUD_PRINTCENTER, message)
     shadow:PrintMessage(HUD_PRINTTALK, message)
 
@@ -136,8 +149,9 @@ local function CreateBuffTimer(shadow, target)
         if buff == SHADOW_BUFF_TEAM_JOIN then
             local role = ROLE_INNOCENT
             local role_team = target:GetRoleTeam(true)
-            -- Copy the player's role if they are on a team that is usually one role by itself
-            if role_team == ROLE_TEAM_JESTER or
+            -- Copy the player's role if the copy role convar is enabled, or they are on a team that is usually one role by itself
+            if target_buff_role_copy:GetBool() or
+                    role_team == ROLE_TEAM_JESTER or
                     role_team == ROLE_TEAM_INDEPENDENT or
                     role_team == ROLE_TEAM_MONSTER then
                 role = target:GetRole()
@@ -194,6 +208,58 @@ hook.Add("ScalePlayerDamage", "Shadow_Buff_ScalePlayerDamage", function(ply, hit
     if not att:GetNWBool("ShadowBuffActive", false) then return end
 
     dmginfo:ScaleDamage(1 + target_buff_damage_bonus:GetFloat())
+end)
+
+-- Used for the shadow's soul-link convar
+local function CopyKillPlayer(ply, attacker, dmg, msg)
+    if not IsPlayer(ply) then return end
+
+    local killDmg = DamageInfo()
+    killDmg:SetDamage(ply:Health() + 1)
+    killDmg:SetDamageType(dmg:GetDamageType())
+    -- If disabled, prevents things like the jester winning if their soul-linked shadow dies
+    if soul_link_kill_credit:GetBool() then
+        local inflictor = dmg:GetInflictor()
+        if IsValid(inflictor) then
+            killDmg:SetInflictor(inflictor)
+        end
+        if IsPlayer(attacker) then
+            killDmg:SetAttacker(attacker)
+        end
+    else
+        killDmg:SetAttacker(ply)
+    end
+    ply:TakeDamageInfo(killDmg)
+
+    -- If the player somehow survives, force-kill them
+    timer.Simple(0.1, function()
+        if IsPlayer(ply) and ply:Alive() and not ply:IsSpec() then
+            ply:Kill()
+        end
+        ply:PrintMessage(HUD_PRINTCENTER, msg)
+        ply:PrintMessage(HUD_PRINTTALK, msg)
+    end)
+end
+
+hook.Add("DoPlayerDeath", "Shadow_SoulLink_DoPlayerDeath", function(ply, attacker, dmg)
+    if not soul_link:GetBool() or not IsPlayer(ply) then return end
+    -- Kill the shadow's target as well
+    if ply:IsShadow() then
+        local target = player.GetBySteamID64(ply:GetNWString("ShadowTarget", ""))
+        if IsPlayer(target) and target:Alive() and not target:IsSpec() then
+            CopyKillPlayer(target, attacker, dmg, ply:Nick() .. " was your Shadow and died!")
+        end
+    else
+        -- Find the shadows that "belong" to this player, and kill them
+        for _, p in ipairs(player.GetAll()) do
+            if p:IsShadow() then
+                local target = player.GetBySteamID64(ply:GetNWString("ShadowTarget", ""))
+                if IsPlayer(target) and target == ply and p:Alive() and not p:IsSpec() then
+                    CopyKillPlayer(p, attacker, dmg, "Your target died!")
+                end
+            end
+        end
+    end
 end)
 
 hook.Add("PostPlayerDeath", "Shadow_Buff_PostPlayerDeath", function(ply)

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -231,7 +231,7 @@ hook.Add("DoPlayerDeath", "Shadow_SoulLink_DoPlayerDeath", function(ply, attacke
         -- Find the shadows that "belong" to this player, and kill them
         for _, p in ipairs(GetAllPlayers()) do
             if p:IsShadow() then
-                local target = player.GetBySteamID64(ply:GetNWString("ShadowTarget", ""))
+                local target = player.GetBySteamID64(p:GetNWString("ShadowTarget", ""))
                 if IsPlayer(target) and target == ply and p:Alive() and not p:IsSpec() then
                     KillSoulLinkedPlayer(p, "Your target died!")
                 end

--- a/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
@@ -148,6 +148,10 @@ table.insert(ROLE_CONVARS[ROLE_SHADOW], {
     decimal = 2
 })
 table.insert(ROLE_CONVARS[ROLE_SHADOW], {
+    cvar = "ttt_shadow_target_buff_role_copy",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_SHADOW], {
     cvar = "ttt_shadow_speed_mult",
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 1
@@ -173,5 +177,13 @@ table.insert(ROLE_CONVARS[ROLE_SHADOW], {
 })
 table.insert(ROLE_CONVARS[ROLE_SHADOW], {
     cvar = "ttt_shadow_target_independent",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_SHADOW], {
+    cvar = "ttt_shadow_soul_link",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_SHADOW], {
+    cvar = "ttt_shadow_soul_link_kill_credit",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
@@ -183,7 +183,3 @@ table.insert(ROLE_CONVARS[ROLE_SHADOW], {
     cvar = "ttt_shadow_soul_link",
     type = ROLE_CONVAR_TYPE_BOOL
 })
-table.insert(ROLE_CONVARS[ROLE_SHADOW], {
-    cvar = "ttt_shadow_soul_link_kill_credit",
-    type = ROLE_CONVAR_TYPE_BOOL
-})

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -27,7 +27,7 @@ end
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.8.10"
+CR_VERSION = "1.8.11"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
- Changed messages displayed to shadow if the join team buff is active
- Join team buff is now the default buff
- Added convars for the shadow and target to be soul-linked,
the shadow to copy the role of their target rather than become a basic team member role,
and whether credit is given to killing a soul-linked player for purposes of things like a jester winning
- Added help description if soul link is turned on for the shadow