### PR TITLE
Beta 1.9.14

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -385,7 +385,7 @@ ttt_turncoat_change_innocent_kill           0       // Whether to change the tur
 ttt_infected_succumb_time                   180     // Time in seconds for the infected to succumb to their disease
 ttt_infected_full_health                    1       // Whether the infected's health is refilled when they become a zombie
 ttt_infected_prime                          1       // Whether the infected will become a prime zombie
-ttt_infected_respawn_enable                 0       // Whether the infected will respawn as a zombie when killed
+ttt_infected_respawn_enabled                0       // Whether the infected will respawn as a zombie when killed
 ttt_infected_show_icon                      1       // Whether to show the infected icon over their head for zombies and zombie allies
 ttt_infected_cough_enabled                  1       // Whether the infected coughs periodically
 ttt_infected_cough_timer_min                30      // The minimum time between infected coughs

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -195,7 +195,7 @@ ttt_hivemind_min_players                    0       // The minimum number of pla
 
 // TRAITOR TEAM SETTINGS
 ttt_traitors_vision_enable                  0       // Whether members of the traitor team can see other members of the traitor team (including Glitches) through walls via a highlight effect
-ttt_traitor_credits_timer                   0       // How often in seconds to give members of the traitor team a credit (set to 0 to disable)
+ttt_traitors_credits_timer                  0       // How often in seconds to give members of the traitor team a credit (set to 0 to disable)
 
 // Traitor
 ttt_traitor_phantom_cure                    0       // Whether to allow the traitor to buy the phantom exorcism device which can remove a haunting phantom. Server must be restarted for changes to take effect

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -530,6 +530,7 @@ ttt_beggar_scan_cooldown                    3       // The amount of time (in se
 ttt_beggar_scan_distance                    2500    // The maximum distance away the scanner target can be
 ttt_beggar_can_see_jesters                  0       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the beggar (Only applies if ttt_beggar_is_independent is enabled)
 ttt_beggar_update_scoreboard                0       // Whether the beggar shows dead players as missing in action (Only applies if ttt_beggar_is_independent is enabled)
+ttt_beggar_announce_delay                   0       // How long the delay between role change and announcement should be
 
 // Bodysnatcher
 ttt_bodysnatcher_is_independent             0       // Whether bodysnatchers should be treated as members of the independent team (rather than the jester team)

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -194,7 +194,7 @@ ttt_hivemind_min_players                    0       // The minimum number of pla
 // ----------------------------------------
 
 // TRAITOR TEAM SETTINGS
-ttt_traitors_vision_enable                  0       // Whether members of the traitor team can see other members of the traitor team (including Glitches) through walls via a highlight effect
+ttt_traitors_vision_enabled                 0       // Whether members of the traitor team can see other members of the traitor team (including Glitches) through walls via a highlight effect
 ttt_traitors_credits_timer                  0       // How often in seconds to give members of the traitor team a credit (set to 0 to disable)
 
 // Traitor
@@ -224,7 +224,7 @@ ttt_single_paramedic_hypnotist_chance       0.5     // The chance that a paramed
 
 // Assassin
 ttt_assassin_show_target_icon               0       // Whether assassins have an icon over their target's heads showing who to kill. Server or round must be restarted for changes to take effect
-ttt_assassin_target_vision_enable           0       // Whether assassins have a visible aura around their target, visible through walls
+ttt_assassin_target_vision_enabled          0       // Whether assassins have a visible aura around their target, visible through walls
 ttt_assassin_next_target_delay              5       // The delay (in seconds) before an assassin is assigned their next target
 ttt_assassin_target_damage_bonus            1       // Damage bonus that the assassin has against their target (e.g. 0.5 = 50% extra damage)
 ttt_assassin_target_bonus_bought            1       // Whether the damage bonus that the assassin has against their target should apply on weapons bought from the shop
@@ -239,12 +239,12 @@ ttt_assassin_allow_vampire_kill             1       // Whether the assassin can 
 // Vampire
 ttt_vampire_is_monster                      0       // Whether vampires should be treated as members of the monster team (rather than the traitor team)
 ttt_vampire_is_independent                  0       // Whether vampires should be treated as members of the independent team (rather than the traitor team)
-ttt_vampire_vision_enable                   0       // Whether vampires have their special vision highlights enabled
-ttt_vampire_drain_enable                    1       // Whether vampires have the ability to drain a living target's blood using their fangs
+ttt_vampire_vision_enabled                  0       // Whether vampires have their special vision highlights enabled
+ttt_vampire_drain_enabled                   1       // Whether vampires have the ability to drain a living target's blood using their fangs
 ttt_vampire_drain_first                     0       // Whether vampires should drain a living target's blood first rather than converting first
 ttt_vampire_drain_credits                   0       // How many credits a vampire should get for draining a living target
 ttt_vampire_drain_mute_target               0       // Whether players being drained by a vampire should be muted
-ttt_vampire_convert_enable                  0       // Whether vampires have the ability to convert living targets to a vampire thrall using their fangs
+ttt_vampire_convert_enabled                 0       // Whether vampires have the ability to convert living targets to a vampire thrall using their fangs
 ttt_vampire_show_target_icon                0       // Whether vampires have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect.
 ttt_vampire_damage_reduction                0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a vampire
 ttt_vampire_fang_timer                      5       // The amount of time fangs must be used to fully drain a target's blood
@@ -423,7 +423,7 @@ ttt_detectives_search_only_wep              0       // Whether only detectives c
 ttt_detectives_search_only_words            0       // Whether only detectives can reveal a body's last words (if last words is enabled). Once a detective searches a body, this information will be available to all players. Ignored when "ttt_detectives_search_only" is enabled.
 ttt_detectives_disable_looting              0       // Whether to disable a detective role's ability to loot credits from bodies
 ttt_detectives_hide_special_mode            0       // How to handle special detective role information. 0 - Show the special detective's role to everyone. 1 - Hide the special detective's role from everyone (just show detective instead). 2 - Hide the special detective's role for everyone but themselves (only they can see their true role)
-ttt_detectives_glow_enable                  0       // Whether members of the detective team (and active detective-like players) can be seen through walls via a highlight effect
+ttt_detectives_glow_enabled                 0       // Whether members of the detective team (and active detective-like players) can be seen through walls via a highlight effect
 ttt_special_detectives_armor_loadout        1       // Whether special detectives (all detective roles other than the original detective itself) get armor automatically for free
 ttt_all_search_postround                    1       // Whether non-detectives can search bodies post-round or not
 ttt_all_search_binoc                        0       // Whether non-detectives can search bodies if they are using binoculars
@@ -584,7 +584,7 @@ ttt_cupid_lovers_notify_mode                1       // Who is notified with cupi
 ttt_cupid_can_damage_lovers                 0       // Whether cupid should be able to damage the lovers
 ttt_cupid_lovers_can_damage_lovers          1       // Whether the lovers should be able to damage each other
 ttt_cupid_lovers_can_damage_cupid           0       // Whether the lovers should be able to damage cupid
-ttt_cupid_lover_vision_enable               1       // Whether the lovers can see outlines of each other through walls
+ttt_cupid_lover_vision_enabled              1       // Whether the lovers can see outlines of each other through walls
 ttt_cupid_notify_mode                       0       // The logic to use when notifying players that a cupid is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_cupid_notify_sound                      0       // Whether to play a cheering sound when a cupid is killed
 ttt_cupid_notify_confetti                   0       // Whether to throw confetti when a cupid is a killed
@@ -691,7 +691,7 @@ ttt_killer_show_target_icon                 1       // Whether killers have an i
 ttt_killer_damage_penalty                   0.25    // The fraction a killer's damage will be scaled by when they are attacking without using their knife
 ttt_killer_damage_reduction                 0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a killer
 ttt_killer_warn_all                         0       // Whether to warn all players if there is a killer. If 0, only traitors will be warned
-ttt_killer_vision_enable                    1       // Whether killers have their special vision highlights enabled
+ttt_killer_vision_enabled                   1       // Whether killers have their special vision highlights enabled
 ttt_killer_credits_starting                 2       // The number of credits a killer should start with
 ttt_killer_can_see_jesters                  1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the killer
 ttt_killer_update_scoreboard                1       // Whether the killer shows dead players as missing in action
@@ -703,9 +703,9 @@ ttt_killer_credits_award_repeat             1       // Whether the credit award 
 ttt_zombie_is_monster                       0       // Whether zombies should be treated as members of the monster team (rather than the independent team)
 ttt_zombie_is_traitor                       0       // Whether zombies should be treated as members of the traitors team (rather than the independent team)
 ttt_zombie_round_chance                     0.1     // The chance that a "zombie round" will occur where all players who would have been traitors are made zombies instead. Only usable when "ttt_zombie_is_traitor" is set to "1"
-ttt_zombie_vision_enable                    0       // Whether zombies have their special vision highlights enabled
-ttt_zombie_spit_enable                      1       // Whether zombies have their spit attack enabled
-ttt_zombie_leap_enable                      1       // Whether zombies have their leap attack enabled
+ttt_zombie_vision_enabled                   0       // Whether zombies have their special vision highlights enabled
+ttt_zombie_spit_enabled                     1       // Whether zombies have their spit attack enabled
+ttt_zombie_leap_enabled                     1       // Whether zombies have their leap attack enabled
 ttt_zombie_show_target_icon                 0       // Whether zombies have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect
 ttt_zombie_damage_penalty                   0.5     // The fraction a zombie's damage will be scaled by when they are attacking without using their claws. For example, setting this to 0.25 will let the zombie deal 75% of normal gun damage, and 0.66 will let the zombie deal 33% of normal damage
 ttt_zombie_damage_reduction                 0       // The fraction an attacker's bullet damage will be reduced by when they are shooting a zombie
@@ -727,7 +727,7 @@ ttt_zombie_update_scoreboard                1       // Whether the zombies show 
 // Mad Scientist
 ttt_madscientist_is_monster                 0       // Whether the mad scientist should be treated as a member of the monster team (rather than the independent team)
 ttt_madscientist_device_time                4       // The amount of time (in seconds) the mad scientist's device takes to use
-ttt_madscientist_respawn_enable             0       // Whether the mad scientist should respawn as a zombie when they are killed
+ttt_madscientist_respawn_enabled            0       // Whether the mad scientist should respawn as a zombie when they are killed
 ttt_madscientist_can_see_jesters            1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the mad scientist (Only applies if ttt_madscientist_is_monster is not enabled)
 ttt_madscientist_update_scoreboard          1       // Whether the mad scientist shows dead players as missing in action (Only applies if ttt_madscientist_is_monster is not enabled)
 
@@ -770,7 +770,7 @@ ttt_detectives_search_only_arsonistdouse    0       // Whether only detectives c
 
 // Hive Mind
 ttt_hivemind_is_monster                     0       // Whether the hive mind should be treated as a member of the monster team (rather than the independent team)
-ttt_hivemind_vision_enable                  1       // Whether the hive mind's member highlighting is enabled
+ttt_hivemind_vision_enabled                 1       // Whether the hive mind's member highlighting is enabled
 ttt_hivemind_friendly_fire                  0       // Whether a member of the hive mind can damage other members of the hive mind
 ttt_hivemind_join_heal_pct                  0.25    // The percentage a new member's maximum health that the hive mind should be healed (e.g. 0.25 = 25% of their health healed)
 ttt_hivemind_regen_timer                    0       // The amount of time (in seconds) between each health regeneration
@@ -1011,7 +1011,7 @@ ttt_scoreboard_score                        0       // Whether to show the score
 ttt_round_summary_tabs                      summary,hilite,events,scores // The tabs to show in the round summary screen. Changing the order of the values will change the order of the tabs. Excluding a value from the comma-delimited list will prevent that tab from showing. Invalid values will be ignored. Round must be restarted for changes to take effect
 
 // Misc.
-ttt_death_notifier_enable                   1       // Whether the name and role of a player's killer should be shown to the victim
+ttt_death_notifier_enabled                  1       // Whether the name and role of a player's killer should be shown to the victim
 ttt_smokegrenade_extinguish                 1       // Whether smoke grenades should extinguish fire
 ttt_player_set_color                        1       // Whether player colors are set each time that player spawns
 ttt_dna_scan_on_dialog                      1       // Whether to show a button to open the DNA scanner on the body search dialog

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -255,7 +255,10 @@ ttt_vampire_fang_overheal_living            -1      // The amount of overheal (s
 ttt_vampire_fang_unfreeze_delay             2       // The number of seconds before players who were frozen in place by the fangs should be released if the vampire stops using the fangs on them
 ttt_vampire_prime_death_mode                0       // What to do when the prime vampire(s) (e.g. players who spawn as vampires originally) are killed. 0 - Do nothing. 1 - Kill all vampire thralls (non-prime vampires). 2 - Revert all vampire thralls (non-prime vampires) to their original role
 ttt_vampire_prime_only_convert              1       // Whether only prime vampires (e.g. players who spawn as vampire originally) are allowed to convert other players
