### PR TITLE
2.0 Prep

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -705,7 +705,7 @@ ttt_zombie_is_traitor                       0       // Whether zombies should be
 ttt_zombie_round_chance                     0.1     // The chance that a "zombie round" will occur where all players who would have been traitors are made zombies instead. Only usable when "ttt_zombie_is_traitor" is set to "1"
 ttt_zombie_vision_enabled                   0       // Whether zombies have their special vision highlights enabled
 ttt_zombie_spit_enabled                     1       // Whether zombies have their spit attack enabled
-ttt_zombie_spit_convert                     0       // Whether players killed by a spitting Zombie will be converted to a Zombie themselves
+ttt_zombie_spit_convert                     0       // Whether players killed by a spitting Zombie will be converted to be a Zombie themselves
 ttt_zombie_leap_enabled                     1       // Whether zombies have their leap attack enabled
 ttt_zombie_show_target_icon                 0       // Whether zombies have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect
 ttt_zombie_damage_penalty                   0.5     // The fraction a zombie's damage will be scaled by when they are attacking without using their claws. For example, setting this to 0.25 will let the zombie deal 75% of normal gun damage, and 0.66 will let the zombie deal 33% of normal damage

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -705,6 +705,7 @@ ttt_zombie_is_traitor                       0       // Whether zombies should be
 ttt_zombie_round_chance                     0.1     // The chance that a "zombie round" will occur where all players who would have been traitors are made zombies instead. Only usable when "ttt_zombie_is_traitor" is set to "1"
 ttt_zombie_vision_enabled                   0       // Whether zombies have their special vision highlights enabled
 ttt_zombie_spit_enabled                     1       // Whether zombies have their spit attack enabled
+ttt_zombie_spit_convert                     0       // Whether players killed by a spitting Zombie will be converted to a Zombie themselves
 ttt_zombie_leap_enabled                     1       // Whether zombies have their leap attack enabled
 ttt_zombie_show_target_icon                 0       // Whether zombies have an icon over other players' heads showing who to kill. Server or round must be restarted for changes to take effect
 ttt_zombie_damage_penalty                   0.5     // The fraction a zombie's damage will be scaled by when they are attacking without using their claws. For example, setting this to 0.25 will let the zombie deal 75% of normal gun damage, and 0.66 will let the zombie deal 33% of normal damage
@@ -776,6 +777,8 @@ ttt_hivemind_join_heal_pct                  0.25    // The percentage a new memb
 ttt_hivemind_regen_timer                    0       // The amount of time (in seconds) between each health regeneration
 ttt_hivemind_regen_per_member_amt           1       // The amount of health per-member of the hive mind that they should regenerate over time
 ttt_hivemind_regen_max_pct                  0.5     // The percentage of the hive mind's maximum health to heal them up to (e.g. 0.5 = 50% of their max health)
+ttt_hivemind_can_see_jesters                1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the hive mind
+ttt_hivemind_update_scoreboard              1       // Whether the hive mind shows dead players as missing in action
 // ----------------------------------------
 
 // WEAPON SHOP SETTINGS

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0
 **Released:**\
