### PR TITLE
1.9.0 Hotfixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@ Includes beta updates [1.8.3](#183-beta) to [1.8.11](#1811-beta).
 ### Changes
 - Changed shadow buff delay to 90 seconds by default
 - Changed shadow target buff notifications to be disabled by default
+- Changed shadow who killed their target to die immediately upon respawn (by defib, etc.)
 - Changed loot goblin win tracking logic to hopefully fix the case where the round summary will show a loot goblin win when that role wasn't in the round
 
 ### Fixes

--- a/gamemodes/terrortown/gamemode/deathnotify.lua
+++ b/gamemodes/terrortown/gamemode/deathnotify.lua
@@ -23,7 +23,7 @@ hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, inflictor, att
         reason = "water"
     elseif attacker == victim then
         reason = "suicide"
-    elseif inflictor then
+    elseif inflictor ~= NULL then
         if IsPlayer(victim) and (StringStartsWith(inflictor:GetClass(), "prop_physics") or inflictor:GetClass() == "prop_dynamic") then
             -- If the killer is also a prop
             reason = "prop"

--- a/gamemodes/terrortown/gamemode/deathnotify.lua
+++ b/gamemodes/terrortown/gamemode/deathnotify.lua
@@ -28,8 +28,7 @@ hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, inflictor, att
             -- If the killer is also a prop
             reason = "prop"
         elseif attacker then
-            if (inflictor:GetClass() == "entityflame" and attacker:GetClass() == "entityflame") or
-                (inflictor:GetClass() == "env_fire" and attacker:GetClass() == "env_fire") then
+            if inflictor:GetClass() == "entityflame" or inflictor:GetClass() == "env_fire" then
                 reason = "burned"
             elseif inflictor:GetClass() == "worldspawn" and attacker:GetClass() == "worldspawn" then
                 reason = "fell"

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -369,7 +369,7 @@ end)
 hook.Add("PlayerDeath", "Shadow_KillCheck_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if not valid_kill then return end
-    if attacker:IsShadow() then return end
+    if not attacker:IsShadow() then return end
 
     if victim:SteamID64() == attacker:GetNWString("ShadowTarget", "") then
         attacker:Kill()

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -355,7 +355,13 @@ hook.Add("TTTBeginRound", "Shadow_TTTBeginRound", function()
 end)
 
 hook.Add("PlayerSpawn", "Shadow_PlayerSpawn", function(ply, transition)
+    if GetRoundState() ~= ROUND_ACTIVE then return end
+
     if ply:IsShadow() then
+        -- If you killed your target, you stay dead!
+        if ply:GetNWString("ShadowTarget", "") then
+            ply:Kill()
+        end
         ply:SetNWFloat("ShadowTimer", CurTime() + start_timer:GetInt())
     end
 end)


### PR DESCRIPTION
- Changed shadow who killed their target to die immediately upon respawn (by defib, etc.)
  - Without this the shadow would trigger an error have no target when they respawned
- Fixed shadow not being killed when they killed their target
- Fixed error with invalid inflictor in the death notify system
- Fixed death notify for burns not working with fire caused by players