### PR TITLE
Fixed issues with Clown/Loot Goblin icon incompatibility

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Additions
 - Added target icon above undoused player's heads for the arsonist, lover's heads for cupid and the lovers, and the shadow's target's head for the shadow
+- Added jester player information to the clown's scoreboard when they are active, matching their target ID (icon, ring, text) visibility
 
 ### Changes
 - Changed appearance of 'KILL' icon used by multiple roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 - Fixed clown seeing jester icons (instead of question mark icons) over all jester team members' heads when they are activated
+- Fixed clown seeing jester icon over the activated loot goblin's head (instead of the loot goblin icon)
 
 ### Developer
 - Changed `plymeta:IsActive` to ensure the player is alive like it was always supposed to

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 - Added `TTTTargetIDPlayerTargetIcon` hook to control what target icon and background color should be shown over the target's head
 - **BREAKING CHANGE** - Deprecated `TTTTargetIDPlayerKillIcon`
   - Use the `TTTTargetIDPlayerTargetIcon` hook instead and return `"kill", true, ROLE_COLORS_SPRITE[ply:GetRole()], "down"`
+- Fixed loot goblin's definition of `ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN` and `ROLE_IS_TARGETID_OVERRIDDEN` using the parameters backwards
 
 ## 1.9.3 (Beta)
 **Released: July 29th, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,9 @@
 - Changed appearance of 'KILL' icon used by multiple roles
 - Expanded the `ttt_roleweapons` command to have additional modes such as list, clean, and reload. See the command documentation for more information.
 
+### Fixes
+- Fixed clown seeing jester icons (instead of question mark icons) over all jester team members' heads when they are activated
+
 ### Developer
 - Changed `plymeta:IsActive` to ensure the player is alive like it was always supposed to
 - Added `weapon_cr_defibbase` and updated all defib-like weapons to use it

--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -106,7 +106,7 @@ function ENT:UseOverride(activator)
     if IsPlayer(activator) then
         -- Traitors not allowed to disarm other traitor's C4 until he is dead
         local owner = self:GetOwner()
-        if self:GetArmed() and owner ~= activator and activator:IsTraitorTeam() and (IsValid(owner) and owner:Alive() and owner:IsTraitorTeam()) then
+        if self:GetArmed() and owner ~= activator and activator:IsTraitorTeam() and (IsValid(owner) and owner:IsActiveTraitorTeam()) then
             LANG.Msg(activator, "c4_no_disarm", { traitor = ROLE_STRINGS[ROLE_TRAITOR] })
             return
         end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -431,7 +431,7 @@ end
 function GM:Tick()
     local client = LocalPlayer()
     if IsValid(client) then
-        if client:IsActive() then
+        if client:Alive() and client:Team() ~= TEAM_SPEC then
             WSWITCH:Think()
             RADIO:StoreTarget()
             if traitor_vision then

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -404,23 +404,21 @@ function GM:Think()
                 if not v.SmokeEmitter then v.SmokeEmitter = ParticleEmitter(v:GetPos()) end
                 if not v.SmokeNextPart then v.SmokeNextPart = CurTime() end
                 local pos = v:GetPos() + smokeOffset
-                if v.SmokeNextPart < CurTime() then
-                    if client:GetPos():Distance(pos) <= 3000 then
-                        v.SmokeEmitter:SetPos(pos)
-                        v.SmokeNextPart = CurTime() + MathRand(0.003, 0.01)
-                        local vec = Vector(MathRand(-8, 8), MathRand(-8, 8), MathRand(10, 55))
-                        local particle = v.SmokeEmitter:Add(smokeParticle, v:LocalToWorld(vec))
-                        particle:SetVelocity(Vector(0, 0, 4) + VectorRand() * 3)
-                        particle:SetDieTime(MathRand(0.5, 2))
-                        particle:SetStartAlpha(MathRandom(150, 220))
-                        particle:SetEndAlpha(0)
-                        local size = MathRandom(4, 7)
-                        particle:SetStartSize(size)
-                        particle:SetEndSize(size + 1)
-                        particle:SetRoll(0)
-                        particle:SetRollDelta(0)
-                        particle:SetColor(smokeColor.r, smokeColor.g, smokeColor.b)
-                    end
+                if v.SmokeNextPart < CurTime() and client:GetPos():Distance(pos) <= 3000 then
+                    v.SmokeEmitter:SetPos(pos)
+                    v.SmokeNextPart = CurTime() + MathRand(0.003, 0.01)
+                    local vec = Vector(MathRand(-8, 8), MathRand(-8, 8), MathRand(10, 55))
+                    local particle = v.SmokeEmitter:Add(smokeParticle, v:LocalToWorld(vec))
+                    particle:SetVelocity(Vector(0, 0, 4) + VectorRand() * 3)
+                    particle:SetDieTime(MathRand(0.5, 2))
+                    particle:SetStartAlpha(MathRandom(150, 220))
+                    particle:SetEndAlpha(0)
+                    local size = MathRandom(4, 7)
+                    particle:SetStartSize(size)
+                    particle:SetEndSize(size + 1)
+                    particle:SetRoll(0)
+                    particle:SetRollDelta(0)
+                    particle:SetColor(smokeColor.r, smokeColor.g, smokeColor.b)
                 end
             elseif v.SmokeEmitter then
                 v.SmokeEmitter:Finish()
