### PR TITLE
1.9.6 Hotfixes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -128,6 +128,17 @@ Called after player information such as role, health, and ammo and equipment inf
 - *labelY* - The Y value representing the first clear space to add information
 - *activeLabels* - The list of current active additional labels. Used to determine the labelY offset to use via: `labelY = labelY + (20 * #activeLabels)`. Be sure to insert an entry when you add your own label so other addons can space appropriately. *(Added in 1.6.11)*
 
+### TTTInformantDefaultScanStage(ply, oldRole, newRole)
+Called when an informant is trying to determine the default scan stage of a plyer. Used to override that value.\
+*Realm:* Server\
+*Added in:* 1.9.6\
+*Parameters:*
+- *ply* - The player whose default stage stage is being determined
+- *oldRole* - The target player's old role. Only used when this hook is called due to a player's role changing
+- *newRole* - The target player's new role. Only used when this hook is called due to a player's role changing
+
+*Return:* The default scan stage to use for this player. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
+
 ### TTTInformantScanStageChanged(ply, tgt, stage)
 Called when an informant has scanned additional information from a target player.\
 *Realm:* Server\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@
 - Fixed sponge role being hidden to traitors when there was an informant in the round
 
 ### Developer
-- Added `TTTInformantDefaultScanStage` to help roles override their default informant scan stage
+- Added `TTTInformantDefaultScanStage` hook to help roles override their default informant scan stage
 
 ## 1.9.5 (Beta)
 **Released: August 13th, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,10 @@
 ### Fixes
 - Fixed typo in the hive mind's tutorial
 - Fixed players getting zombie claws as non-zombies if they were turned right before a round restarted
+- Fixed sponge role being hidden to traitors when there was an informant in the round
+
+### Developer
+- Added `TTTInformantDefaultScanStage` to help roles override their default informant scan stage
 
 ## 1.9.5 (Beta)
 **Released: August 13th, 2023**

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -198,6 +198,22 @@
             <li><em>activeLabels</em> - The list of current active additional labels. Used to determine the labelY offset to use via: <code>labelY = labelY + (20 * #activeLabels)</code>. Be sure to insert an entry when you add your own label so other addons can space appropriately. <em>(Added in 1.6.11)</em></li>
         </ul>
 
+        <h3><a id="tttinformantdefaultscanstageply-oldrole-newrole" href="#tttinformantdefaultscanstageply-oldrole-newrole">TTTInformantDefaultScanStage(ply, oldRole, newRole)</a></h3>
+        <p>
+            Called when an informant has scanned additional information from a target player.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 1.9.6<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The player whose default stage stage is being determined</li>
+            <li><em>oldRole</em> - The target player's old role. Only used when this hook is called due to a player's role changing</li>
+            <li><em>newRole</em> - The target player's new role. Only used when this hook is called due to a player's role changing</li>
+        </ul>
+        <p>
+            <em>Return:</em> The default scan stage to use for this player. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
+        </p>
+
         <h3><a id="tttinformantscanstagechangedply-tgt-stage" href="#tttinformantscanstagechangedply-tgt-stage">TTTInformantScanStageChanged(ply, tgt, stage)</a></h3>
         <p>
             Called when an informant has scanned additional information from a target player.<br>

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -67,6 +67,15 @@ local zombie_prime_attack_delay = CreateConVar("ttt_zombie_prime_attack_delay", 
 local zombie_thrall_attack_delay = CreateConVar("ttt_zombie_thrall_attack_delay", "1.4", FCVAR_REPLICATED, "The amount of time between claw attacks for a zombie thrall (e.g. non-prime zombie). Server or round must be restarted for changes to take effect", 0.1, 3)
 
 function SWEP:Initialize()
+    if CLIENT then
+        self:AddHUDHelp("zom_claws_help_pri", "zom_claws_help_sec", true)
+    end
+    return self.BaseClass.Initialize(self)
+end
+
+function SWEP:SetWeaponHoldType(t)
+    self.BaseClass.SetWeaponHoldType(self, t)
+
     self.ActivityTranslate[ACT_MP_STAND_IDLE]                  = ACT_HL2MP_IDLE_ZOMBIE
     self.ActivityTranslate[ACT_MP_WALK]                        = ACT_HL2MP_WALK_ZOMBIE_01
     self.ActivityTranslate[ACT_MP_RUN]                         = ACT_HL2MP_RUN_ZOMBIE
@@ -75,11 +84,6 @@ function SWEP:Initialize()
     self.ActivityTranslate[ACT_MP_ATTACK_STAND_PRIMARYFIRE]    = ACT_GMOD_GESTURE_RANGE_ZOMBIE
     self.ActivityTranslate[ACT_MP_ATTACK_CROUCH_PRIMARYFIRE]   = ACT_GMOD_GESTURE_RANGE_ZOMBIE
     self.ActivityTranslate[ACT_RANGE_ATTACK1]                  = ACT_GMOD_GESTURE_RANGE_ZOMBIE
-
-    if CLIENT then
-        self:AddHUDHelp("zom_claws_help_pri", "zom_claws_help_sec", true)
-    end
-    return self.BaseClass.Initialize(self)
 end
 
 function SWEP:PlayAnimation(sequence, anim)

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -5,6 +5,7 @@ local IsValid = IsValid
 local pairs = pairs
 
 local GetAllPlayers = player.GetAll
+local CallHook = hook.Call
 
 -------------
 -- CONVARS --
@@ -83,6 +84,12 @@ local function SetDefaultScanState(ply, oldRole, newRole)
         ply:SetNWInt("TTTInformantScanStage", INFORMANT_SCANNED_TEAM)
     else
         ply:SetNWInt("TTTInformantScanStage", INFORMANT_UNSCANNED)
+    end
+
+    -- Allow roles to overwrite their default scan stages if there's some reason why they should be known or hidden
+    local scan_stage = CallHook("TTTInformantDefaultScanStage", nil, ply, oldRole, newRole)
+    if type(scan_stage) == "number" and scan_stage >= INFORMANT_UNSCANNED and scan_stage <= INFORMANT_SCANNED_TRACKED then
+        ply:SetNWInt("TTTInformantScanStage", scan_stage)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/roles/sponge/sponge.lua
+++ b/gamemodes/terrortown/gamemode/roles/sponge/sponge.lua
@@ -103,6 +103,17 @@ hook.Add("Think", "Sponge_Aura_Think", function()
     end
 end)
 
+-----------------------
+-- ROLE INTERACTIONS --
+-----------------------
+
+-- The sponge is viewable to everyone so the informant's default scan stage should be "ROLE" since their role is already known
+hook.Add("TTTInformantDefaultScanStage", "Sponge_TTTInformantDefaultScanStage", function(ply, oldRole, newRole)
+    if ply:IsSponge() then
+        return INFORMANT_SCANNED_ROLE
+    end
+end)
+
 ----------------
 -- WIN CHECKS --
 ----------------


### PR DESCRIPTION
- Fixed sponge role being hidden to traitors when there was an informant in the round
- Added `TTTInformantDefaultScanStage` hook to help roles override their default informant scan stage

Fixes #471
Fixes #470 