-ttt_vampire_kill_credits                    1       // Whether the vampire receives credits when they kill another player
+ttt_vampire_kill_credits                    1       // Whether the vampire receives credits when they kill another player. (Only applies when ttt_vampire_is_independent and ttt_vampire_is_monster are both disabled)
+ttt_vampire_credits_award_pct               0.35    // When this percentage of the innocent players are dead, vampires are awarded more credits. (Only applies when ttt_vampire_is_monster or ttt_vampire_is_independent is enabled)
+ttt_vampire_credits_award_size              1       // The number of credits awarded. (Only applies when ttt_vampire_is_monster or ttt_vampire_is_independent is enabled)
+ttt_vampire_credits_award_repeat            1       // Whether the credit award is handed out multiple times. if for example you set the percentage to 0.25, and enable this, vampires will be awarded credits at 25% killed, 50% killed, and 75% killed. (Only applies when ttt_vampire_is_monster or ttt_vampire_is_independent is enabled)
 ttt_vampire_loot_credits                    1       // Whether the vampire can loot credits from a dead player
 ttt_vampire_prime_friendly_fire             0       // How to handle friendly fire damage to the prime vampire(s) from their thralls. 0 - Do nothing. 1 - Reflect damage back to the attacker (non-prime vampire). 2 - Negate damage to the prime vampire.
 ttt_vampire_credits_starting                1       // The number of credits a vampire should start with
@@ -692,6 +695,9 @@ ttt_killer_vision_enable                    1       // Whether killers have thei
 ttt_killer_credits_starting                 2       // The number of credits a killer should start with
 ttt_killer_can_see_jesters                  1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the killer
 ttt_killer_update_scoreboard                1       // Whether the killer shows dead players as missing in action
+ttt_killer_credits_award_pct                0.35    // When this percentage of the innocent players are dead, the killer is awarded more credits.
+ttt_killer_credits_award_size               1       // The number of credits awarded.
+ttt_killer_credits_award_repeat             1       // Whether the credit award is handed out multiple times. if for example you set the percentage to 0.25, and enable this, the killer will be awarded credits at 25% killed, 50% killed, and 75% killed.
 
 // Zombie
 ttt_zombie_is_monster                       0       // Whether zombies should be treated as members of the monster team (rather than the independent team)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.0.0
+**Released:**\
+Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
+
+### Fixes
+- Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
+
 ## 1.9.13 (Beta)
 **Released: October 21st, 2023**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,9 @@ Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
 ### Additions
 - Added `ttt_beggar_announce_delay` (disabled by default) to allow delaying the announcement of the beggar's role change
 
+### Changes
+- **BREAKING CHANGE** - Renamed `ttt_traitor_credits_timer` to `ttt_traitors_credits_timer`
+
 ### Fixes
 - Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
 - Fixed `ttt_monster_max` greater than 1 not working

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 - Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
 - Fixed `ttt_monster_max` greater than 1 not working
 - Fixed infected player that is in the progress of respawning due dying while `ttt_infected_respawn_enabled` is enabled not counting as zombifying for the purposes of delaying the round end
+- Fixed paramedic's defibrillator not changing detective-like roles not on the innocent or traitor teams to be their base role when resurrected
 
 ## 1.9.13 (Beta)
 **Released: October 21st, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,7 @@
 # Release Notes
 
-## 2.0.0
-**Released:**\
-Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
+## 1.9.14 (Beta)
+**Released:**
 
 ### Additions
 - Added `ttt_beggar_announce_delay` (disabled by default) to allow delaying the announcement of the beggar's role change

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@ Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
 ### Fixes
 - Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
 - Fixed `ttt_monster_max` greater than 1 not working
+- Fixed infected player that is in the progress of respawning due dying while `ttt_infected_respawn_enabled` is enabled not counting as zombifying for the purposes of delaying the round end
 
 ## 1.9.13 (Beta)
 **Released: October 21st, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,8 @@ Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
 
 ### Changes
 - **BREAKING CHANGE** - Renamed `ttt_traitor_credits_timer` to `ttt_traitors_credits_timer`
+- **BREAKING CHANGE** - Changed vampire to use the new `ttt_vampire_credits_award_pct`, `ttt_vampire_credits_award_size`, and `ttt_vampire_credits_award_repeat` convars instead of the traitor ones when the vampire is not a traitor
+- **BREAKING CHANGE** - Changed killer to use the new `ttt_killer_credits_award_pct`, `ttt_killer_credits_award_size`, and `ttt_killer_credits_award_repeat` convars instead of the traitor ones
 
 ### Fixes
 - Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,9 @@
 **Released:**\
 Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
 
+### Additions
+- Added `ttt_beggar_announce_delay` (disabled by default) to allow delaying the announcement of the beggar's role change
+
 ### Fixes
 - Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,21 @@
 
 ### Changes
 - **BREAKING CHANGE** - Renamed `ttt_traitor_credits_timer` to `ttt_traitors_credits_timer`
-- **BREAKING CHANGE** - Renamed `ttt_infected_respawn_enable` to `ttt_infected_respawn_enabled`
+- **BREAKING CHANGE** - Renamed the following ConVars to change the `_enable` ending to `_enabled` for consistency:
+  - ttt_assassin_target_vision_enable -> ttt_assassin_target_vision_enabled
+  - ttt_cupid_lover_vision_enable -> ttt_cupid_lover_vision_enabled
+  - ttt_death_notifier_enable -> ttt_death_notifier_enabled
+  - ttt_detective_glow_enable -> ttt_detective_glow_enabled
+  - ttt_hivemind_vision_enable -> ttt_hivemind_vision_enabled
+  - ttt_infected_respawn_enable -> ttt_infected_respawn_enabled
+  - ttt_killer_vision_enable -> ttt_killer_vision_enabled
+  - ttt_madscientist_respawn_enable -> ttt_madscientist_respawn_enabled
+  - ttt_vampire_convert_enable -> ttt_vampire_convert_enabled
+  - ttt_vampire_drain_enable -> ttt_vampire_drain_enabled
+  - ttt_vampire_vision_enable -> ttt_vampire_vision_enabled
+  - ttt_zombie_leap_enable -> ttt_zombie_leap_enabled
+  - ttt_zombie_spit_enable -> ttt_zombie_spit_enabled
+  - ttt_zombie_vision_enable -> ttt_zombie_vision_enabled
 - **BREAKING CHANGE** - Changed vampire to use the new `ttt_vampire_credits_award_pct`, `ttt_vampire_credits_award_size`, and `ttt_vampire_credits_award_repeat` convars instead of the traitor ones when the vampire is not a traitor
 - **BREAKING CHANGE** - Changed killer to use the new `ttt_killer_credits_award_pct`, `ttt_killer_credits_award_size`, and `ttt_killer_credits_award_repeat` convars instead of the traitor ones
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
 
 ### Fixes
 - Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
+- Fixed `ttt_monster_max` greater than 1 not working
 
 ## 1.9.13 (Beta)
 **Released: October 21st, 2023**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Includes beta updates [1.9.3](#193-beta) to [1.9.13](#1913-beta).
 
 ### Changes
 - **BREAKING CHANGE** - Renamed `ttt_traitor_credits_timer` to `ttt_traitors_credits_timer`
+- **BREAKING CHANGE** - Renamed `ttt_infected_respawn_enable` to `ttt_infected_respawn_enabled`
 - **BREAKING CHANGE** - Changed vampire to use the new `ttt_vampire_credits_award_pct`, `ttt_vampire_credits_award_size`, and `ttt_vampire_credits_award_repeat` convars instead of the traitor ones when the vampire is not a traitor
 - **BREAKING CHANGE** - Changed killer to use the new `ttt_killer_credits_award_pct`, `ttt_killer_credits_award_size`, and `ttt_killer_credits_award_repeat` convars instead of the traitor ones
 

--- a/docs/deprecatedglobals.html
+++ b/docs/deprecatedglobals.html
@@ -210,11 +210,12 @@
                 ["ttt_cupids_are_independent", "ttt_cupid_is_independent"],
                 ["ttt_detective_glow_enable", "ttt_detectives_glow_enable"],
                 ["ttt_detective_credits_timer", "ttt_detectives_credits_timer"],
+                ["ttt_infected_respawn_enable", "ttt_infected_respawn_enabled"],
+                ["ttt_traitor_credits_timer", "ttt_traitors_credits_timer"],
                 ["ttt_vampires_are_monsters", "ttt_vampire_is_monster"],
                 ["ttt_vampires_are_independent", "ttt_vampire_is_independent"],
                 ["ttt_zombies_are_monsters", "ttt_zombie_is_monster"],
-                ["ttt_zombies_are_traitors", "ttt_zombie_is_traitor"],
-                ["ttt_traitor_credits_timer", "ttt_traitors_credits_timer"]
+                ["ttt_zombies_are_traitors", "ttt_zombie_is_traitor"]
             ]
 
             const button = document.getElementById('open');

--- a/docs/deprecatedglobals.html
+++ b/docs/deprecatedglobals.html
@@ -210,6 +210,7 @@
                 ["ttt_detective_credits_timer", "ttt_detectives_credits_timer"],
                 ["ttt_detective_disable_looting", "ttt_detectives_disable_looting"],
                 ["ttt_detective_glow_enable", "ttt_detectives_glow_enabled"],
+                ["ttt_detectives_glow_enable", "ttt_detectives_glow_enabled"]
                 ["ttt_detective_hide_special_mode", "ttt_detectives_hide_special_mode"],
                 ["ttt_detective_search_only", "ttt_detectives_search_only"],
                 ["ttt_hivemind_vision_enable", "ttt_hivemind_vision_enabled"],
@@ -218,6 +219,7 @@
                 ["ttt_madscientist_respawn_enable", "ttt_madscientist_respawn_enabled"],
                 ["ttt_traitor_credits_timer", "ttt_traitors_credits_timer"],
                 ["ttt_traitor_vision_enable", "ttt_traitors_vision_enabled"],
+                ["ttt_traitors_vision_enable", "ttt_traitors_vision_enabled"],
                 ["ttt_vampires_are_monsters", "ttt_vampire_is_monster"],
                 ["ttt_vampires_are_independent", "ttt_vampire_is_independent"],
                 ["ttt_vampire_convert_enable", "ttt_vampire_convert_enabled"],

--- a/docs/deprecatedglobals.html
+++ b/docs/deprecatedglobals.html
@@ -201,21 +201,33 @@
                 "_shop_sync"
             ]
             const renamedConvars = [
-                ["ttt_detective_disable_looting", "ttt_detectives_disable_looting"],
-                ["ttt_detective_hide_special_mode", "ttt_detectives_hide_special_mode"],
-                ["ttt_detective_search_only", "ttt_detectives_search_only"],
-                ["ttt_traitor_vision_enable", "ttt_traitors_vision_enable"],
+                ["ttt_assassin_target_vision_enable", "ttt_assassin_target_vision_enabled"],
                 ["ttt_beggars_are_independent", "ttt_beggar_is_independent"],
                 ["ttt_bodysnatchers_are_independent", "ttt_bodysnatcher_is_independent"] ,
                 ["ttt_cupids_are_independent", "ttt_cupid_is_independent"],
-                ["ttt_detective_glow_enable", "ttt_detectives_glow_enable"],
+                ["ttt_cupid_lover_vision_enable", "ttt_cupid_lover_vision_enabled"],
+                ["ttt_death_notifier_enable", "ttt_death_notifier_enabled"],
                 ["ttt_detective_credits_timer", "ttt_detectives_credits_timer"],
+                ["ttt_detective_disable_looting", "ttt_detectives_disable_looting"],
+                ["ttt_detective_glow_enable", "ttt_detectives_glow_enabled"],
+                ["ttt_detective_hide_special_mode", "ttt_detectives_hide_special_mode"],
+                ["ttt_detective_search_only", "ttt_detectives_search_only"],
+                ["ttt_hivemind_vision_enable", "ttt_hivemind_vision_enabled"],
                 ["ttt_infected_respawn_enable", "ttt_infected_respawn_enabled"],
+                ["ttt_killer_vision_enable", "ttt_killer_vision_enabled"],
+                ["ttt_madscientist_respawn_enable", "ttt_madscientist_respawn_enabled"],
                 ["ttt_traitor_credits_timer", "ttt_traitors_credits_timer"],
+                ["ttt_traitor_vision_enable", "ttt_traitors_vision_enabled"],
                 ["ttt_vampires_are_monsters", "ttt_vampire_is_monster"],
                 ["ttt_vampires_are_independent", "ttt_vampire_is_independent"],
+                ["ttt_vampire_convert_enable", "ttt_vampire_convert_enabled"],
+                ["ttt_vampire_drain_enable", "ttt_vampire_drain_enabled"],
+                ["ttt_vampire_vision_enable", "ttt_vampire_vision_enabled"],
                 ["ttt_zombies_are_monsters", "ttt_zombie_is_monster"],
-                ["ttt_zombies_are_traitors", "ttt_zombie_is_traitor"]
+                ["ttt_zombies_are_traitors", "ttt_zombie_is_traitor"],
+                ["ttt_zombie_leap_enable", "ttt_zombie_leap_enabled"],
+                ["ttt_zombie_spit_enable", "ttt_zombie_spit_enabled"],
+                ["ttt_zombie_vision_enable", "ttt_zombie_vision_enabled"]
             ]
 
             const button = document.getElementById('open');

