### PR TITLE
2.0.4 Hotfix

### DIFF
--- a/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
@@ -25,6 +25,8 @@ local hivemind_regen_max_pct = GetConVar("ttt_hivemind_regen_max_pct")
 ----------------------
 
 AddHook("PlayerSay", "HiveMind_PlayerSay", function(ply, text, team_only)
+    if not IsPlayer(ply) then return end
+    if not ply:IsHiveMind() then return end
     if team_only then return end
 
     net.Start("TTT_HiveMindChatDupe")


### PR DESCRIPTION
## Changelog
- Fixed any player using text chat with a hive mind in the round causing the hive mind to repeat their message
- Fixed player role and name not revealed to non-detectives in the body search dialog after a detective searches body with certain convars enabled

## Affected Issues

## Checklist
- [x] Tested in-game
- [ ] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