-Includes beta updates [1.8.3](#193-beta) to [1.8.11](#1914-beta).
+Includes beta updates [1.9.3](#193-beta) to [1.9.14](#1914-beta).
 
 ### Fixes
 - Fixed various low-frequency errors by adding sanity checks

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.0.0
+**Released:**\
+Includes beta updates [1.8.3](#193-beta) to [1.8.11](#1914-beta).
+
+### Fixes
+- Fixed various low-frequency errors by adding sanity checks
+
 ## 1.9.14 (Beta)
 **Released: November 11th, 2023**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,9 @@ Includes beta updates [1.9.3](#193-beta) to [1.9.14](#1914-beta).
 - Fixed various low-frequency errors by adding sanity checks
 - Fixed edge case errors when a role changes to independent part-way through the round but doesn't have certain independent-only convars created
 
+### Developer
+- Removed bot SteamID64 client-side shims now that the client-side values match the server-side
+
 ## 1.9.14 (Beta)
 **Released: November 11th, 2023**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,9 @@
 **Released:**\
 Includes beta updates [1.9.3](#193-beta) to [1.9.14](#1914-beta).
 
+### Changes
+- Changed hive mind to be able to see jesters and that players are missing-in-action on the scoreboard by default
+
 ### Fixes
 - Fixed various low-frequency errors by adding sanity checks
 - Fixed edge case errors when a role changes to independent part-way through the round but doesn't have certain independent-only convars created

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@ Includes beta updates [1.8.3](#193-beta) to [1.8.11](#1914-beta).
 
 ### Fixes
 - Fixed various low-frequency errors by adding sanity checks
+- Fixed edge case errors when a role changes to independent part-way through the round but doesn't have certain independent-only convars created
 
 ## 1.9.14 (Beta)
 **Released: November 11th, 2023**

--- a/docs/js/shared.js
+++ b/docs/js/shared.js
@@ -29,8 +29,7 @@ window.onload = openAnchor();
 
 var coll = document.getElementsByClassName("collapsible");
 for (var i = 0; i < coll.length; i++) {
-    coll[i].addEventListener("click", function(event)
-    {
+    coll[i].addEventListener("click", function(event) {
         var targetTag = event.target.tagName;
         if (targetTag == "DIV" || targetTag == "BUTTON") {
             expandContent(this);

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -1015,7 +1015,7 @@
                             <td>ttt_zombie_spit_convert</td>
                             <td>0</td>
                             <td>Boolean</td>
-                            <td>Whether players killed by a spitting Zombie will be converted to a Zombie themselves.</td>
+                            <td>Whether players killed by a spitting Zombie will be converted to be a Zombie themselves.</td>
                         </tr>
                         <tr>
                             <td>ttt_zombie_thrall_attack_damage</td>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -344,6 +344,12 @@
                         </thead>
                         <tbody>
                         <tr>
+                            <td>ttt_hivemind_can_see_jesters</td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether jesters are revealed (via overhead icons, color/icon on the scoreboard, etc.) to the Hive Mind.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_hivemind_friendly_fire</td>
                             <td>0</td>
                             <td>Boolean</td>
@@ -392,6 +398,12 @@
                                     <li>(Traitor) All weapons available to the Traitor.</li>
                                 </ol>
                             </td>
+                        </tr>
+                        <tr>
+                            <td>ttt_hivemind_update_scoreboard</td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether the Hive Mind shows dead players as missing in action.</td>
                         </tr>
                         <tr>
                             <td>ttt_hivemind_vision_enabled</td>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -1012,6 +1012,12 @@
                             <td>Whether Zombies have their spit attack enabled.</td>
                         </tr>
                         <tr>
+                            <td>ttt_zombie_spit_convert</td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether players killed by a spitting Zombie will be converted to a Zombie themselves.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_zombie_thrall_attack_damage</td>
                             <td>45</td>
                             <td>Integer</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zom_claws.lua
@@ -82,6 +82,11 @@ end
 function SWEP:SetWeaponHoldType(t)
     self.BaseClass.SetWeaponHoldType(self, t)
 
+    -- Sanity check, this should have been set up by the BaseClass.SetWeaponHoldType call above
+    if not self.ActivityTranslate then
+        self.ActivityTranslate = {}
+    end
+
     self.ActivityTranslate[ACT_MP_STAND_IDLE]                  = ACT_HL2MP_IDLE_ZOMBIE
     self.ActivityTranslate[ACT_MP_WALK]                        = ACT_HL2MP_WALK_ZOMBIE_01
     self.ActivityTranslate[ACT_MP_RUN]                         = ACT_HL2MP_RUN_ZOMBIE

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -101,23 +101,6 @@ function CLSCORE:AddEvent(e, offset)
     table.insert(customEvents, e)
 end
 
-local function GetPlayerFromSteam64(id)
-    -- The first bot's ID is 90071996842377216 which translates to "STEAM_0:0:0", an 11-character string
-    -- At some point it becomes double digits at the end (e.g. "STEAM_0:0:10") so we check for 12 or fewer characters
-    -- A player's Steam ID cannot be that short, so if it is this must be a bot
-    local isBot = #util.SteamIDFrom64(id) <= 12
-    -- Bots cannot be retrieved by SteamID on the client so search by name instead
-    if isBot then
-        for _, p in pairs(player.GetAll()) do
-            if p:Nick() == CLSCORE.Players[id] then
-                return p
-            end
-        end
-    else
-        return player.GetBySteamID64(id)
-    end
-end
-
 local function FitNicknameLabel(nicklbl, maxwidth, getstring, args)
     local nickw, _ = nicklbl:GetSize()
     while nickw > maxwidth do
@@ -176,7 +159,7 @@ end)
 net.Receive("TTT_RoleChanged", function(len)
     local s64 = net.ReadString()
     local role = net.ReadInt(8)
-    local ply = GetPlayerFromSteam64(s64)
+    local ply = player.GetBySteamID64(s64)
     local name = "UNKNOWN"
     if IsValid(ply) then
         name = ply:Nick()
@@ -545,7 +528,7 @@ function CLSCORE:BuildSummaryPanel(dpanel)
             end
 
             if foundPlayer then
-                local ply = GetPlayerFromSteam64(id)
+                local ply = player.GetBySteamID64(id)
 
                 -- Backup in case people disconnect and we cant check their role at the end of the round
                 local startingRole = s.role
@@ -948,7 +931,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
     local playerInfo = {}
     for id, nick in pairs(self.Players) do
         local role = self.Roles[GetRoleId(id)]
-        local ply = GetPlayerFromSteam64(id)
+        local ply = player.GetBySteamID64(id)
         -- If the player disconnected, use their starting role
         if IsValid(ply) then
             role = ply:GetRole()

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -236,7 +236,7 @@ function GM:PostDrawTranslucentRenderables()
                         noz = true
                     end
                 elseif client:IsIndependentTeam() then
-                    if showJester and GetConVar("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters"):GetBool() then
+                    if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
                         role = ROLE_NONE
                         color_role = ROLE_JESTER
                     end
@@ -479,7 +479,7 @@ function GM:HUDDrawTargetID()
                     target_monster = ent:GetRole()
                 end
             elseif client:IsIndependentTeam() then
-                if showJester and GetConVar("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters"):GetBool() then
+                if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
                     target_jester = showJester
                 end
             end

--- a/gamemodes/terrortown/gamemode/player.lua
+++ b/gamemodes/terrortown/gamemode/player.lua
@@ -46,15 +46,10 @@ function GM:PlayerInitialSpawn(ply)
         SendAllLists(ply)
     end
 
-
-    if ply:IsBot() then
-        ply:SetNWString("BotSteamID64", ply:SteamID64())
-
-        -- Handle spec bots
-        if GetConVar("ttt_bots_are_spectators"):GetBool() then
-            ply:SetTeam(TEAM_SPEC)
-            ply:SetForceSpec(true)
-        end
+    -- Handle spec bots
+    if ply:IsBot() and GetConVar("ttt_bots_are_spectators"):GetBool() then
+        ply:SetTeam(TEAM_SPEC)
+        ply:SetForceSpec(true)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -28,17 +28,6 @@ function plymeta:SetupDataTables()
     self:NetworkVar("Float", 0, "SprintStamina")
 end
 
-if CLIENT then
-    local oldSteamID64 = plymeta.SteamID64
-    function plymeta:SteamID64()
-        if self:IsBot() then
-            return self:GetNWString("BotSteamID64", "90071996842377216") -- 90071996842377216 is the first SteamID64 used by bots
-        else
-            return oldSteamID64(self)
-        end
-    end
-end
-
 AccessorFunc(plymeta, "role", "Role", FORCE_NUMBER)
 
 local oldSetRole = plymeta.SetRole
@@ -643,21 +632,6 @@ else
                 table.Empty(self.DeathRoleWeapons)
             end
         end)
-    end
-end
-
-if CLIENT then
-    local oldGetBySteamID64 = player.GetBySteamID64
-    function player.GetBySteamID64(sid64)
-        local minSID64 = "90071996842377216" -- 90071996842377216 is the first SteamID64 used by bots
-        if sid64 >= minSID64 then -- We compare using strings instead of numbers here because these numbers are so large that lua's arithmetic is inaccurate
-            for _, v in pairs(player.GetBots()) do
-                local botSID64 = v:GetNWString("BotSteamID64", "90071996842377216")
-                if botSID64 == sid64 then return v end
-            end
-        else
-            return oldGetBySteamID64(sid64)
-        end
     end
 end
 

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -183,7 +183,7 @@ function plymeta:ShouldHideJesters()
     elseif self:IsMonsterTeam() then
         return not GetConVar("ttt_jesters_visible_to_monsters"):GetBool()
     elseif self:IsIndependentTeam() then
-        return not GetConVar("ttt_" .. ROLE_STRINGS_RAW[self:GetRole()] .. "_can_see_jesters"):GetBool()
+        return not cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[self:GetRole()] .. "_can_see_jesters", false)
     end
     return true
 end

--- a/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
@@ -44,7 +44,7 @@ function plymeta:ShouldRevealBeggar(tgt)
     local traitorTeam = self:IsTraitorTeam() and (beggarMode == BEGGAR_REVEAL_TRAITORS or beggarMode == BEGGAR_REVEAL_ROLES_THAT_CAN_SEE_JESTER)
     local innocentTeam = self:IsInnocentTeam() and beggarMode == BEGGAR_REVEAL_INNOCENTS
     local monsterTeam = self:IsMonsterTeam() and beggarMode == BEGGAR_REVEAL_ROLES_THAT_CAN_SEE_JESTER
-    local indepTeam = self:IsIndependentTeam() and beggarMode == BEGGAR_REVEAL_ROLES_THAT_CAN_SEE_JESTER and GetConVar("ttt_" .. ROLE_STRINGS_RAW[self:GetRole()] .. "_can_see_jesters"):GetBool()
+    local indepTeam = self:IsIndependentTeam() and beggarMode == BEGGAR_REVEAL_ROLES_THAT_CAN_SEE_JESTER and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[self:GetRole()] .. "_can_see_jesters", false)
 
     -- Check the setting value and whether the client's team matches the reveal mode
     return beggarMode == BEGGAR_REVEAL_ALL or traitorTeam or innocentTeam or monsterTeam or indepTeam

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
@@ -28,7 +28,7 @@ function plymeta:ShouldRevealBodysnatcher(tgt)
     local sameTeam = self:IsSameTeam(tgt) and bodysnatcherMode == BODYSNATCHER_REVEAL_TEAM
     local traitorTeam = self:IsTraitorTeam() and bodysnatcherMode == BODYSNATCHER_REVEAL_ROLES_THAT_CAN_SEE_JESTER
     local monsterTeam = self:IsMonsterTeam() and bodysnatcherMode == BODYSNATCHER_REVEAL_ROLES_THAT_CAN_SEE_JESTER
-    local indepTeam = self:IsIndependentTeam() and bodysnatcherMode == BODYSNATCHER_REVEAL_ROLES_THAT_CAN_SEE_JESTER and GetConVar("ttt_" .. ROLE_STRINGS_RAW[self:GetRole()] .. "_can_see_jesters"):GetBool()
+    local indepTeam = self:IsIndependentTeam() and bodysnatcherMode == BODYSNATCHER_REVEAL_ROLES_THAT_CAN_SEE_JESTER and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[self:GetRole()] .. "_can_see_jesters", false)
 
     -- Check the setting value and whether the player and the target are the same team or a member of a team that can see jesters
     return bodysnatcherMode == BODYSNATCHER_REVEAL_ALL or sameTeam or traitorTeam or monsterTeam or indepTeam

--- a/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
@@ -58,6 +58,9 @@ table.insert(ROLE_CONVARS[ROLE_HIVEMIND], {
 -- ROLE FEATURES --
 -------------------
 
+ROLE_CAN_SEE_JESTERS[ROLE_HIVEMIND] = true
+ROLE_CAN_SEE_MIA[ROLE_HIVEMIND] = true
+
 ROLE_VICTIM_CHANGING_ROLE[ROLE_HIVEMIND] = function(ply, victim)
     return not victim:IsHiveMind()
 end

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -22,7 +22,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "1.9.14"
+CR_VERSION = "2.0.0"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -103,7 +103,7 @@ function ScoreGroup(p)
                 -- To terrorists, missing players show as alive
                 if client:IsSpec() or
                         client:IsActiveTraitorTeam() or client:IsActiveMonsterTeam() or
-                        (client:IsActiveIndependentTeam() and GetConVar("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_update_scoreboard"):GetBool()) or
+                        (client:IsActiveIndependentTeam() and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_update_scoreboard", false)) or
                         ((GAMEMODE.round_state ~= ROUND_ACTIVE) and client:IsTerror()) then
                     return GROUP_NOTFOUND
                 else

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -291,10 +291,12 @@ function PANEL:Paint(width, height)
     if new_color then c = new_color end
     if new_role_str then roleStr = new_role_str end
 
-    surface.SetDrawColor(c)
+    if c then
+        surface.SetDrawColor(c)
+    end
     surface.DrawRect(0, 0, width, SB_ROW_HEIGHT)
 
-    if ROLE_TAB_ICON_MATERIALS[roleStr] then
+    if roleStr and ROLE_TAB_ICON_MATERIALS[roleStr] then
         self.sresult:SetMaterial(ROLE_TAB_ICON_MATERIALS[roleStr])
         self.sresult:SetVisible(true)
     else

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -179,7 +179,7 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
             end
         end
     elseif client:IsIndependentTeam() then
-        if showJester and GetConVar("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters"):GetBool() then
+        if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
             return ROLE_JESTER
         end
     elseif client:IsMonsterTeam() then


### PR DESCRIPTION
**Changes**
- Changed hive mind to be able to see jesters and that players are missing-in-action on the scoreboard by default

**Fixes**
- Fixed various low-frequency errors by adding sanity checks
- Fixed edge case errors when a role changes to independent part-way through the round but doesn't have certain independent-only convars created

**Developer**
- Removed bot SteamID64 client-side shims now that the client-side values match the server-side