--- a/docs/deprecatedglobals.html
+++ b/docs/deprecatedglobals.html
@@ -213,7 +213,8 @@
                 ["ttt_vampires_are_monsters", "ttt_vampire_is_monster"],
                 ["ttt_vampires_are_independent", "ttt_vampire_is_independent"],
                 ["ttt_zombies_are_monsters", "ttt_zombie_is_monster"],
-                ["ttt_zombies_are_traitors", "ttt_zombie_is_traitor"]
+                ["ttt_zombies_are_traitors", "ttt_zombie_is_traitor"],
+                ["ttt_traitor_credits_timer", "ttt_traitors_credits_timer"]
             ]
 
             const button = document.getElementById('open');

--- a/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_med_defib.lua
@@ -58,10 +58,12 @@ if SERVER then
             ply:SetRole(ROLE_INNOCENT)
             ply:StripRoleWeapons()
         elseif ply:GetDetectiveLike() then
-            if ply:IsInnocentTeam() then
-                ply:SetRole(ROLE_INNOCENT)
+            if ply:IsJesterTeam() then
+                ply:SetRole(ROLE_JESTER)
             elseif ply:IsTraitorTeam() then
                 ply:SetRole(ROLE_TRAITOR)
+            else
+                ply:SetRole(ROLE_INNOCENT)
             end
             ply:StripRoleWeapons()
         end

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -337,7 +337,7 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
     self:GetOwner():FireBullets(bullet)
 
     -- Owner can die after firebullets
-    if (not IsValid(self:GetOwner())) or (not self:GetOwner():Alive()) or self:GetOwner():IsNPC() then return end
+    if (not IsValid(self:GetOwner())) or self:GetOwner():IsNPC() or (not self:GetOwner():Alive()) then return end
 
     if ((game.SinglePlayer() and SERVER) or
             ((not game.SinglePlayer()) and CLIENT and IsFirstTimePredicted())) then

--- a/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_vam_fangs.lua
@@ -64,8 +64,8 @@ local STATE_KILL = 4
 
 local beep = Sound("npc/fast_zombie/fz_alert_close1.wav")
 
-local vampire_convert_enable = CreateConVar("ttt_vampire_convert_enable", "0", FCVAR_REPLICATED, "Whether vampires have the ability to convert living targets to a vampire thrall using their fangs", 0, 1)
-local vampire_drain_enable = CreateConVar("ttt_vampire_drain_enable", "1", FCVAR_REPLICATED, "Whether vampires have the ability to drain a living target's blood using their fangs", 0, 1)
+local vampire_convert_enabled = CreateConVar("ttt_vampire_convert_enabled", "0", FCVAR_REPLICATED, "Whether vampires have the ability to convert living targets to a vampire thrall using their fangs", 0, 1)
+local vampire_drain_enabled = CreateConVar("ttt_vampire_drain_enabled", "1", FCVAR_REPLICATED, "Whether vampires have the ability to drain a living target's blood using their fangs", 0, 1)
 local vampire_drain_first = CreateConVar("ttt_vampire_drain_first", "0", FCVAR_REPLICATED, "Whether vampires should drain a living target's blood first rather than converting first", 0, 1)
 local vampire_prime_only_convert = CreateConVar("ttt_vampire_prime_only_convert", "1", FCVAR_REPLICATED, "Whether only prime vampires (e.g. players who spawn as vampire originally) are allowed to convert other players", 0, 1)
 
@@ -155,7 +155,7 @@ function SWEP:OnRemove()
 end
 
 function SWEP:CanConvert()
-    return vampire_convert_enable:GetBool() and (not vampire_prime_only_convert:GetBool() or self:GetOwner():IsVampirePrime())
+    return vampire_convert_enabled:GetBool() and (not vampire_prime_only_convert:GetBool() or self:GetOwner():IsVampirePrime())
 end
 
 local function GetPlayerFromBody(body)
@@ -189,7 +189,7 @@ function SWEP:PrimaryAttack()
             end
 
             self:Eat(tr.Entity)
-        elseif ent:IsPlayer() and vampire_drain_enable:GetBool() then
+        elseif ent:IsPlayer() and vampire_drain_enabled:GetBool() then
             self:SetTargetIsBody(false)
             if ent:ShouldActLikeJester() then
                 self:Error("TARGET IS A JESTER")

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -65,8 +65,8 @@ SWEP.NextReload = CurTime()
 SWEP.DeploySpeed = 2
 local sound_single = Sound("Weapon_Crowbar.Single")
 
-local zombie_leap_enable = CreateConVar("ttt_zombie_leap_enable", "1", FCVAR_REPLICATED)
-local zombie_spit_enable = CreateConVar("ttt_zombie_spit_enable", "1", FCVAR_REPLICATED)
+local zombie_leap_enabled = CreateConVar("ttt_zombie_leap_enabled", "1", FCVAR_REPLICATED)
+local zombie_spit_enabled = CreateConVar("ttt_zombie_spit_enabled", "1", FCVAR_REPLICATED)
 local zombie_prime_attack_damage = CreateConVar("ttt_zombie_prime_attack_damage", "65", FCVAR_REPLICATED, "The amount of a damage a prime zombie (e.g. player who spawned as a zombie originally) does with their claws. Server or round must be restarted for changes to take effect", 1, 100)
 local zombie_thrall_attack_damage = CreateConVar("ttt_zombie_thrall_attack_damage", "45", FCVAR_REPLICATED, "The amount of a damage a zombie thrall (e.g. non-prime zombie) does with their claws. Server or round must be restarted for changes to take effect", 1, 100)
 local zombie_prime_attack_delay = CreateConVar("ttt_zombie_prime_attack_delay", "0.7", FCVAR_REPLICATED, "The amount of time between claw attacks for a prime zombie (e.g. player who spawned as a zombie originally). Server or round must be restarted for changes to take effect", 0.1, 3)
@@ -173,7 +173,7 @@ Jump Attack
 ]]
 
 function SWEP:SecondaryAttack()
-    if not zombie_leap_enable:GetBool() then return end
+    if not zombie_leap_enabled:GetBool() then return end
 
     local owner = self:GetOwner()
     if not IsValid(owner) then return end
@@ -226,7 +226,7 @@ Spit Attack
 ]]
 
 function SWEP:Reload()
-    if not zombie_spit_enable:GetBool() then return end
+    if not zombie_spit_enabled:GetBool() then return end
     if self.NextReload > CurTime() then return end
 
     local owner = self:GetOwner()

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -230,7 +230,7 @@ local function ReceiveRole()
     client:SetRole(role)
 
     -- Update the local state
-    traitor_vision = GetConVar("ttt_traitors_vision_enable"):GetBool()
+    traitor_vision = GetConVar("ttt_traitors_vision_enabled"):GetBool()
     jesters_visible_to_traitors = GetConVar("ttt_jesters_visible_to_traitors"):GetBool()
 
     -- Disable highlights on role change

--- a/gamemodes/terrortown/gamemode/deathnotify.lua
+++ b/gamemodes/terrortown/gamemode/deathnotify.lua
@@ -9,11 +9,11 @@ local StringStartsWith = string.StartsWith
 
 util.AddNetworkString("TTT_ClientDeathNotify")
 
