### PR TITLE
1.9.4 Hotfixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,7 @@
 - Fixed clown seeing jester icons (instead of question mark icons) over all jester team members' heads when they are activated
 - Fixed clown seeing jester icon over the activated loot goblin's head (instead of the loot goblin icon)
 - Fixed `ttt_cupid_lovers_notify_mode` not working
+- Fixed loot goblin not being revealed to traitor team members if they had an informant on their team
 
 ### Developer
 - Changed `plymeta:IsActive` to ensure the player is alive like it was always supposed to

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -250,7 +250,7 @@ function GM:PostDrawTranslucentRenderables()
 
             if not icon then  -- TODO: Remove after 2.0.0
                 local showKillIcon = CallHook("TTTTargetIDPlayerKillIcon", nil, v, client, false, showJester)
-                if showKillIcon then
+                if showKillIcon and not client:IsSameTeam(v) then
                     icon = "kill"
                     iconNoZ = true
                     iconColor = ROLE_COLORS_SPRITE[client:GetRole()]

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -64,7 +64,7 @@ local function AssignAssassinTarget(ply, start, delay)
     end
 
     for _, p in pairs(GetAllPlayers()) do
-        if p:IsActive() then
+        if p:Alive() and not p:IsSpec() then
             -- Include all non-traitor detective-like players
             if p:IsDetectiveLike() and not p:IsTraitorTeam() then
                 table.insert(detectives, p:SteamID64())
@@ -111,7 +111,7 @@ local function AssignAssassinTarget(ply, start, delay)
         targetMessage = "No further targets available."
     end
 
-    if ply:IsActive() then
+    if ply:Alive() and not ply:IsSpec() then
         if not delay and not start then targetMessage = "Target eliminated. " .. targetMessage end
         ply:QueueMessage(MSG_PRINTBOTH, targetMessage)
     end

--- a/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
@@ -52,7 +52,7 @@ end)
 
 -- Show skull icon over the target's head
 hook.Add("TTTTargetIDPlayerTargetIcon", "Assassin_TTTTargetIDPlayerTargetIcon", function(ply, cli, showJester)
-    if cli:IsAssassin() and assassin_show_target_icon:GetBool() and cli:GetNWString("AssassinTarget") == ply:SteamID64() and not showJester then
+    if cli:IsAssassin() and assassin_show_target_icon:GetBool() and cli:GetNWString("AssassinTarget") == ply:SteamID64() and not showJester and not cli:IsSameTeam(ply) then
         return "kill", true, ROLE_COLORS_SPRITE[ROLE_ASSASSIN], "down"
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
+++ b/gamemodes/terrortown/gamemode/roles/clown/cl_clown.lua
@@ -40,7 +40,7 @@ end)
 
 -- Show skull icon over the target's head
 hook.Add("TTTTargetIDPlayerTargetIcon", "Clown_TTTTargetIDPlayerTargetIcon", function(ply, cli, showJester)
-    if cli:IsClown() and cli:IsRoleActive() and clown_show_target_icon:GetBool() and not showJester then
+    if cli:IsClown() and cli:IsRoleActive() and clown_show_target_icon:GetBool() and not showJester and not cli:IsSameTeam(ply) then
         return "kill", true, ROLE_COLORS_SPRITE[ROLE_CLOWN], "down"
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/detectivelike.lua
@@ -59,7 +59,7 @@ end
 local function FindAndPromoteDetectiveLike()
     for _, ply in pairs(GetAllPlayers()) do
         if ply:IsDetectiveLikePromotable() then
-            local alive = ply:Alive()
+            local alive = ply:Alive() and not ply:IsSpec()
             if alive then
                 ply:QueueMessage(MSG_PRINTBOTH, "You have been promoted to " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "!")
             end

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -50,7 +50,7 @@ end)
 
 -- Show skull icon over all non-jester team heads
 hook.Add("TTTTargetIDPlayerTargetIcon", "Killer_TTTTargetIDPlayerTargetIcon", function(ply, cli, showJester)
-    if cli:IsKiller() and killer_show_target_icon:GetBool() and not showJester then
+    if cli:IsKiller() and killer_show_target_icon:GetBool() and not showJester and not cli:IsSameTeam(ply) then
         return "kill", true, ROLE_COLORS_SPRITE[ROLE_KILLER], "down"
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -149,7 +149,7 @@ end)
 -- SCOREBOARD --
 ----------------
 