@@ -433,7 +431,7 @@ end
 function GM:Tick()
     local client = LocalPlayer()
     if IsValid(client) then
-        if client:Alive() and client:Team() ~= TEAM_SPEC then
+        if client:IsActive() then
             WSWITCH:Think()
             RADIO:StoreTarget()
             if traitor_vision then

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -558,7 +558,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
                 local finalRole = startingRole
 
                 if IsValid(ply) then
-                    alive = ply:IsActive()
+                    alive = ply:Alive() and not ply:IsSpec()
                     finalRole = ply:GetRole()
                     -- Sanity check to make sure only valid roles are used for icons and stuff
                     if not finalRole or finalRole <= ROLE_NONE or finalRole > ROLE_MAX then

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -902,7 +902,7 @@ function BeginRound()
     net.Broadcast()
 
     for _, v in pairs(GetAllPlayers()) do
-        if v:IsActive() then
+        if v:Alive() and v:IsTerror() then
             net.Start("TTT_SpawnedPlayers")
             net.WriteString(v:Nick())
             net.WriteInt(v:GetRole(), 8)

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -154,7 +154,7 @@ function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
     local blocking = FindEntsInBox(pos + Vector(-16, -16, 0), pos + Vector(16, 16, 64))
 
     for _, p in ipairs(blocking) do
-        if IsPlayer(p) and p:IsActive() then
+        if IsPlayer(p) and p:IsTerror() and p:Alive() then
             if force then
                 p:Kill()
             else

