### PR TITLE
Adds `req` Property to Weapons/Equipment

### DIFF
--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -418,6 +418,8 @@ local function PreqLabels(parent, x, y)
     tbl.bought.Check = function(s, sel)
         if sel.limited and LocalPlayer():HasBought(tostring(sel.id)) then
             return false, "X", GetTranslation("equip_stock_deny")
+        elseif sel.req and not WEPS.PlayerOwnsWepReqs(LocalPlayer(), sel) then
+            return false, "X", GetTranslation("equip_req_deny")
         else
             return true, "✔", GetTranslation("equip_stock_ok")
         end
@@ -667,7 +669,8 @@ local function TraitorMenuPopup()
                     -- already carrying a weapon for this slot
                     (ItemIsWeapon(item) and (not CanCarryWeapon(item))) or
                     -- already bought the item before
-                    (item.limited and ply:HasBought(tostring(item.id)))
+                    (item.limited and ply:HasBought(tostring(item.id))) or
+                    not WEPS.PlayerOwnsWepReqs(ply, item)
         end
 
         local function FillEquipmentList(itemlist)

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -670,6 +670,7 @@ local function TraitorMenuPopup()
                     (ItemIsWeapon(item) and (not CanCarryWeapon(item))) or
                     -- already bought the item before
                     (item.limited and ply:HasBought(tostring(item.id))) or
+                    -- doesn't have the required items
                     not WEPS.PlayerOwnsWepReqs(ply, item)
         end
 

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -91,6 +91,7 @@ L.equip_carry_slot = "You are already carrying a weapon in slot {slot}."
 
 L.equip_help_stock = "Of certain items you can only buy one per round."
 L.equip_stock_deny = "This item is no longer in stock."
+L.equip_req_deny = "Another item must be purchased before this becomes available."
 L.equip_stock_ok = "This item is in stock."
 
 L.equip_custom = "Custom item added by this server."

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -91,7 +91,7 @@ L.equip_carry_slot = "You are already carrying a weapon in slot {slot}."
 
 L.equip_help_stock = "Of certain items you can only buy one per round."
 L.equip_stock_deny = "This item is no longer in stock."
-L.equip_req_deny = "Another item must be purchased before this becomes available."
+L.equip_stock_req_deny  = "Another item must be purchased before this becomes available."
 L.equip_stock_ok = "This item is in stock."
 
 L.equip_custom = "Custom item added by this server."

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -543,6 +543,14 @@ local function OrderEquipment(ply, cmd, args)
             end
         end
 
+        -- Check if the item needs another purchased before it can be
+        if allowed then
+            if not WEPS.PlayerOwnsWepReqs(ply, allowed.req) then
+                print(ply, "tried to buy item requiring another item they don't own", id)
+                return 
+            end
+        end
+
         if not allowed then
             print(ply, "tried to buy item not buyable for their role:", id)
             return

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -545,9 +545,9 @@ local function OrderEquipment(ply, cmd, args)
 
         -- Check if the item needs another purchased before it can be
         if allowed then
-            if not WEPS.PlayerOwnsWepReqs(ply, allowed.req) then
+            if not WEPS.PlayerOwnsWepReqs(ply, allowed) then
                 print(ply, "tried to buy item requiring another item they don't own", id)
-                return 
+                return
             end
         end
 

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -124,6 +124,53 @@ function WEPS.ResetRoleWeaponCache()
     end
 end
 
+local function PlayerOwnsWepOrItem(ply, classOrId)
+    if isstring(classOrId) then
+        for _, wep in ipairs(ply:GetWeapons()) do
+            if wep:GetClass() == classOrId then
+                return true
+            end
+        end
+
+        return false
+    else
+        return ply:HasEquipmentItem(classOrId)
+    end
+end
+
+-- ply should be a valid player ent, wep should be either a valid ent class name or valid item ID
+function WEPS.PlayerOwnsWepReqs(ply, wep)
+    local role = ply:GetRole()
+    local tab = nil
+
+    if isnumber(wep) then
+        tab = GetEquipmentItem(role, wep)
+    elseif istable(wep) then
+        tab = wep
+    else
+        tab = weapons.GetStored(wep)
+    end
+
+    if tab and tab.req then
+        local requisiteItems = tab.req
+
+        if istable(requisiteItems) then
+            for _, classOrId in ipairs(requisiteItems) do
+                if not PlayerOwnsWepOrItem(ply, classOrId) then
+                    return false
+                end
+            end
+
+            return true
+        else
+            return PlayerOwnsWepOrItem(ply, requisiteItems)
+        end
+    end
+
+    -- If no requisite items provided, return true
+    return true
+end
+
 -- Useful for allowing roles to have a shop only if weapons are assigned to them
 function WEPS.DoesRoleHaveWeapon(role, promoted)
     WEPS.PrepWeaponsLists(role)

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -127,7 +127,7 @@ end
 local function PlayerOwnsWepOrItem(ply, classOrId)
     if isstring(classOrId) then
         for _, wep in ipairs(ply:GetWeapons()) do
-            if wep:GetClass() == classOrId then
+            if WEPS.GetClass(wep) == classOrId then
                 return true
             end
         end

--- a/gamemodes/terrortown/gamemode/weaponry_shd.lua
+++ b/gamemodes/terrortown/gamemode/weaponry_shd.lua
@@ -133,18 +133,17 @@ local function PlayerOwnsWepOrItem(ply, classOrId)
         end
 
         return false
-    else
-        return ply:HasEquipmentItem(classOrId)
     end
+
+    return ply:HasEquipmentItem(classOrId)
 end
 
 -- ply should be a valid player ent, wep should be either a valid ent class name or valid item ID
 function WEPS.PlayerOwnsWepReqs(ply, wep)
-    local role = ply:GetRole()
-    local tab = nil
+    local tab
 
     if isnumber(wep) then
-        tab = GetEquipmentItem(role, wep)
+        tab = GetEquipmentItem(ply:GetRole(), wep)
     elseif istable(wep) then
         tab = wep
     else
@@ -162,9 +161,9 @@ function WEPS.PlayerOwnsWepReqs(ply, wep)
             end
 
             return true
-        else
-            return PlayerOwnsWepOrItem(ply, requisiteItems)
         end
+
+        return PlayerOwnsWepOrItem(ply, requisiteItems)
     end
 
     -- If no requisite items provided, return true


### PR DESCRIPTION
## Changelog
- Weapons or Equipment can add a "req" property to disable purchasing of the weapon/equipment until another item has been purchased (does not say which item, ideally the name of the weapon/equipment is enough of a giveaway, i.e. `Something` and `Something V2` or `Something Upgrade`)
- Property should be scoped to both client and server
- `req` can be provided as an EquipmentID(), class name, or table containing both
- Explanation message is provided in the English lang file
- Property is optional, weapons/equipment without property are entirely unaffected
- Update does not check if required equipment does not exist

## Affected Issues
- None

## Checklist
- [x] Tested in-game
- [ ] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
