### PR TITLE
1.9.0 Arsonist Hotfixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,9 @@ Includes beta updates [1.8.3](#183-beta) to [1.8.11](#1811-beta).
 
 ### Fixes
 - Fixed phantoms being stuck possessing a dead player if their attacker died before they did
+- Fixed everyone being able to see whether someone was doused by the arsonist on the scoreboard
+- Fixed players being notified that they were doused by the arsonist after they were already ignited
+- Fixed players being notified that they were doused by the arsonist even if they were dead
 
 ### Developer
 - Removed old, unused code from the paramedic's defib, hypnotist's brainwashing device, and mad scientists zombification device

--- a/gamemodes/terrortown/entities/weapons/weapon_ars_igniter.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ars_igniter.lua
@@ -108,6 +108,9 @@ function SWEP:PrimaryAttack()
         local message = "You have been ignited by the " .. ROLE_STRINGS[ROLE_ARSONIST] .. "!"
         p:PrintMessage(HUD_PRINTCENTER, message)
         p:PrintMessage(HUD_PRINTTALK, message)
+
+        -- Remove the notification delay timer since the message above already tells them the same thing
+        timer.Remove("TTTArsonistNotifyDelay_" .. p:SteamID64())
     end
 
     -- Log the event

--- a/gamemodes/terrortown/gamemode/roles/arsonist/arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/arsonist.lua
@@ -142,6 +142,11 @@ hook.Add("Think", "Arsonist_Douse_Think", function()
     end
 end)
 
+hook.Add("PostPlayerDeath", "Arsonist_PostPlayerDeath", function(ply)
+    -- Remove the notification delay timer since the player is already dead
+    timer.Remove("TTTArsonistNotifyDelay_" .. ply:SteamID64())
+end)
+
 hook.Add("TTTPrepareRound", "Arsonist_TTTPrepareRound", function()
     for _, v in pairs(GetAllPlayers()) do
         v:SetNWInt("TTTArsonistDouseStage", ARSONIST_UNDOUSED)

--- a/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
@@ -61,6 +61,7 @@ end)
 -- Show "DOUSED" label on the players who have been doused
 hook.Add("TTTScoreboardPlayerName", "Arsonist_TTTScoreboardPlayerName", function(ply, cli, text)
     if GetRoundState() < ROUND_ACTIVE then return end
+    if not cli:IsArsonist() then return end
 
     local state = ply:GetNWInt("TTTArsonistDouseStage", ARSONIST_UNDOUSED)
     if state ~= ARSONIST_DOUSED then return end


### PR DESCRIPTION
- Fixed everyone being able to see whether someone was doused by the arsonist on the scoreboard
- Fixed players being notified that they were doused by the arsonist after they were already ignited
- Fixed players being notified that they were doused by the arsonist even if they were dead