-hook.Add("TTTScoreboardPlayerRole", "LootGoblin_TTTScoreboardPlayerRole", function(ply, client, color, roleFileName)
+hook.Add("TTTScoreboardPlayerRole", "LootGoblin_TTTScoreboardPlayerRole", function(ply, cli, color, roleFileName)
     if ply:IsActiveLootGoblin() and ply:IsRoleActive() and lootgoblin_active_display:GetBool() then
         return ROLE_COLORS_SCOREBOARD[ROLE_LOOTGOBLIN], ROLE_STRINGS_SHORT[ROLE_LOOTGOBLIN]
     end

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -56,6 +56,7 @@ local lootgoblin_radar_enabled = GetConVar("ttt_lootgoblin_radar_enabled")
 local lootgoblin_announce = GetConVar("ttt_lootgoblin_announce")
 local lootgoblin_cackle_enabled = GetConVar("ttt_lootgoblin_cackle_enabled")
 local lootgoblin_jingle_enabled = GetConVar("ttt_lootgoblin_jingle_enabled")
+local lootgoblin_active_display = GetConVar("ttt_lootgoblin_active_display")
 
 -----------
 -- KARMA --
@@ -155,6 +156,14 @@ local lootGoblinActive = false
 local function ActivateLootGoblin(ply)
     ply:SetNWBool("LootGoblinActive", true)
     ply:PrintMessage(HUD_PRINTTALK, "You have transformed into a goblin!")
+
+    -- Update the scan state if there is an informant, the goblin should be revealed, and they haven't already been scanned
+    if lootgoblin_active_display:GetBool() then
+        local state = ply:GetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
+        if state ~= INFORMANT_UNSCANNED and state < INFORMANT_SCANNED_ROLE then
+            ply:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_ROLE)
+        end
+    end
 
     local mode = lootgoblin_regen_mode:GetInt()
     if mode == LOOTGOBLIN_REGEN_MODE_ALWAYS then

--- a/gamemodes/terrortown/gamemode/roles/revenger/revenger.lua
+++ b/gamemodes/terrortown/gamemode/roles/revenger/revenger.lua
@@ -129,7 +129,7 @@ end
 ROLE_ON_ROLE_ASSIGNED[ROLE_REVENGER] = function(ply)
     local potentialSoulmates = {}
     for _, p in pairs(GetAllPlayers()) do
-        if p:IsActive() and p ~= ply then
+        if p:Alive() and not p:IsSpec() and p ~= ply then
             table.insert(potentialSoulmates, p)
         end
     end

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -58,7 +58,7 @@ end)
 
 -- Show skull icon over all non-jester team heads
 hook.Add("TTTTargetIDPlayerTargetIcon", "Vampire_TTTTargetIDPlayerTargetIcon", function(ply, cli, showJester)
-    if cli:IsVampire() and vampire_show_target_icon:GetBool() and not showJester then
+    if cli:IsVampire() and vampire_show_target_icon:GetBool() and not showJester and not cli:IsSameTeam(ply) then
         return "kill", true, ROLE_COLORS_SPRITE[ROLE_VAMPIRE], "down"
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -54,7 +54,7 @@ end)
 
 -- Show skull icon over all non-jester team heads when the zombie is using their claws
 hook.Add("TTTTargetIDPlayerTargetIcon", "Zombie_TTTTargetIDPlayerTargetIcon", function(ply, cli, showJester)
-    if cli:IsZombie() and zombie_show_target_icon:GetBool() and cli.GetActiveWeapon and IsValid(cli:GetActiveWeapon()) and cli:GetActiveWeapon():GetClass() == "weapon_zom_claws" and not showJester then
+    if cli:IsZombie() and zombie_show_target_icon:GetBool() and cli.GetActiveWeapon and IsValid(cli:GetActiveWeapon()) and cli:GetActiveWeapon():GetClass() == "weapon_zom_claws" and not showJester and not cli:IsSameTeam(ply) then
         return "kill", true, ROLE_COLORS_SPRITE[ROLE_ZOMBIE], "down"
     end
 end)


### PR DESCRIPTION
- Fixed kill icon showing for team members as well
- Fixed Assassin not being given their target and Revenger not being assigned a lover
- Fixed loot goblin not being revealed to traitor team members if they had an informant on their team