-local death_notifier_enable = CreateConVar("ttt_death_notifier_enable", "1")
+local death_notifier_enabled = CreateConVar("ttt_death_notifier_enabled", "1")
 
 hook.Add("PlayerDeath", "TTT_ClientDeathNotify", function(victim, inflictor, attacker)
     if gmod.GetGamemode().Name ~= "Trouble in Terrorist Town" then return end
-    if not death_notifier_enable:GetBool() then return end
+    if not death_notifier_enabled:GetBool() then return end
 
     local reason = "nil"
     local killerName = "nil"

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -1666,6 +1666,7 @@ function SelectRoles()
                     if not delayed or not JESTER_ROLES[r] then continue end
                     HandleDelayedRole(r, independentRoles)
                 end
+                -- Allow external addons to modify available roles and their weights
                 CallHook("TTTSelectRolesJesterOptions", nil, independentRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
             end
 
@@ -1690,6 +1691,7 @@ function SelectRoles()
                 if not delayed or not JESTER_ROLES[r] then continue end
                 HandleDelayedRole(r, jesterRoles)
             end
+            -- Allow external addons to modify available roles and their weights
             CallHook("TTTSelectRolesJesterOptions", nil, jesterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
 
             if #jesterRoles ~= 0 then
@@ -1702,6 +1704,32 @@ function SelectRoles()
                 for i = #jesterRoles, 1, -1 do
                     if jesterRoles[i] == role then
                         table.remove(jesterRoles, i)
+                    end
+                end
+            end
+        end
+    end
+
+    if monster_count > 0 and #choices > 0 then
+        for r, delayed in pairs(delayedCheckRoles) do
+            if not delayed or not MONSTER_ROLES[r] then continue end
+            HandleDelayedRole(r, monsterRoles)
+        end
+
+        -- Allow external addons to modify available roles and their weights
+        CallHook("TTTSelectRolesMonsterOptions", nil, monsterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
+
+        for _ = 1, monster_count do
+            if #monsterRoles ~= 0 and math.random() <= GetConVar("ttt_monster_chance"):GetFloat() and #choices > 0 then
+                local plyPick = math.random(1, #choices)
+                local ply = table.remove(choices, plyPick)
+                local rolePick = math.random(1, #monsterRoles)
+                local role = monsterRoles[rolePick]
+                ply:SetRole(role)
+                PrintRole(ply, role)
+                for i = #monsterRoles, 1, -1 do
+                    if monsterRoles[i] == role then
+                        table.remove(monsterRoles, i)
                     end
                 end
             end
@@ -1741,34 +1769,6 @@ function SelectRoles()
                         table.remove(specialInnocentRoles, i)
                     end
                 end
-            end
-        end
-    end
-
-    if monster_count > 0 then
-        local monster_chosen = false
-        for _ = 1, monster_count do
-            for r, delayed in pairs(delayedCheckRoles) do
-                if not delayed or not MONSTER_ROLES[r] then continue end
-                HandleDelayedRole(r, monsterRoles)
-            end
-
-            -- Allow external addons to modify available roles and their weights
-            CallHook("TTTSelectRolesMonsterOptions", nil, monsterRoles, choices_copy, choice_count, traitors_copy, traitor_count, detectives_copy, detective_count)
-
-            if #monsterRoles ~= 0 and math.random() <= GetConVar("ttt_monster_chance"):GetFloat() and #choices > 0 and not monster_chosen then
-                local plyPick = math.random(1, #choices)
-                local ply = table.remove(choices, plyPick)
-                local rolePick = math.random(1, #monsterRoles)
-                local role = monsterRoles[rolePick]
-                ply:SetRole(role)
-                PrintRole(ply, role)
-                for i = #monsterRoles, 1, -1 do
-                    if monsterRoles[i] == role then
-                        table.remove(monsterRoles, i)
-                    end
-                end
-                monster_chosen = true
             end
         end
     end

--- a/gamemodes/terrortown/gamemode/init_shd.lua
+++ b/gamemodes/terrortown/gamemode/init_shd.lua
@@ -30,7 +30,7 @@ for _, dataType in ipairs(CORPSE_ICON_TYPES) do
 end
 
 -- Traitor role properties
-CreateConVar("ttt_traitors_vision_enable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_traitors_vision_enabled", "0", FCVAR_REPLICATED)
 
 -- Jester role properties
 CreateConVar("ttt_jesters_visible_to_traitors", "1", FCVAR_REPLICATED)

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -16,7 +16,7 @@ local GetAllPlayers = player.GetAll
 local assassin_shop_roles_last = CreateConVar("ttt_assassin_shop_roles_last", "0")
 
 local assassin_show_target_icon = GetConVar("ttt_assassin_show_target_icon")
-local assassin_target_vision_enable = GetConVar("ttt_assassin_target_vision_enable")
+local assassin_target_vision_enabled = GetConVar("ttt_assassin_target_vision_enabled")
 local assassin_next_target_delay = GetConVar("ttt_assassin_next_target_delay")
 local assassin_target_damage_bonus = GetConVar("ttt_assassin_target_damage_bonus")
 local assassin_target_bonus_bought = GetConVar("ttt_assassin_target_bonus_bought")
@@ -270,7 +270,7 @@ end)
 hook.Add("SetupPlayerVisibility", "Assassin_SetupPlayerVisibility", function(ply)
     if not ply:ShouldBypassCulling() then return end
     if not ply:IsActiveAssassin() then return end
-    if not assassin_target_vision_enable:GetBool() and not assassin_show_target_icon:GetBool() then return end
+    if not assassin_target_vision_enabled:GetBool() and not assassin_show_target_icon:GetBool() then return end
 
     local target_sid64 = ply:GetNWString("AssassinTarget", "")
     for _, v in ipairs(GetAllPlayers()) do

--- a/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/cl_assassin.lua
@@ -12,7 +12,7 @@ local GetAllPlayers = player.GetAll
 -------------
 
 local assassin_show_target_icon = GetConVar("ttt_assassin_show_target_icon")
-local assassin_target_vision_enable = GetConVar("ttt_assassin_target_vision_enable")
+local assassin_target_vision_enabled = GetConVar("ttt_assassin_target_vision_enabled")
 local assassin_next_target_delay = GetConVar("ttt_assassin_next_target_delay")
 local assassin_allow_lootgoblin_kill = GetConVar("ttt_assassin_allow_lootgoblin_kill")
 local assassin_allow_zombie_kill = GetConVar("ttt_assassin_allow_zombie_kill")
@@ -141,7 +141,7 @@ end
 
 hook.Add("TTTUpdateRoleState", "Assassin_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    assassin_target_vision = assassin_target_vision_enable:GetBool()
+    assassin_target_vision = assassin_target_vision_enabled:GetBool()
 
     -- Disable highlights on role change
     if vision_enabled then
@@ -210,7 +210,7 @@ hook.Add("TTTTutorialRoleText", "Assassin_TTTTutorialRoleText", function(role, t
         end
         html = html .. "after their current target is <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>killed</span>.</span>"
 
-        local hasVision = assassin_target_vision_enable:GetBool()
+        local hasVision = assassin_target_vision_enabled:GetBool()
         if hasVision then
             html = html .. "<span style='display: block; margin-top: 10px;'>Their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>target intel</span> helps them see their target through walls by highlighting them.</span>"
         end
@@ -223,7 +223,7 @@ hook.Add("TTTTutorialRoleText", "Assassin_TTTTutorialRoleText", function(role, t
             html = html .. " be identified by the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>KILL</span> icon floating over their head.</span>"
         end
 
-        if GetConVar("ttt_traitors_vision_enable"):GetBool() then
+        if GetConVar("ttt_traitors_vision_enabled"):GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'><span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Constant communication</span> with their allies allows them to quickly identify friends by highlighting them in their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>team color</span>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/assassin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/shared.lua
@@ -29,7 +29,7 @@ end)
 ------------------
 
 CreateConVar("ttt_assassin_show_target_icon", "0", FCVAR_REPLICATED)
-CreateConVar("ttt_assassin_target_vision_enable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_assassin_target_vision_enabled", "0", FCVAR_REPLICATED)
 CreateConVar("ttt_assassin_next_target_delay", "5", FCVAR_REPLICATED, "The delay (in seconds) before an assassin is assigned their next target", 0, 30)
 CreateConVar("ttt_assassin_allow_lootgoblin_kill", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_assassin_allow_zombie_kill", "1", FCVAR_REPLICATED)
@@ -45,7 +45,7 @@ table.insert(ROLE_CONVARS[ROLE_ASSASSIN], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_ASSASSIN], {
-    cvar = "ttt_assassin_target_vision_enable",
+    cvar = "ttt_assassin_target_vision_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_ASSASSIN], {

--- a/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
@@ -61,6 +61,7 @@ CreateConVar("ttt_beggar_respawn_delay", "3", FCVAR_REPLICATED, "The delay to us
 CreateConVar("ttt_beggar_respawn_change_role", "0", FCVAR_REPLICATED, "Whether to change the role of the respawning the beggar (if \"ttt_beggar_respawn\" is enabled)", 0, 1)
 CreateConVar("ttt_beggar_reveal_traitor", "1", FCVAR_REPLICATED, "Who the beggar is revealed to when they join the traitor team", 0, 4)
 CreateConVar("ttt_beggar_reveal_innocent", "2", FCVAR_REPLICATED, "Who the beggar is revealed to when they join the innocent team", 0, 4)
+CreateConVar("ttt_beggar_announce_delay", "0", FCVAR_REPLICATED, "How long the delay between role change and announcement should be")
 CreateConVar("ttt_beggar_scan", "0", FCVAR_REPLICATED, "Whether the beggar can scan players to see if they are traitors. 0 - Disabled. 1 - Can only scan traitors. 2 - Can scan any role that has a shop.", 0, 2)
 CreateConVar("ttt_beggar_scan_time", "15", FCVAR_REPLICATED, "The amount of time (in seconds) the beggar's scanner takes to use", 0, 60)
 CreateConVar("ttt_beggar_can_see_jesters", "0", FCVAR_REPLICATED)
@@ -144,6 +145,11 @@ table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
 table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
     cvar = "ttt_beggar_update_scoreboard",
     type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
+    cvar = "ttt_beggar_announce_delay",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })
 
 -------------------

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -14,7 +14,7 @@ local StringUpper = string.upper
 -- CONVARS --
 -------------
 
-local cupid_lover_vision_enable = GetConVar("ttt_cupid_lover_vision_enable")
+local cupid_lover_vision_enabled = GetConVar("ttt_cupid_lover_vision_enabled")
 local cupid_is_independent = GetConVar("ttt_cupid_is_independent")
 local cupid_lovers_notify_mode = GetConVar("ttt_cupid_lovers_notify_mode")
 local cupid_can_damage_lovers = GetConVar("ttt_cupid_can_damage_lovers")
@@ -300,7 +300,7 @@ end
 
 AddHook("TTTUpdateRoleState", "Cupid_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    lover_vision = cupid_lover_vision_enable:GetBool()
+    lover_vision = cupid_lover_vision_enabled:GetBool()
 
     -- Disable highlights on role change
     if vision_enabled then

--- a/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
@@ -6,7 +6,7 @@ local table = table
 -- ROLE CONVARS --
 ------------------
 
-CreateConVar("ttt_cupid_lover_vision_enable", "1", FCVAR_REPLICATED, "Whether the lovers can see outlines of each other through walls", 0, 1)
+CreateConVar("ttt_cupid_lover_vision_enabled", "1", FCVAR_REPLICATED, "Whether the lovers can see outlines of each other through walls", 0, 1)
 CreateConVar("ttt_cupid_can_see_jesters", "0", FCVAR_REPLICATED)
 CreateConVar("ttt_cupid_update_scoreboard", "0", FCVAR_REPLICATED)
 local cupid_is_independent = CreateConVar("ttt_cupid_is_independent", "0", FCVAR_REPLICATED, "Whether cupids should be treated as members of the independent team", 0, 1)
@@ -51,7 +51,7 @@ table.insert(ROLE_CONVARS[ROLE_CUPID], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_CUPID], {
-    cvar = "ttt_cupid_lover_vision_enable",
+    cvar = "ttt_cupid_lover_vision_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_CUPID], {

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/cl_detectivelike.lua
@@ -15,7 +15,7 @@ local TableInsert = table.insert
 -- CONVARS --
 -------------
 
-local detectives_glow_enable = GetConVar("ttt_detectives_glow_enable")
+local detectives_glow_enabled = GetConVar("ttt_detectives_glow_enabled")
 
 ------------------
 -- TRANSLATIONS --
@@ -128,7 +128,7 @@ end
 
 AddHook("TTTUpdateRoleState", "DetectiveLike_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    detective_glow = detectives_glow_enable:GetBool()
+    detective_glow = detectives_glow_enabled:GetBool()
 
     -- Disable highlights on role change
     if vision_enabled then

--- a/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/detectivelike/shared.lua
@@ -17,7 +17,7 @@ ROLE_MOVE_ROLE_STATE[ROLE_IMPERSONATOR] = MoveRoleState
 -- CONVARS --
 -------------
 
-local detectives_glow_enable = CreateConVar("ttt_detectives_glow_enable", "0", FCVAR_REPLICATED)
+local detectives_glow_enabled = CreateConVar("ttt_detectives_glow_enabled", "0", FCVAR_REPLICATED)
 
 --------------------
 -- PLAYER METHODS --
@@ -60,6 +60,6 @@ plymeta.IsDetectiveLike = plymeta.GetDetectiveLike
 plymeta.IsDetectiveLikePromotable = plymeta.GetDetectiveLikePromotable
 
 ROLETEAM_IS_TARGET_HIGHLIGHTED[ROLE_TEAM_DETECTIVE] = function(ply, tgt)
-    if tgt:IsActiveDetectiveLike() then return detectives_glow_enable:GetBool() end
+    if tgt:IsActiveDetectiveLike() then return detectives_glow_enabled:GetBool() end
     return false
 end

--- a/gamemodes/terrortown/gamemode/roles/hivemind/cl_hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/cl_hivemind.lua
@@ -12,7 +12,7 @@ local StringUpper = string.upper
 -- CONVARS --
 -------------
 
-local hivemind_vision_enable = GetConVar("ttt_hivemind_vision_enable")
+local hivemind_vision_enabled = GetConVar("ttt_hivemind_vision_enabled")
 local hivemind_friendly_fire = GetConVar("ttt_hivemind_friendly_fire")
 local hivemind_join_heal_pct = GetConVar("ttt_hivemind_join_heal_pct")
 local hivemind_regen_timer = GetConVar("ttt_hivemind_regen_timer")
@@ -128,7 +128,7 @@ end
 
 AddHook("TTTUpdateRoleState", "HiveMind_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    hivemind_vision = hivemind_vision_enable:GetBool()
+    hivemind_vision = hivemind_vision_enabled:GetBool()
 
     -- Disable highlights on role change
     if vision_enabled then
@@ -216,7 +216,7 @@ AddHook("TTTTutorialRoleText", "HiveMind_TTTTutorialRoleText", function(role, ti
 
         html = html .. "<span style='display: block; margin-top: 10px;'>The " .. ROLE_STRINGS[ROLE_HIVEMIND] .. " also has a <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>shared pool of credits</span> -- gaining or spending credits affects the collective.</span>"
 
-        if hivemind_vision_enable:GetBool() then
+        if hivemind_vision_enabled:GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'>To help identify other members of the " .. ROLE_STRINGS[ROLE_HIVEMIND] .. ", they are <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>highlighted with a visible glow</span>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
@@ -13,7 +13,7 @@ util.AddNetworkString("TTT_HiveMindChatDupe")
 -- CONVARS --
 -------------
 
-local hivemind_vision_enable = GetConVar("ttt_hivemind_vision_enable")
+local hivemind_vision_enabled = GetConVar("ttt_hivemind_vision_enabled")
 local hivemind_friendly_fire = GetConVar("ttt_hivemind_friendly_fire")
 local hivemind_join_heal_pct = GetConVar("ttt_hivemind_join_heal_pct")
 local hivemind_regen_timer = GetConVar("ttt_hivemind_regen_timer")
@@ -291,7 +291,7 @@ end)
 AddHook("SetupPlayerVisibility", "HiveMind_SetupPlayerVisibility", function(ply)
     if not ply:ShouldBypassCulling() then return end
     if not ply:IsActiveHiveMind() then return end
-    if not hivemind_vision_enable:GetBool() then return end
+    if not hivemind_vision_enabled:GetBool() then return end
 
     for _, v in ipairs(GetAllPlayers()) do
         if ply:TestPVS(v) then continue end

--- a/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
@@ -12,7 +12,7 @@ local TableInsert = table.insert
 -- ROLE CONVARS --
 ------------------
 
-CreateConVar("ttt_hivemind_vision_enable", "1", FCVAR_REPLICATED)
+CreateConVar("ttt_hivemind_vision_enabled", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_hivemind_friendly_fire", "0", FCVAR_REPLICATED)
 local hivemind_is_monster = CreateConVar("ttt_hivemind_is_monster", "0", FCVAR_REPLICATED)
 CreateConVar("ttt_hivemind_join_heal_pct", 0.25, FCVAR_REPLICATED, "The percentage a new member's maximum health that the hive mind should be healed (e.g. 0.25 = 25% of their health healed)", 0, 1)
@@ -22,7 +22,7 @@ CreateConVar("ttt_hivemind_regen_max_pct", 0.5, FCVAR_REPLICATED, "The percentag
 
 ROLE_CONVARS[ROLE_HIVEMIND] = {}
 TableInsert(ROLE_CONVARS[ROLE_HIVEMIND], {
-    cvar = "ttt_hivemind_vision_enable",
+    cvar = "ttt_hivemind_vision_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 TableInsert(ROLE_CONVARS[ROLE_HIVEMIND], {

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/cl_hypnotist.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/cl_hypnotist.lua
@@ -90,7 +90,7 @@ hook.Add("TTTTutorialRoleText", "Hypnotist_TTTTutorialRoleText", function(role, 
         end
         html = html .. ".</span>"
 
-        if GetConVar("ttt_traitors_vision_enable"):GetBool() then
+        if GetConVar("ttt_traitors_vision_enabled"):GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'><span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Constant communication</span> with their allies allows them to quickly identify friends by highlighting them in their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>team color</span>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/infected/cl_infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/cl_infected.lua
@@ -13,7 +13,7 @@ local StringUpper = string.upper
 -------------
 
 local infected_cough_enabled = GetConVar("ttt_infected_cough_enabled")
-local infected_respawn_enable = GetConVar("ttt_infected_respawn_enable")
+local infected_respawn_enabled = GetConVar("ttt_infected_respawn_enabled")
 local infected_show_icon = GetConVar("ttt_infected_show_icon")
 local infected_succumb_time = GetConVar("ttt_infected_succumb_time")
 local infected_full_health = GetConVar("ttt_infected_full_health")
@@ -183,7 +183,7 @@ hook.Add("TTTTutorialRoleText", "Infected_TTTTutorialRoleText", function(role, t
             html = html .. "<span style='display: block; margin-top: 10px;'>Once the " .. ROLE_STRINGS[ROLE_INFECTED] .. " has succumbed to their infection, they are <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>healed back to full health</span>.</span>"
         end
 
-        if infected_respawn_enable:GetBool() then
+        if infected_respawn_enabled:GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'>The " .. ROLE_STRINGS[ROLE_INFECTED] .. " will also turn into " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " if <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>they are killed</span>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/infected/cl_infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/cl_infected.lua
@@ -12,6 +12,7 @@ local StringUpper = string.upper
 -- CONVARS --
 -------------
 
+local infected_prime = GetConVar("ttt_infected_prime")
 local infected_cough_enabled = GetConVar("ttt_infected_cough_enabled")
 local infected_respawn_enabled = GetConVar("ttt_infected_respawn_enabled")
 local infected_show_icon = GetConVar("ttt_infected_show_icon")
@@ -185,6 +186,10 @@ hook.Add("TTTTutorialRoleText", "Infected_TTTTutorialRoleText", function(role, t
 
         if infected_respawn_enabled:GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'>The " .. ROLE_STRINGS[ROLE_INFECTED] .. " will also turn into " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " if <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>they are killed</span>.</span>"
+        end
+
+        if infected_prime:GetBool() then
+            html = html .. "<span style='display: block; margin-top: 10px;'>The " .. ROLE_STRINGS[ROLE_INFECTED] .. " will come back back as a <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>prime " .. ROLE_STRINGS[ROLE_ZOMBIE] .. "</span>, meaning they have all the abilities and stat bonuses that " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " spawning into the round normally would have.</span>"
         end
 
         if infected_cough_enabled:GetBool() then

--- a/gamemodes/terrortown/gamemode/roles/infected/infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/infected.lua
@@ -21,10 +21,10 @@ util.AddNetworkString("TTT_InfectedSuccumbed")
 -- CONVARS --
 -------------
 
-local infected_prime = CreateConVar("ttt_infected_prime", "1", FCVAR_NONE, "Whether the infected will become a prime zombie", 0, 1)
 local infected_cough_timer_min = CreateConVar("ttt_infected_cough_timer_min", "30", FCVAR_NONE, "The minimum time between infected coughs", 0, 180)
 local infected_cough_timer_max = CreateConVar("ttt_infected_cough_timer_max", "60", FCVAR_NONE, "The maximum time between infected coughs", 0, 300)
 
+local infected_prime = GetConVar("ttt_infected_prime")
 local infected_cough_enabled = GetConVar("ttt_infected_cough_enabled")
 local infected_respawn_enabled = GetConVar("ttt_infected_respawn_enabled")
 local infected_succumb_time = GetConVar("ttt_infected_succumb_time")

--- a/gamemodes/terrortown/gamemode/roles/infected/infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/infected.lua
@@ -26,7 +26,7 @@ local infected_cough_timer_min = CreateConVar("ttt_infected_cough_timer_min", "3
 local infected_cough_timer_max = CreateConVar("ttt_infected_cough_timer_max", "60", FCVAR_NONE, "The maximum time between infected coughs", 0, 300)
 
 local infected_cough_enabled = GetConVar("ttt_infected_cough_enabled")
-local infected_respawn_enable = GetConVar("ttt_infected_respawn_enable")
+local infected_respawn_enabled = GetConVar("ttt_infected_respawn_enabled")
 local infected_succumb_time = GetConVar("ttt_infected_succumb_time")
 local infected_full_health = GetConVar("ttt_infected_full_health")
 
@@ -137,7 +137,7 @@ local function StartSuccumbTimer()
 end
 
 hook.Add("PlayerDeath", "Infected_KillCheck_PlayerDeath", function(victim, infl, attacker)
-    if not infected_respawn_enable:GetBool() then return end
+    if not infected_respawn_enabled:GetBool() then return end
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if not valid_kill then return end
     if not victim:IsInfected() then return end

--- a/gamemodes/terrortown/gamemode/roles/infected/infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/infected.lua
@@ -157,16 +157,6 @@ ROLE_ON_ROLE_ASSIGNED[ROLE_INFECTED] = function()
     StartCoughTimer()
 end
 
-------------------
--- CUPID LOVERS --
-------------------
-
-hook.Add("TTTCupidShouldLoverSurvive", "Infected_TTTCupidShouldLoverSurvive", function(ply, lover)
-    if ply:GetNWBool("InfectedIsZombifying", false) or lover:GetNWBool("InfectedIsZombifying", false) then
-        return true
-    end
-end)
-
 -------------
 -- CLEANUP --
 -------------

--- a/gamemodes/terrortown/gamemode/roles/infected/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/shared.lua
@@ -6,6 +6,7 @@ local table = table
 -- ROLE CONVARS --
 ------------------
 
+CreateConVar("ttt_infected_prime", "1", FCVAR_NONE, "Whether the infected will become a prime zombie", 0, 1)
 CreateConVar("ttt_infected_cough_enabled", "1", FCVAR_REPLICATED, "Whether the infected coughs periodically", 0, 1)
 CreateConVar("ttt_infected_respawn_enabled", "0", FCVAR_REPLICATED, "Whether the infected will respawn as a zombie when killed", 0, 1)
 CreateConVar("ttt_infected_show_icon", "1", FCVAR_REPLICATED, "Whether to show the infected icon over their head for zombies and zombie allies", 0, 1)

--- a/gamemodes/terrortown/gamemode/roles/infected/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/shared.lua
@@ -7,7 +7,7 @@ local table = table
 ------------------
 
 CreateConVar("ttt_infected_cough_enabled", "1", FCVAR_REPLICATED, "Whether the infected coughs periodically", 0, 1)
-CreateConVar("ttt_infected_respawn_enable", "0", FCVAR_REPLICATED, "Whether the infected will respawn as a zombie when killed", 0, 1)
+CreateConVar("ttt_infected_respawn_enabled", "0", FCVAR_REPLICATED, "Whether the infected will respawn as a zombie when killed", 0, 1)
 CreateConVar("ttt_infected_show_icon", "1", FCVAR_REPLICATED, "Whether to show the infected icon over their head for zombies and zombie allies", 0, 1)
 CreateConVar("ttt_infected_succumb_time", "180", FCVAR_REPLICATED, "Time in seconds for the infected to succumb to their disease", 0, 300)
 CreateConVar("ttt_infected_full_health", "1", FCVAR_REPLICATED, "Whether the infected's health is refilled when they become a zombie", 0, 1)
@@ -27,7 +27,7 @@ table.insert(ROLE_CONVARS[ROLE_INFECTED], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_INFECTED], {
-    cvar = "ttt_infected_respawn_enable",
+    cvar = "ttt_infected_respawn_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_INFECTED], {

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -11,7 +11,7 @@ local killer_knife_enabled = GetConVar("ttt_killer_knife_enabled")
 local killer_crowbar_enabled = GetConVar("ttt_killer_crowbar_enabled")
 local killer_smoke_enabled = GetConVar("ttt_killer_smoke_enabled")
 local killer_show_target_icon = GetConVar("ttt_killer_show_target_icon")
-local killer_vision_enable = GetConVar("ttt_killer_vision_enable")
+local killer_vision_enabled = GetConVar("ttt_killer_vision_enabled")
 local killer_warn_all = GetConVar("ttt_killer_warn_all")
 local killer_can_see_jesters = GetConVar("ttt_killer_can_see_jesters")
 
@@ -73,7 +73,7 @@ end
 
 hook.Add("TTTUpdateRoleState", "Killer_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    killer_vision = killer_vision_enable:GetBool()
+    killer_vision = killer_vision_enabled:GetBool()
     can_see_jesters = killer_can_see_jesters:GetBool()
 
     -- Disable highlights on role change
@@ -175,7 +175,7 @@ hook.Add("TTTTutorialRoleText", "Killer_TTTTutorialRoleText", function(role, tit
         end
 
         -- Vision
-        local hasVision = killer_vision_enable:GetBool()
+        local hasVision = killer_vision_enabled:GetBool()
         if hasVision then
             html = html .. "<span style='display: block; margin-top: 10px;'>Their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>blood lust</span> helps them see their targets through walls by highlighting their enemies.</span>"
         end

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -13,6 +13,7 @@ local killer_smoke_enabled = GetConVar("ttt_killer_smoke_enabled")
 local killer_show_target_icon = GetConVar("ttt_killer_show_target_icon")
 local killer_vision_enable = GetConVar("ttt_killer_vision_enable")
 local killer_warn_all = GetConVar("ttt_killer_warn_all")
+local killer_can_see_jesters = GetConVar("ttt_killer_can_see_jesters")
 
 ------------------
 -- TRANSLATIONS --
@@ -61,17 +62,19 @@ end)
 
 local killer_vision = false
 local vision_enabled = false
+local can_see_jesters = false
 local client = nil
 
 local function EnableKillerHighlights()
     hook.Add("PreDrawHalos", "Killer_Highlight_PreDrawHalos", function()
-        OnPlayerHighlightEnabled(client, {ROLE_KILLER}, GetConVar("ttt_killer_can_see_jesters"):GetBool(), false, false)
+        OnPlayerHighlightEnabled(client, {ROLE_KILLER}, can_see_jesters, false, false)
     end)
 end
 
 hook.Add("TTTUpdateRoleState", "Killer_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
     killer_vision = killer_vision_enable:GetBool()
+    can_see_jesters = killer_can_see_jesters:GetBool()
 
     -- Disable highlights on role change
     if vision_enabled then

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -17,6 +17,9 @@ local GetAllPlayers = player.GetAll
 local killer_smoke_timer = CreateConVar("ttt_killer_smoke_timer", "60", FCVAR_NONE, "Number of seconds before a killer will start to smoke after their last kill", 1, 120)
 local killer_damage_penalty = CreateConVar("ttt_killer_damage_penalty", "0.25", FCVAR_NONE, "The fraction a killer's damage will be scaled by when they are attacking without using their knife", 0, 1)
 local killer_damage_reduction = CreateConVar("ttt_killer_damage_reduction", "0", FCVAR_NONE, "The fraction an attacker's bullet damage will be reduced by when they are shooting a killer", 0, 1)
+local killer_credits_award_pct = CreateConVar("ttt_killer_credits_award_pct", "0.35")
+local killer_credits_award_size = CreateConVar("ttt_killer_credits_award_size", "1")
+local killer_credits_award_repeat = CreateConVar("ttt_killer_credits_award_repeat", "1")
 
 local killer_knife_enabled = GetConVar("ttt_killer_knife_enabled")
 local killer_crowbar_enabled = GetConVar("ttt_killer_crowbar_enabled")
@@ -154,7 +157,7 @@ hook.Add("DoPlayerDeath", "Killer_Credits_DoPlayerDeath", function(victim, attac
 
     local valid_attacker = IsPlayer(attacker)
 
-    if valid_attacker and attacker:IsActiveKiller() and (not (victim:IsKiller() or victim:IsJesterTeam())) and (not GAMEMODE.AwardedKillerCredits or GetConVar("ttt_credits_award_repeat"):GetBool()) then
+    if valid_attacker and attacker:IsActiveKiller() and (not (victim:IsKiller() or victim:IsJesterTeam())) and (not GAMEMODE.AwardedKillerCredits or killer_credits_award_repeat:GetBool()) then
         local ply_alive = 0
         local ply_dead = 0
 
@@ -180,9 +183,9 @@ hook.Add("DoPlayerDeath", "Killer_Credits_DoPlayerDeath", function(victim, attac
         end
 
         local pct = ply_dead / ply_total
-        if pct >= GetConVar("ttt_credits_award_pct"):GetFloat() then
+        if pct >= killer_credits_award_pct:GetFloat() then
             -- Traitors have killed sufficient people to get an award
-            local amt = GetConVar("ttt_credits_award_size"):GetInt()
+            local amt = killer_credits_award_size:GetInt()
 
             -- If size is 0, awards are off
             if amt > 0 then

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -25,7 +25,7 @@ local killer_knife_enabled = GetConVar("ttt_killer_knife_enabled")
 local killer_crowbar_enabled = GetConVar("ttt_killer_crowbar_enabled")
 local killer_smoke_enabled = GetConVar("ttt_killer_smoke_enabled")
 local killer_show_target_icon = GetConVar("ttt_killer_show_target_icon")
-local killer_vision_enable = GetConVar("ttt_killer_vision_enable")
+local killer_vision_enabled = GetConVar("ttt_killer_vision_enabled")
 local killer_warn_all = GetConVar("ttt_killer_warn_all")
 
 -----------
@@ -344,7 +344,7 @@ end)
 hook.Add("SetupPlayerVisibility", "Killer_SetupPlayerVisibility", function(ply)
     if not ply:ShouldBypassCulling() then return end
     if not ply:IsActiveKiller() then return end
-    if not killer_vision_enable:GetBool() and not killer_show_target_icon:GetBool() then return end
+    if not killer_vision_enabled:GetBool() and not killer_show_target_icon:GetBool() then return end
 
     for _, v in ipairs(GetAllPlayers()) do
         if ply:TestPVS(v) then continue end

--- a/gamemodes/terrortown/gamemode/roles/killer/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/shared.lua
@@ -161,3 +161,17 @@ table.insert(ROLE_CONVARS[ROLE_KILLER], {
     cvar = "ttt_killer_update_scoreboard",
     type = ROLE_CONVAR_TYPE_BOOL
 })
+table.insert(ROLE_CONVARS[ROLE_KILLER], {
+    cvar = "ttt_killer_credits_award_pct",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 2
+})
+table.insert(ROLE_CONVARS[ROLE_KILLER], {
+    cvar = "ttt_killer_credits_award_size",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
+})
+table.insert(ROLE_CONVARS[ROLE_KILLER], {
+    cvar = "ttt_killer_credits_award_repeat",
+    type = ROLE_CONVAR_TYPE_BOOL
+})

--- a/gamemodes/terrortown/gamemode/roles/killer/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/shared.lua
@@ -89,7 +89,7 @@ CreateConVar("ttt_killer_knife_enabled", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_killer_crowbar_enabled", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_killer_smoke_enabled", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_killer_show_target_icon", "1", FCVAR_REPLICATED)
-CreateConVar("ttt_killer_vision_enable", "1", FCVAR_REPLICATED)
+CreateConVar("ttt_killer_vision_enabled", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_killer_update_scoreboard", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_killer_warn_all", "0", FCVAR_REPLICATED)
 
@@ -130,7 +130,7 @@ table.insert(ROLE_CONVARS[ROLE_KILLER], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_KILLER], {
-    cvar = "ttt_killer_vision_enable",
+    cvar = "ttt_killer_vision_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_KILLER], {

--- a/gamemodes/terrortown/gamemode/roles/madscientist/cl_madscientist.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/cl_madscientist.lua
@@ -4,7 +4,7 @@ local hook = hook
 -- CONVARS --
 -------------
 
-local madscientist_respawn_enable = GetConVar("ttt_madscientist_respawn_enable")
+local madscientist_respawn_enabled = GetConVar("ttt_madscientist_respawn_enabled")
 
 ------------------
 -- TRANSLATIONS --
@@ -34,7 +34,7 @@ hook.Add("TTTTutorialRoleText", "MadScientist_TTTTutorialRoleText", function(rol
         local html = "The " .. ROLE_STRINGS[ROLE_MADSCIENTIST] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. string.lower(roleTeamString) .. " team</span> whose goal is to resurrect dead bodies as their <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>" .. ROLE_STRINGS[ROLE_ZOMBIE] .. " minions</span>."
 
         -- Respawn
-        if madscientist_respawn_enable:GetBool() then
+        if madscientist_respawn_enabled:GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'>If the " .. ROLE_STRINGS[ROLE_MADSCIENTIST] .. " is killed they will <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>respawn as " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " thrall</spawn>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/madscientist/madscientist.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/madscientist.lua
@@ -6,7 +6,7 @@ local hook = hook
 -- CONVARS --
 -------------
 
-local madscientist_respawn_enable = GetConVar("ttt_madscientist_respawn_enable")
+local madscientist_respawn_enabled = GetConVar("ttt_madscientist_respawn_enabled")
 
 -------------------
 -- ROLE FEATURES --
@@ -15,7 +15,7 @@ local madscientist_respawn_enable = GetConVar("ttt_madscientist_respawn_enable")
 hook.Add("PlayerDeath", "MadScientist_PlayerDeath", function(victim, infl, attacker)
     if GetRoundState() ~= ROUND_ACTIVE then return end
     if not victim:IsMadScientist() then return end
-    if not madscientist_respawn_enable:GetBool() then return end
+    if not madscientist_respawn_enabled:GetBool() then return end
 
     -- Respawn the mad scientist as a zombie if they are killed
     victim:RespawnAsZombie()

--- a/gamemodes/terrortown/gamemode/roles/madscientist/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/madscientist/shared.lua
@@ -10,7 +10,7 @@ ROLE_CAN_SEE_MIA[ROLE_MADSCIENTIST] = true
 -- ROLE CONVARS --
 ------------------
 
-CreateConVar("ttt_madscientist_respawn_enable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_madscientist_respawn_enabled", "0", FCVAR_REPLICATED)
 local madscientist_is_monster = CreateConVar("ttt_madscientist_is_monster", "0", FCVAR_REPLICATED)
 
 ROLE_CONVARS[ROLE_MADSCIENTIST] = {}
@@ -20,7 +20,7 @@ table.insert(ROLE_CONVARS[ROLE_MADSCIENTIST], {
     decimal = 0
 })
 table.insert(ROLE_CONVARS[ROLE_MADSCIENTIST], {
-    cvar = "ttt_madscientist_respawn_enable",
+    cvar = "ttt_madscientist_respawn_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_MADSCIENTIST], {

--- a/gamemodes/terrortown/gamemode/roles/paramedic/cl_paramedic.lua
+++ b/gamemodes/terrortown/gamemode/roles/paramedic/cl_paramedic.lua
@@ -48,9 +48,13 @@ hook.Add("TTTTutorialRoleText", "Paramedic_TTTTutorialRoleText", function(role, 
         end
 
         -- Respawn as Innocent
+        html = html .. "<span style='display: block; margin-top: 10px;'>Any player <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>resurrected by the defibrillator</span>"
         if paramedic_defib_as_innocent:GetBool() then
-            html = html .. "<span style='display: block; margin-top: 10px;'>Any player <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>resurrected by the defibrillator</span> is converted to " .. ROLE_STRINGS_EXT[ROLE_INNOCENT] .. ".</span>"
+            html = html .. " is converted to " .. ROLE_STRINGS_EXT[ROLE_INNOCENT]
+        else
+            html = html .. " retains their previous role, with the exception of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "-like roles (e.g. " .. ROLE_STRINGS[ROLE_DETECTIVE] .. ", " .. ROLE_STRINGS[ROLE_DEPUTY] .. ", " .. ROLE_STRINGS[ROLE_IMPERSONATOR] .. ", etc.) which are converted to the vanilla role for their team (" .. ROLE_STRINGS[ROLE_INNOCENT] .. ", " .. ROLE_STRINGS[ROLE_TRAITOR] .. ", etc.)"
         end
+        html = html .. ".</span>"
 
         return html
     end

--- a/gamemodes/terrortown/gamemode/roles/spy/cl_spy.lua
+++ b/gamemodes/terrortown/gamemode/roles/spy/cl_spy.lua
@@ -84,7 +84,7 @@ hook.Add("TTTTutorialRoleText", "Spy_TTTTutorialRoleText", function(role, titleL
             html = html .. ".</span>"
         end
 
-        if GetConVar("ttt_traitors_vision_enable"):GetBool() then
+        if GetConVar("ttt_traitors_vision_enabled"):GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'><span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Constant communication</span> with their allies allows them to quickly identify friends by highlighting them in their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>team color</span>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/traitor/cl_traitor.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/cl_traitor.lua
@@ -20,7 +20,7 @@ hook.Add("TTTTutorialRoleText", "Traitor_TTTTutorialRoleText", function(role, ti
         local roleColor = ROLE_COLORS[ROLE_TRAITOR]
         local html = "The " .. ROLE_STRINGS[ROLE_TRAITOR] .. " is a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>traitor team</span> whose job is to kill all of their enemies, both innocent and independent."
 
-        if GetConVar("ttt_traitors_vision_enable"):GetBool() then
+        if GetConVar("ttt_traitors_vision_enabled"):GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'><span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Constant communication</span> with their allies allows them to quickly identify friends by highlighting them in their <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>team color</span>.</span>"
         end
 

--- a/gamemodes/terrortown/gamemode/roles/traitor/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/shared.lua
@@ -64,7 +64,7 @@ end)
 --------------------
 
 ROLETEAM_IS_TARGET_HIGHLIGHTED[ROLE_TEAM_TRAITOR] = function(ply, tgt)
-    local traitor_vision = GetConVar("ttt_traitors_vision_enable"):GetBool()
+    local traitor_vision = GetConVar("ttt_traitors_vision_enabled"):GetBool()
     if ply:IsActiveTraitorTeam() and tgt:IsActiveTraitorTeam() then return traitor_vision end
     if ply:IsActiveTraitorTeam() and tgt:IsActiveJesterTeam() then return traitor_vision and GetConVar("ttt_jesters_visible_to_traitors"):GetBool() end
     return false

--- a/gamemodes/terrortown/gamemode/roles/traitor/traitor.lua
+++ b/gamemodes/terrortown/gamemode/roles/traitor/traitor.lua
@@ -8,7 +8,7 @@ local GetAllPlayers = player.GetAll
 -- CONVARS --
 -------------
 
-local traitor_credits_timer = CreateConVar("ttt_traitor_credits_timer", "0")
+local traitor_credits_timer = CreateConVar("ttt_traitors_credits_timer", "0")
 
 -----------------------
 -- PLAYER VISIBILITY --

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -280,7 +280,7 @@ hook.Add("TTTTutorialRoleText", "Vampire_TTTTutorialRoleText", function(role, ti
         end
 
         -- Vision
-        local hasVision = vampire_vision_enable:GetBool()
+        local hasVision = vampire_vision_enabled:GetBool()
         if hasVision then
             html = html .. "<span style='display: block; margin-top: 10px;'>Their <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>hunger for blood</span> helps them see their targets through walls by highlighting their enemies.</span>"
         end

--- a/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/cl_vampire.lua
@@ -11,7 +11,7 @@ local RemoveHook = hook.Remove
 -------------
 
 local vampire_show_target_icon = GetConVar("ttt_vampire_show_target_icon")
-local vampire_vision_enable = GetConVar("ttt_vampire_vision_enable")
+local vampire_vision_enabled = GetConVar("ttt_vampire_vision_enabled")
 local vampire_prime_death_mode = GetConVar("ttt_vampire_prime_death_mode")
 local vampire_damage_reduction = GetConVar("ttt_vampire_damage_reduction")
 
@@ -195,7 +195,7 @@ end
 
 hook.Add("TTTUpdateRoleState", "Vampire_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    vampire_vision = vampire_vision_enable:GetBool()
+    vampire_vision = vampire_vision_enabled:GetBool()
     jesters_visible_to_traitors = GetConVar("ttt_jesters_visible_to_traitors"):GetBool()
     jesters_visible_to_monsters = GetConVar("ttt_jesters_visible_to_monsters"):GetBool()
     jesters_visible_to_independents = INDEPENDENT_ROLES[ROLE_VAMPIRE] and GetConVar("ttt_vampire_can_see_jesters"):GetBool()
@@ -247,7 +247,7 @@ hook.Add("TTTTutorialRoleText", "Vampire_TTTTutorialRoleText", function(role, ti
 
         -- Draining
         html = html .. "<span style='display: block; margin-top: 10px;'>They can heal themselves by <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>draining blood</span> from "
-        local drainEnabled = GetConVar("ttt_vampire_drain_enable"):GetBool()
+        local drainEnabled = GetConVar("ttt_vampire_drain_enabled"):GetBool()
         if drainEnabled then
             html = html .. "both living players and "
         end
@@ -257,7 +257,7 @@ hook.Add("TTTTutorialRoleText", "Vampire_TTTTutorialRoleText", function(role, ti
         html = html .. "<span style='display: block; margin-top: 10px;'>By using the secondary attack with their fangs, they can also <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>fade from view</span> and gain a temporary speed bonus. This is useful for either chasing down prey or running away from conflict.</span>"
 
         -- Convert
-        if drainEnabled and GetConVar("ttt_vampire_convert_enable"):GetBool() then
+        if drainEnabled and GetConVar("ttt_vampire_convert_enabled"):GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'>"
             if GetConVar("ttt_vampire_prime_only_convert"):GetBool() then
                 html = html .. "Prime "

--- a/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
@@ -59,7 +59,7 @@ local vampire_is_monster = CreateConVar("ttt_vampire_is_monster", "0", FCVAR_REP
 local vampire_is_independent = CreateConVar("ttt_vampire_is_independent", "0", FCVAR_REPLICATED)
 local vampire_loot_credits = CreateConVar("ttt_vampire_loot_credits", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_vampire_show_target_icon", "0", FCVAR_REPLICATED)
-CreateConVar("ttt_vampire_vision_enable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_vampire_vision_enabled", "0", FCVAR_REPLICATED)
 CreateConVar("ttt_vampire_prime_death_mode", "0", FCVAR_REPLICATED, "What to do when the prime vampire(s) (e.g. players who spawn as vampires originally) are killed. 0 - Do nothing. 1 - Kill all vampire thralls (non-prime vampires). 2 - Revert all vampire thralls (non-prime vampires) to their original role", 0, 2)
 CreateConVar("ttt_vampire_damage_reduction", "0", FCVAR_REPLICATED, "The fraction an attacker's bullet damage will be reduced by when they are shooting a vampire", 0, 1)
 CreateConVar("ttt_vampire_can_see_jesters", "1", FCVAR_REPLICATED)
@@ -75,11 +75,11 @@ table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
-    cvar = "ttt_vampire_convert_enable",
+    cvar = "ttt_vampire_convert_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
-    cvar = "ttt_vampire_drain_enable",
+    cvar = "ttt_vampire_drain_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
@@ -157,7 +157,7 @@ table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
-    cvar = "ttt_vampire_vision_enable",
+    cvar = "ttt_vampire_vision_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {

--- a/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/shared.lua
@@ -168,6 +168,20 @@ table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
     cvar = "ttt_vampire_update_scoreboard",
     type = ROLE_CONVAR_TYPE_BOOL
 })
+table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
+    cvar = "ttt_vampire_credits_award_pct",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 2
+})
+table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
+    cvar = "ttt_vampire_credits_award_size",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
+})
+table.insert(ROLE_CONVARS[ROLE_VAMPIRE], {
+    cvar = "ttt_vampire_credits_award_repeat",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
 
 -------------------
 -- ROLE FEATURES --

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -34,7 +34,7 @@ local vampire_credits_award_repeat = CreateConVar("ttt_vampire_credits_award_rep
 
 local vampire_damage_reduction = GetConVar("ttt_vampire_damage_reduction")
 local vampire_show_target_icon = GetConVar("ttt_vampire_show_target_icon")
-local vampire_vision_enable = GetConVar("ttt_vampire_vision_enable")
+local vampire_vision_enabled = GetConVar("ttt_vampire_vision_enabled")
 local vampire_prime_death_mode = GetConVar("ttt_vampire_prime_death_mode")
 
 -------------
@@ -362,7 +362,7 @@ end)
 hook.Add("SetupPlayerVisibility", "Vampire_SetupPlayerVisibility", function(ply)
     if not ply:ShouldBypassCulling() then return end
     if not ply:IsActiveVampire() then return end
-    if not vampire_vision_enable:GetBool() and not vampire_show_target_icon:GetBool() then return end
+    if not vampire_vision_enabled:GetBool() and not vampire_show_target_icon:GetBool() then return end
 
     -- Only use this when the vampire would see the highlighting and icons (when they have their fangs out)
     local hasFangs = ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_vam_fangs"

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -28,6 +28,9 @@ resource.AddSingleFile("sound/weapons/ttt/vampireeat.wav")
 
 local vampire_kill_credits = CreateConVar("ttt_vampire_kill_credits", "1")
 local vampire_prime_friendly_fire = CreateConVar("ttt_vampire_prime_friendly_fire", "0", FCVAR_NONE, "How to handle friendly fire damage to the prime vampire(s) from their thralls. 0 - Do nothing. 1 - Reflect damage back to the attacker (non-prime vampire). 2 - Negate damage to the prime vampire.", 0, 2)
+local vampire_credits_award_pct = CreateConVar("ttt_vampire_credits_award_pct", "0.35")
+local vampire_credits_award_size = CreateConVar("ttt_vampire_credits_award_size", "1")
+local vampire_credits_award_repeat = CreateConVar("ttt_vampire_credits_award_repeat", "1")
 
 local vampire_damage_reduction = GetConVar("ttt_vampire_damage_reduction")
 local vampire_show_target_icon = GetConVar("ttt_vampire_show_target_icon")
@@ -55,7 +58,7 @@ hook.Add("DoPlayerDeath", "Vampire_Credits_DoPlayerDeath", function(victim, atta
 
     local valid_attacker = IsPlayer(attacker)
     local kill_credits = vampire_kill_credits:GetBool()
-    if kill_credits and valid_attacker and not TRAITOR_ROLES[ROLE_VAMPIRE] and attacker:IsActiveVampire() and (not (victim:IsMonsterTeam() or victim:IsJesterTeam())) and (not GAMEMODE.AwardedVampireCredits or GetConVar("ttt_credits_award_repeat"):GetBool()) then
+    if kill_credits and valid_attacker and not TRAITOR_ROLES[ROLE_VAMPIRE] and attacker:IsActiveVampire() and (not (victim:IsMonsterTeam() or victim:IsJesterTeam())) and (not GAMEMODE.AwardedVampireCredits or vampire_credits_award_repeat:GetBool()) then
         local ply_alive = 0
         local ply_dead = 0
 
@@ -81,9 +84,9 @@ hook.Add("DoPlayerDeath", "Vampire_Credits_DoPlayerDeath", function(victim, atta
         end
 
         local pct = ply_dead / ply_total
-        if pct >= GetConVar("ttt_credits_award_pct"):GetFloat() then
+        if pct >= vampire_credits_award_pct:GetFloat() then
             -- Traitors have killed sufficient people to get an award
-            local amt = GetConVar("ttt_credits_award_size"):GetInt()
+            local amt = vampire_credits_award_size:GetInt()
 
             -- If size is 0, awards are off
             if amt > 0 then

--- a/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/cl_zombie.lua
@@ -12,7 +12,7 @@ local StringUpper = string.upper
 -------------
 
 local zombie_show_target_icon = GetConVar("ttt_zombie_show_target_icon")
-local zombie_vision_enable = GetConVar("ttt_zombie_vision_enable")
+local zombie_vision_enabled = GetConVar("ttt_zombie_vision_enabled")
 local zombie_damage_penalty = GetConVar("ttt_zombie_damage_penalty")
 local zombie_damage_reduction = GetConVar("ttt_zombie_damage_reduction")
 local zombie_spit_convert = GetConVar("ttt_zombie_spit_convert")
@@ -249,7 +249,7 @@ end
 
 hook.Add("TTTUpdateRoleState", "Zombie_Highlight_TTTUpdateRoleState", function()
     client = LocalPlayer()
-    zombie_vision = zombie_vision_enable:GetBool()
+    zombie_vision = zombie_vision_enabled:GetBool()
     jesters_visible_to_traitors = GetConVar("ttt_jesters_visible_to_traitors"):GetBool()
     jesters_visible_to_monsters = GetConVar("ttt_jesters_visible_to_monsters"):GetBool()
     jesters_visible_to_independents = INDEPENDENT_ROLES[ROLE_ZOMBIE] and GetConVar("ttt_zombie_can_see_jesters"):GetBool()
@@ -303,12 +303,12 @@ hook.Add("TTTTutorialRoleText", "Zombie_TTTTutorialRoleText", function(role, tit
         html = html .. "<span style='display: block; margin-top: 10px;'>Killing a player with their claws will <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>turn the target</span> into " .. ROLE_STRINGS_EXT[ROLE_ZOMBIE] .. " thrall.</span>"
 
         -- Leap
-        if GetConVar("ttt_zombie_leap_enable"):GetBool() then
+        if GetConVar("ttt_zombie_leap_enabled"):GetBool() then
             html = html .. "<span style='display: block; margin-top: 10px;'>By using the secondary attack with the claws, " .. ROLE_STRINGS_PLURAL[ROLE_ZOMBIE] .. " can <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>leap in the air</span> to surprise their potential targets.</span>"
         end
 
         -- Spit
-        if GetConVar("ttt_zombie_spit_enable"):GetBool() then
+        if GetConVar("ttt_zombie_spit_enabled"):GetBool() then
             local keyMappingStyles = "font-size: 12px; color: black; display: inline-block; padding: 0px 3px; height: 16px; border-width: 4px; border-style: solid; border-left-color: rgb(221, 221, 221); border-bottom-color: rgb(119, 119, 102); border-right-color: rgb(119, 119, 119); border-top-color: rgb(255, 255, 255); background-color: rgb(204, 204, 187);"
             html = html .. "<span style='display: block; margin-top: 10px;'>If the target is out of range of the claws, the " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " can <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>spit acid</span> at them by pressing the "
 
@@ -323,7 +323,7 @@ hook.Add("TTTTutorialRoleText", "Zombie_TTTTutorialRoleText", function(role, tit
         end
 
         -- Vision
-        local hasVision = zombie_vision_enable:GetBool()
+        local hasVision = zombie_vision_enabled:GetBool()
         if hasVision then
             html = html .. "<span style='display: block; margin-top: 10px;'>Their <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>hunger for brains</span> helps them see their targets through walls by highlighting their enemies.</span>"
         end

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -49,7 +49,7 @@ end
 plymeta.IsZombiePrime = plymeta.GetZombiePrime
 plymeta.IsZombieAlly = plymeta.GetZombieAlly
 
-function plymeta:IsZombifying() return self:GetNWBool("IsZombifying", false) end
+function plymeta:IsZombifying() return self:GetNWBool("IsZombifying", false) or self:GetNWBool("InfectedIsZombifying", false) end
 
 ------------------
 -- ROLE CONVARS --

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -56,7 +56,7 @@ function plymeta:IsZombifying() return self:GetNWBool("IsZombifying", false) or 
 ------------------
 
 CreateConVar("ttt_zombie_show_target_icon", "0", FCVAR_REPLICATED)
-CreateConVar("ttt_zombie_vision_enable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_zombie_vision_enabled", "0", FCVAR_REPLICATED)
 local zombie_is_monster = CreateConVar("ttt_zombie_is_monster", "0", FCVAR_REPLICATED)
 local zombie_is_traitor = CreateConVar("ttt_zombie_is_traitor", "0", FCVAR_REPLICATED)
 local zombie_prime_speed_bonus = CreateConVar("ttt_zombie_prime_speed_bonus", "0.35", FCVAR_REPLICATED, "The amount of bonus speed a prime zombie (e.g. player who spawned as a zombie originally) should get when using their claws. Server or round must be restarted for changes to take effect", 0, 1)
@@ -108,15 +108,15 @@ table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
     decimal = 2
 })
 table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
-    cvar = "ttt_zombie_vision_enable",
+    cvar = "ttt_zombie_vision_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
-    cvar = "ttt_zombie_leap_enable",
+    cvar = "ttt_zombie_leap_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {
-    cvar = "ttt_zombie_spit_enable",
+    cvar = "ttt_zombie_spit_enabled",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_ZOMBIE], {

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -30,7 +30,7 @@ local zombie_prime_convert_chance = CreateConVar("ttt_zombie_prime_convert_chanc
 local zombie_thrall_convert_chance = CreateConVar("ttt_zombie_thrall_convert_chance", "1", FCVAR_NONE, "The chance that a zombie thrall (e.g. non-prime zombie) will convert other players who are killed by their claws to be zombies as well. Set to 0 to disable", 0, 1)
 
 local zombie_show_target_icon = GetConVar("ttt_zombie_show_target_icon")
-local zombie_vision_enable = GetConVar("ttt_zombie_vision_enable")
+local zombie_vision_enabled = GetConVar("ttt_zombie_vision_enabled")
 local zombie_damage_penalty = GetConVar("ttt_zombie_damage_penalty")
 local zombie_damage_reduction = GetConVar("ttt_zombie_damage_reduction")
 local zombie_spit_convert = GetConVar("ttt_zombie_spit_convert")
@@ -371,7 +371,7 @@ end)
 hook.Add("SetupPlayerVisibility", "Zombie_SetupPlayerVisibility", function(ply)
     if not ply:ShouldBypassCulling() then return end
     if not ply:IsActiveZombie() then return end
-    if not zombie_vision_enable:GetBool() and not zombie_show_target_icon:GetBool() then return end
+    if not zombie_vision_enabled:GetBool() and not zombie_show_target_icon:GetBool() then return end
 
     -- Only use this when the zombie would see the highlighting and icons (when they have their claws out)
     local hasFangs = ply.GetActiveWeapon and IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == "weapon_zom_claws"

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -22,7 +22,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.0.0"
+CR_VERSION = "1.9.14"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1731,6 +1731,9 @@ end
 CreateConVar("ttt_traitor_vision_enable", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_traitor_vision_enable", "ttt_traitors_vision_enable")
 
+CreateConVar("ttt_traitor_credits_timer", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_traitor_credits_timer", "ttt_traitors_credits_timer")
+
 -- Arsonist
 CreateConVar("ttt_detective_search_only_arsonistdouse", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_detective_search_only_arsonistdouse", "ttt_detectives_search_only_arsonistdouse")

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -22,7 +22,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.9.13"
+CR_VERSION = "2.0.0"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1729,7 +1729,11 @@ for _, dataType in ipairs(CORPSE_ICON_TYPES) do
 end
 
 CreateConVar("ttt_traitor_vision_enable", "0", FCVAR_REPLICATED)
-OldCVarWarning("ttt_traitor_vision_enable", "ttt_traitors_vision_enable")
+OldCVarWarning("ttt_traitor_vision_enable", "ttt_traitors_vision_enabled")
+
+-- Assassin
+CreateConVar("ttt_assassin_target_vision_enable", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_assassin_target_vision_enable", "ttt_assassin_target_vision_enabled")
 
 -- Arsonist
 CreateConVar("ttt_detective_search_only_arsonistdouse", "0", FCVAR_REPLICATED)
@@ -1747,18 +1751,33 @@ OldCVarWarning("ttt_bodysnatchers_are_independent", "ttt_bodysnatcher_is_indepen
 CreateConVar("ttt_cupids_are_independent", "0", FCVAR_REPLICATED, "Whether cupids should be treated as members of the independent team", 0, 1)
 OldCVarWarning("ttt_cupids_are_independent", "ttt_cupid_is_independent")
 
+CreateConVar("ttt_cupid_lover_vision_enable", "1", FCVAR_REPLICATED, "Whether the lovers can see outlines of each other through walls", 0, 1)
+OldCVarWarning("ttt_cupid_lover_vision_enable", "ttt_cupid_lover_vision_enabled")
+
 -- Detective-Like
 CreateConVar("ttt_detective_glow_enable", "0", FCVAR_REPLICATED)
-OldCVarWarning("ttt_detective_glow_enable", "ttt_detectives_glow_enable")
+OldCVarWarning("ttt_detective_glow_enable", "ttt_detectives_glow_enabled")
 
 if SERVER then
     CreateConVar("ttt_detective_credits_timer", "0")
     OldCVarWarning("ttt_detective_credits_timer", "ttt_detectives_credits_timer")
 end
 
+-- Hive Mind
+CreateConVar("ttt_hivemind_vision_enable", "1", FCVAR_REPLICATED)
+OldCVarWarning("ttt_hivemind_vision_enable", "ttt_hivemind_vision_enabled")
+
 -- Infected
 CreateConVar("ttt_infected_respawn_enable", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_infected_respawn_enable", "ttt_infected_respawn_enabled")
+
+-- Killer
+CreateConVar("ttt_killer_vision_enable", "1", FCVAR_REPLICATED)
+OldCVarWarning("ttt_killer_vision_enable", "ttt_killer_vision_enabled")
+
+-- Mad Scientist
+CreateConVar("ttt_madscientist_respawn_enable", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_madscientist_respawn_enable", "ttt_madscientist_respawn_enabled")
 
 -- Traitor
 if SERVER then
@@ -1773,9 +1792,33 @@ OldCVarWarning("ttt_vampires_are_monsters", "ttt_vampire_is_monster")
 CreateConVar("ttt_vampires_are_independent", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_vampires_are_independent", "ttt_vampire_is_independent")
 
+CreateConVar("ttt_vampire_convert_enable", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_vampire_convert_enable", "ttt_vampire_convert_enabled")
+
+CreateConVar("ttt_vampire_drain_enable", "1", FCVAR_REPLICATED)
+OldCVarWarning("ttt_vampire_drain_enable", "ttt_vampire_drain_enabled")
+
+CreateConVar("ttt_vampire_vision_enable", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_vampire_vision_enable", "ttt_vampire_vision_enabled")
+
 -- Zombie
 CreateConVar("ttt_zombies_are_monsters", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_zombies_are_monsters", "ttt_zombie_is_monster")
 
 CreateConVar("ttt_zombies_are_traitors", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_zombies_are_traitors", "ttt_zombie_is_traitor")
+
+CreateConVar("ttt_zombie_leap_enable", "1", FCVAR_REPLICATED)
+OldCVarWarning("ttt_zombie_leap_enable", "ttt_zombie_leap_enabled")
+
+CreateConVar("ttt_zombie_spit_enable", "1", FCVAR_REPLICATED)
+OldCVarWarning("ttt_zombie_spit_enable", "ttt_zombie_spit_enabled")
+
+CreateConVar("ttt_zombie_vision_enable", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_zombie_vision_enable", "ttt_zombie_vision_enabled")
+
+-- Death Notifier
+if SERVER then
+    CreateConVar("ttt_death_notifier_enable", "1")
+    OldCVarWarning("ttt_death_notifier_enable", "ttt_death_notifier_enabled")
+end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1731,9 +1731,6 @@ end
 CreateConVar("ttt_traitor_vision_enable", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_traitor_vision_enable", "ttt_traitors_vision_enable")
 
-CreateConVar("ttt_traitor_credits_timer", "0", FCVAR_REPLICATED)
-OldCVarWarning("ttt_traitor_credits_timer", "ttt_traitors_credits_timer")
-
 -- Arsonist
 CreateConVar("ttt_detective_search_only_arsonistdouse", "0", FCVAR_REPLICATED)
 OldCVarWarning("ttt_detective_search_only_arsonistdouse", "ttt_detectives_search_only_arsonistdouse")
@@ -1757,6 +1754,16 @@ OldCVarWarning("ttt_detective_glow_enable", "ttt_detectives_glow_enable")
 if SERVER then
     CreateConVar("ttt_detective_credits_timer", "0")
     OldCVarWarning("ttt_detective_credits_timer", "ttt_detectives_credits_timer")
+end
+
+-- Infected
+CreateConVar("ttt_infected_respawn_enable", "0", FCVAR_REPLICATED)
+OldCVarWarning("ttt_infected_respawn_enable", "ttt_infected_respawn_enabled")
+
+-- Traitor
+if SERVER then
+    CreateConVar("ttt_traitor_credits_timer", "0")
+    OldCVarWarning("ttt_traitor_credits_timer", "ttt_traitors_credits_timer")
 end
 
 -- Vampire


### PR DESCRIPTION
**Additions**
- Added `ttt_beggar_announce_delay` (disabled by default) to allow delaying the announcement of the beggar's role change
- Added tutorial entry for infected's `ttt_infected_prime` convar
- Added tutorial entry for paramedic's defib changing detective-like players roles

**Changes**
- **BREAKING CHANGE** - Renamed `ttt_traitor_credits_timer` to `ttt_traitors_credits_timer`
- **BREAKING CHANGE** - Renamed the following ConVars to change the `_enable` ending to `_enabled` for consistency:
  - ttt_assassin_target_vision_enable -> ttt_assassin_target_vision_enabled
  - ttt_cupid_lover_vision_enable -> ttt_cupid_lover_vision_enabled
  - ttt_death_notifier_enable -> ttt_death_notifier_enabled
  - ttt_detective_glow_enable -> ttt_detective_glow_enabled
  - ttt_hivemind_vision_enable -> ttt_hivemind_vision_enabled
  - ttt_infected_respawn_enable -> ttt_infected_respawn_enabled
  - ttt_killer_vision_enable -> ttt_killer_vision_enabled
  - ttt_madscientist_respawn_enable -> ttt_madscientist_respawn_enabled
  - ttt_vampire_convert_enable -> ttt_vampire_convert_enabled
  - ttt_vampire_drain_enable -> ttt_vampire_drain_enabled
  - ttt_vampire_vision_enable -> ttt_vampire_vision_enabled
  - ttt_zombie_leap_enable -> ttt_zombie_leap_enabled
  - ttt_zombie_spit_enable -> ttt_zombie_spit_enabled
  - ttt_zombie_vision_enable -> ttt_zombie_vision_enabled
- **BREAKING CHANGE** - Changed vampire to use the new `ttt_vampire_credits_award_pct`, `ttt_vampire_credits_award_size`, and `ttt_vampire_credits_award_repeat` convars instead of the traitor ones when the vampire is not a traitor
- **BREAKING CHANGE** - Changed killer to use the new `ttt_killer_credits_award_pct`, `ttt_killer_credits_award_size`, and `ttt_killer_credits_award_repeat` convars instead of the traitor ones

**Fixes**
- Ported "TTT: Prevent error when NPC fires SWEP derived from weapon_tttbase" from base TTT
- Fixed `ttt_monster_max` greater than 1 not working
- Fixed infected player that is in the progress of respawning due dying while `ttt_infected_respawn_enabled` is enabled not counting as zombifying for the purposes of delaying the round end
- Fixed paramedic's defibrillator not changing detective-like roles not on the innocent or traitor teams to be their base role when resurrected

Fixes #523
Closes #524
Closes #525
Closes #527

Depends on https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX/pull/84