--- a/gamemodes/terrortown/gamemode/roles/arsonist/arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/arsonist.lua
@@ -214,7 +214,7 @@ hook.Add("TTTPrepareRound", "Arsonist_TTTPrepareRound", function()
 end)
 
 hook.Add("TTTPlayerSpawnForRound", "Arsonist_TTTPlayerSpawnForRound", function(ply, dead_only)
-    if dead_only and ply:IsActive() then return end
+    if dead_only and ply:Alive() and not ply:IsSpec() then return end
 
     -- Player is respawning that has not been doused
     if ply:GetNWInt("TTTArsonistDouseStage", ARSONIST_UNDOUSED) == ARSONIST_UNDOUSED then

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -53,7 +53,7 @@ end
 hook.Add("TTTTargetIDPlayerRoleIcon", "Clown_TTTTargetIDPlayerRoleIcon", function(ply, cli, role, noz, color_role, hideBeggar, showJester, hideBodysnatcher)
     -- If the local client is an activated clown and the target is a jester, show the jester icon
     if IsClownActive(cli) and ply:ShouldActLikeJester() then
-        return ROLE_JESTER, false, ROLE_JESTER
+        return ROLE_NONE, false, ROLE_JESTER
     end
     -- Show the clown icon if the target is an activated clown
     if IsClownVisible(ply) then
@@ -79,7 +79,8 @@ hook.Add("TTTTargetIDPlayerText", "Clown_TTTTargetIDPlayerText", function(ent, c
 
     -- If the local client is an activated clown and the target is a jester, show the jester information
     if IsPlayer(ent) and IsClownActive(cli) and ent:ShouldActLikeJester() then
-        return StringUpper(ROLE_STRINGS[ROLE_JESTER]), ROLE_COLORS_RADAR[ROLE_JESTER]
+        local role_string = LANG.GetParamTranslation("target_unknown_team", { targettype = LANG.GetTranslation("jester")})
+        return StringUpper(role_string), ROLE_COLORS_RADAR[ROLE_JESTER]
     end
     if IsClownVisible(ent) then
         return StringUpper(ROLE_STRINGS[ROLE_CLOWN]), ROLE_COLORS_RADAR[ROLE_CLOWN]

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -155,17 +155,32 @@ end)
 -- SCOREBOARD --
 ----------------
 
-hook.Add("TTTScoreboardPlayerRole", "Clown_TTTScoreboardPlayerRole", function(ply, client, color, roleFileName)
+hook.Add("TTTScoreboardPlayerRole", "Clown_TTTScoreboardPlayerRole", function(ply, cli, color, roleFileName)
+    -- If the local client is an activated clown and the target is a jester, show the jester icon
+    if IsClownActive(cli) and ply:ShouldActLikeJester() then
+        local _, role_overridden = ply:IsScoreboardInfoOverridden(cli)
+        if role_overridden then return end
+
+        return ROLE_COLORS_SCOREBOARD[ROLE_JESTER], ROLE_STRINGS_SHORT[ROLE_NONE]
+    end
     if IsClownVisible(ply) then
         return ROLE_COLORS_SCOREBOARD[ROLE_CLOWN], ROLE_STRINGS_SHORT[ROLE_CLOWN]
     end
 end)
 
 ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_CLOWN] = function(ply, target)
-    if not IsClownVisible(target) then return end
+    if not IsPlayer(target) then return end
+
+    local role_overridden = false
+    local target_jester = IsClownActive(ply) and target:ShouldActLikeJester()
+    -- We only care about whether these are overridden if the target is a tester
+    if target_jester then
+        _, role_overridden = target:IsScoreboardInfoOverridden(ply)
+    end
+    local visible = IsClownVisible(target)
 
     ------ name,  role
-    return false, true
+    return false, (target_jester and not role_overridden) or visible
 end
 
 -------------------

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -286,7 +286,7 @@ local function EnableLoverHighlights()
     AddHook("PreDrawHalos", "Cupid_Highlight_PreDrawHalos", function()
         local lover = client:GetNWString("TTTCupidLover", "")
         local loverPly = player.GetBySteamID64(lover)
-        if not IsPlayer(loverPly) or not loverPly:Alive() or not loverPly:IsTerror() then return end
+        if not IsPlayer(loverPly) or not loverPly:IsActive() then return end
 
         HaloAdd({ loverPly }, Color(230, 90, 200, 255), 1, 1, 1, true, true)
     end)

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -123,7 +123,7 @@ hook.Add("TTTPrepareRound", "Killer_Smoke_PrepareRound", function()
 end)
 
 hook.Add("TTTPlayerSpawnForRound", "Killer_Smoke_TTTPlayerSpawnForRound", function(ply, dead_only)
-    if dead_only and ply:IsActive() then return end
+    if dead_only and ply:Alive() and not ply:IsSpec() then return end
 
     ply:SetNWBool("KillerSmoke", false)
 end)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -73,9 +73,9 @@ hook.Add("TTTTargetIDPlayerText", "LootGoblin_TTTTargetIDPlayerText", function(e
 end)
 
 ROLE_IS_TARGETID_OVERRIDDEN[ROLE_LOOTGOBLIN] = function(ply, target)
-    if not IsPlayer(target) then return end
-    if not target:IsActiveLootGoblin() then return end
-    if not target:IsRoleActive() then return end
+    if not IsPlayer(ply) then return end
+    if not ply:IsActiveLootGoblin() then return end
+    if not ply:IsRoleActive() then return end
     if not lootgoblin_active_display:GetBool() then return end
 
     ------ icon, ring, text
@@ -151,9 +151,9 @@ hook.Add("TTTScoreboardPlayerRole", "LootGoblin_TTTScoreboardPlayerRole", functi
 end)
 
 ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_LOOTGOBLIN] = function(ply, target)
-    if not IsPlayer(target) then return end
-    if not target:IsActiveLootGoblin() then return end
-    if not target:IsRoleActive() then return end
+    if not IsPlayer(ply) then return end
+    if not ply:IsActiveLootGoblin() then return end
+    if not ply:IsRoleActive() then return end
     if not lootgoblin_active_display:GetBool() then return end
 
     ------ name,  role

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -80,7 +80,7 @@ end)
 local function StartRegen(ply)
     local rate = lootgoblin_regen_rate:GetInt()
     timer.Create("LootGoblinRegen_" .. ply:SteamID64(), rate, 0, function()
-        if ply:IsActive() and ply:IsLootGoblin() then
+        if ply:IsActiveLootGoblin() then
             local hp = ply:Health()
             if hp < ply:GetMaxHealth() then
                 ply:SetHealth(hp + 1)
@@ -110,7 +110,7 @@ hook.Add("FinishMove", "LootGoblin_FinishMove", function(ply, mv)
     local mode = lootgoblin_regen_mode:GetInt()
     if mode ~= LOOTGOBLIN_REGEN_MODE_STILL then return end
 
-    if ply:IsLootGoblin() and ply:IsActive() and ply:IsRoleActive() then
+    if ply:IsActiveLootGoblin() and ply:IsRoleActive() then
         local loc = ply:GetPos()
         local sid64 = ply:SteamID64()
         -- Keep track of when a player moves and stop regeneration when they do
@@ -131,7 +131,7 @@ hook.Add("PostEntityTakeDamage", "LootGoblin_PostEntityTakeDamage", function(ent
     local dmg = dmginfo:GetDamage()
     if dmg <= 0 then return end
 
-    if not ent:IsLootGoblin() or not ent:Alive() or ent:IsSpec() or not ent:IsRoleActive() then return end
+    if not ent:IsActiveLootGoblin() or not ent:IsRoleActive() then return end
 
     local mode = lootgoblin_regen_mode:GetInt()
     if mode ~= LOOTGOBLIN_REGEN_MODE_AFTER_DAMAGE then return end
@@ -191,7 +191,7 @@ local function StartGoblinTimers()
     local goblinTime = MathRandom(goblinTimeMin, goblinTimeMax)
     SetGlobalFloat("ttt_lootgoblin_activate", CurTime() + goblinTime)
     for _, v in ipairs(GetAllPlayers()) do
-        if v:IsLootGoblin() and v:IsActive() then
+        if v:IsActiveLootGoblin() then
             v:PrintMessage(HUD_PRINTTALK, "You will transform into a goblin in " .. tostring(goblinTime) .. " seconds!")
         end
     end
@@ -199,7 +199,7 @@ local function StartGoblinTimers()
         lootGoblinActive = true
         local revealMode = lootgoblin_announce:GetInt()
         for _, v in ipairs(GetAllPlayers()) do
-            if v:IsLootGoblin() and v:IsActive() then
+            if v:IsActiveLootGoblin() then
                 ActivateLootGoblin(v)
             elseif revealMode == JESTER_NOTIFY_EVERYONE or
                     (v:IsActiveTraitorTeam() and (revealMode == JESTER_NOTIFY_TRAITOR or JESTER_NOTIFY_DETECTIVE_AND_TRAITOR)) or
@@ -218,7 +218,7 @@ local function StartGoblinTimers()
             end
             timer.Create("LootGoblinCackle", MathRandom(min, max), 0, function()
                 for _, v in ipairs(GetAllPlayers()) do
-                    if v:IsLootGoblin() and v:IsActive() and not v:GetNWBool("LootGoblinKilled", false) then
+                    if v:IsActiveLootGoblin() and not v:GetNWBool("LootGoblinKilled", false) then
                         local idx = MathRandom(1, #cackles)
                         local chosen_sound = cackles[idx]
                         sound.Play(chosen_sound, v:GetPos())
@@ -239,7 +239,7 @@ local function HandleLootGoblinWinChecks(win_type)
 
     local hasLootGoblin = false
     for _, v in ipairs(GetAllPlayers()) do
-        if v:IsLootGoblin() and v:IsActive() and not v:GetNWBool("LootGoblinKilled", false) then
+        if v:IsActiveLootGoblin() and not v:GetNWBool("LootGoblinKilled", false) then
             hasLootGoblin = true
         end
     end
@@ -346,7 +346,7 @@ hook.Add("TTTBeginRound", "LootGoblin_Radar_TTTBeginRound", function()
 
     timer.Create("LootGoblinRadarDelay", 1, 0, function()
         for _, v in ipairs(GetAllPlayers()) do
-            if v:IsLootGoblin() and v:IsActive() then
+            if v:IsActiveLootGoblin() then
                 local locations = goblins[v:SteamID64()]
                 if locations == nil then
                     locations = {}

--- a/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
+++ b/gamemodes/terrortown/gamemode/roles/paladin/cl_paladin.lua
@@ -72,7 +72,7 @@ hook.Add("HUDPaintBackground", "Paladin_HUDPaintBackground", function()
 
     local inside = false
     for _, p in pairs(GetAllPlayers()) do
-        if p:IsActive() and p:Alive() and p:GetDisplayedRole() == ROLE_PALADIN and client:GetPos():Distance(p:GetPos()) <= (paladin_aura_radius:GetFloat() * UNITS_PER_METER) then
+        if p:IsActive() and p:GetDisplayedRole() == ROLE_PALADIN and client:GetPos():Distance(p:GetPos()) <= (paladin_aura_radius:GetFloat() * UNITS_PER_METER) then
             inside = true
             break
         end

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -272,7 +272,7 @@ hook.Add("DoPlayerDeath", "Parasite_DoPlayerDeath", function(ply, attacker, dmgi
                 local transfer = parasite_infection_transfer:GetBool()
                 local suicideMode = parasite_infection_suicide_mode:GetInt()
                 -- Transfer the infection to the new attacker if there is one, they are alive, the parasite is still alive, and the transfer feature is enabled
-                if IsPlayer(attacker) and attacker:Alive() and parasiteDead and transfer then
+                if IsPlayer(attacker) and attacker:IsActive() and parasiteDead and transfer then
                     deadParasites[key].attacker = attacker:SteamID64()
                     HandleParasiteInfection(attacker, deadParasite, not parasite_infection_transfer_reset:GetBool())
                     deadParasite:PrintMessage(HUD_PRINTCENTER, "Your host has been killed and your infection has spread to their killer.")

--- a/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
@@ -114,7 +114,7 @@ hook.Add("PlayerDeath", "Phantom_PlayerDeath", function(victim, infl, attacker)
 
         if phantom_announce_death:GetBool() then
             for _, v in pairs(GetAllPlayers()) do
-                if v ~= attacker and v:IsDetectiveLike() and v:IsActive() and v:SteamID64() ~= loverSID then
+                if v ~= attacker and v:IsActiveDetectiveLike() and v:SteamID64() ~= loverSID then
                     v:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_PHANTOM] .. " has been killed.")
                 end
             end
@@ -309,7 +309,7 @@ hook.Add("DoPlayerDeath", "Phantom_DoPlayerDeath", function(ply, attacker, dmgin
 
         if respawn and phantom_announce_death:GetBool() then
             for _, v in pairs(GetAllPlayers()) do
-                if v:IsDetectiveLike() and v:IsActive() then
+                if v:IsActiveDetectiveLike() then
                     v:PrintMessage(HUD_PRINTCENTER, "The " .. ROLE_STRINGS[ROLE_PHANTOM] .. " has been respawned.")
                 end
             end

--- a/gamemodes/terrortown/gamemode/roles/sapper/cl_sapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/sapper/cl_sapper.lua
@@ -96,7 +96,7 @@ hook.Add("HUDPaintBackground", "Sapper_HUDPaintBackground", function()
 
     local inside = false
     for _, p in pairs(GetAllPlayers()) do
-        if p:IsActive() and p:Alive() and p:GetDisplayedRole() == ROLE_SAPPER and client:GetPos():Distance(p:GetPos()) <= (sapper_aura_radius:GetInt() * UNITS_PER_METER) then
+        if p:IsActive() and p:GetDisplayedRole() == ROLE_SAPPER and client:GetPos():Distance(p:GetPos()) <= (sapper_aura_radius:GetInt() * UNITS_PER_METER) then
             inside = true
             break
         end

--- a/gamemodes/terrortown/gamemode/roles/sponge/cl_sponge.lua
+++ b/gamemodes/terrortown/gamemode/roles/sponge/cl_sponge.lua
@@ -79,7 +79,7 @@ hook.Add("HUDPaintBackground", "Sponge_HUDPaintBackground", function()
     local inside = false
     local allInside = false
     for _, p in pairs(GetAllPlayers()) do
-        if p:IsActiveSponge() and p:Alive() and client:GetPos():Distance(p:GetPos()) <= GetGlobalFloat("ttt_sponge_aura_radius", UNITS_PER_FIVE_METERS) then
+        if p:IsActiveSponge() and client:GetPos():Distance(p:GetPos()) <= GetGlobalFloat("ttt_sponge_aura_radius", UNITS_PER_FIVE_METERS) then
             inside = true
             if p:GetNWBool("SpongeAllInRadius", false) then
                 allInside = true

--- a/scripts/pietsmiet_deagles.lua
+++ b/scripts/pietsmiet_deagles.lua
@@ -19,7 +19,7 @@ local function ShootBullet(weap, dmg, onPlayerShot)
     bullet.Force  = 0
     bullet.Damage = dmg
     if SERVER then
-        bullet.Callback = function(atk, tr, dmg)
+        bullet.Callback = function(atk, tr, d)
             local ent = tr.Entity
             if ent:IsPlayer() and ent:IsTerror() then
                 onPlayerShot(ent, atk)


### PR DESCRIPTION
**Additions**
- Added jester player information to the clown's scoreboard when they are active, matching their target ID (icon, ring, text) visibility

**Fixes**
- Fixed clown seeing jester icons (instead of question mark icons) over all jester team members' heads when they are activated
- Fixed clown seeing jester icon over the activated loot goblin's head (instead of the loot goblin icon)

**Developer**
- Fixed loot goblin's definition of `ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN` and `ROLE_IS_TARGETID_OVERRIDDEN` using the parameters backwards

Fixes #435

(Diff also includes changes in #434)