### PR TITLE
Misc. fixes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1134,7 +1134,14 @@ globals = {
     "DEATHRADAR",
 
     -- Randomat Namespaces
-    "Randomat"
+    "Randomat",
+
+    -- Scripts
+    "EQUIP_DOUBLETAP",
+    "EQUIP_JUGGERNOG",
+    "EQUIP_PHD",
+    "EQUIP_SPEEDCOLA",
+    "EQUIP_STAMINUP"
 }
 std = {
     globals = {

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -7,6 +7,16 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 ***NOTE:*** Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the *remaining hook instances to be completely skipped*. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.
 
+### TTTBodyCreditsLooted(ply, deadPly, rag, credits)
+Called when a player loots credits off of a dead player's body.\
+*Realm:* Server\
+*Added in:* 2.1.3\
+*Parameters:*
+- *ply* - The player who is looting credits
+- *deadPly* - The dead player whose corpse was looted
+- *rag* - The corpse that was looted
+- *credits* - The number of credits looted
+
 ### TTTBodySearchButtons(ply, rag, buttons, searchRaw, detectiveSearchOnly)
 Called when a player opens the body search dialog. Used to add new buttons to the dialog.\
 *Realm:* Client\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,10 @@
 
 ### Fixes
 - Fixed minor typo in vindicator event log entry
+- Fixed hive mind all having the same number of credits on their body, allowing their killer to loot many times the credits they should have gotten
+
+### Developer
+- Added `TTTBodyCreditsLooted` hook that is called when a player looks credits from a body
 
 ## 2.1.2 (Beta)
 **Released: February 17th, 2024**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.1.3 (Beta)
+**Released:**
+
+### Fixes
+- Fixed minor typo in vindicator event log entry
+
 ## 2.1.2 (Beta)
 **Released: February 17th, 2024**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 - Fixed hive mind all having the same number of credits on their body, allowing their killer to loot many times the credits they should have gotten
 
 ### Developer
-- Added `TTTBodyCreditsLooted` hook that is called when a player looks credits from a body
+- Added `TTTBodyCreditsLooted` hook that is called when a player loots credits from a body
 
 ## 2.1.2 (Beta)
 **Released: February 17th, 2024**

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,7 +20,7 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
-        <h3><a id="tttbodycreditslootedply-deadPly-rag-credits" href="#tttbodycreditslootedply-deadPly-rag-credits">TTTBodyCreditsLooted(ply, deadPly, rag, credits)</a></h3>
+        <h3><a id="tttbodycreditslootedply-deadPly-rag-credits" href="#tttbodycreditslootedply-deadPly-rag-credits">TTTBodyCreditsLooted(ply, deadPly, rag, credits)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
         <p>
             Called when a player loots credits off of a dead player's body.<br>
             <em>Realm:</em> Server<br>

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,6 +20,20 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
+        <h3><a id="tttbodycreditslootedply-deadPly-rag-credits" href="#tttbodycreditslootedply-deadPly-rag-credits">TTTBodyCreditsLooted(ply, deadPly, rag, credits)</a></h3>
+        <p>
+            Called when a player loots credits off of a dead player's body.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 2.1.3<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The player who is looting credits</li>
+            <li><em>deadPly</em> - The dead player whose corpse was looted</li>
+            <li><em>rag</em> - The corpse that was looted</li>
+            <li><em>credits</em> - The number of credits looted</li>
+        </ul>
+
         <h3><a id="tttbodysearchbuttonsply-rag-buttons-searchraw-detectivesearchonly" href="#tttbodysearchbuttonsply-rag-buttons-searchraw-detectivesearchonly">TTTBodySearchButtons(ply, rag, buttons, searchRaw, detectiveSearchOnly)</a></h3>
         <p>
             Called when a player opens the body search dialog. Used to add new buttons to the dialog.<br>
@@ -31,12 +45,12 @@
             <li><em>ply</em> - The player who is opening the body search dialog</li>
             <li><em>rag</em> - The <code>prop_ragdoll</code> representing a player's body being searched</li>
             <li><em>buttons</em> - The table of buttons being rendered on the body search dialog. Insert a new descriptive object into this table to add a button to the window. The possible descriptive object properties are:
-        <ul>
-            <li><em>text</em> - The text to show on the button</li>
-            <li><em>onclick</em> - The function to call when the button is clicked. The only parameter passed to this function is the <a href="https://wiki.facepunch.com/gmod/DButton" target="_blank">DButton</a> instance.</li>
-            <li><em>disabled</em> - A boolean or function which returns a boolean used to determine whether this button should be clickable. Defaults to <code>true</code> if not provided.</li>
-        </ul>
-        </li>
+            <ul>
+                <li><em>text</em> - The text to show on the button</li>
+                <li><em>onclick</em> - The function to call when the button is clicked. The only parameter passed to this function is the <a href="https://wiki.facepunch.com/gmod/DButton" target="_blank">DButton</a> instance.</li>
+                <li><em>disabled</em> - A boolean or function which returns a boolean used to determine whether this button should be clickable. Defaults to <code>true</code> if not provided.</li>
+            </ul>
+            </li>
             <li><em>searchRaw</em> - The raw search data</li>
             <li><em>detectiveSearchOnly</em> - Whether only detectives should be able to search bodies</li>
         </ul>

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -349,6 +349,7 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
         CORPSE.SetCredits(rag, 0)
         ServerLog(ply:Nick() .. " took " .. credits .. " credits from the body of " .. nick .. "\n")
         SCORE:HandleCreditFound(ply, nick, credits)
+        hook.Call("TTTBodyCreditsLooted", GAMEMODE, ply, ownerEnt, rag, credits)
         return
     elseif DetectiveMode() then
         if CORPSE.CanBeSearched(ply, rag) then

--- a/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
@@ -94,6 +94,20 @@ AddHook("TTTPlayerRoleChanged", "HiveMind_CreditsSync_TTTPlayerRoleChanged", fun
     HandleCreditsSync(ply:GetCredits())
 end)
 
+AddHook("TTTBodyCreditsLooted", "HiveMind_CreditsSync_TTTBodyCreditsLooted", function(ply, deadPly, rag, credits)
+    if not IsPlayer(deadPly) or not deadPly:IsHiveMind() then return end
+
+    -- Find all corpses that being to hive minds and remove their credits
+    for _, p in ipairs(GetAllPlayers()) do
+        if not p:IsHiveMind() then continue end
+        p:SetCredits(0)
+        local p_rag = p.server_ragdoll or p:GetRagdollEntity()
+        if IsValid(p_rag) then
+            CORPSE.SetCredits(p_rag, 0)
+        end
+    end
+end)
+
 -------------------
 -- SHARED HEALTH --
 -------------------

--- a/gamemodes/terrortown/gamemode/roles/vindicator/cl_vindicator.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/cl_vindicator.lua
@@ -192,7 +192,7 @@ end)
 
 hook.Add("TTTEventFinishText", "Vindicator_TTTEventFinishText", function(e)
     if e.win == WIN_VINDICATOR then
-        return LANG.GetTranslation("ev_win_vindicator")
+        return LANG.GetParamTranslation("ev_win_vindicator", { role = string.lower(ROLE_STRINGS[ROLE_VINDICATOR]) })
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -23,7 +23,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.2"
+CR_VERSION = "2.1.3"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/scripts/perkfix.lua
+++ b/scripts/perkfix.lua
@@ -1,0 +1,34 @@
+if engine.ActiveGamemode() ~= "terrortown" then return end
+
+AddCSLuaFile()
+
+if not CLIENT then return end
+
+print("[PERKFIX] Loading...")
+
+local function ApplyFixes()
+    print("[PERKFIX] Applying fixes...")
+
+    hook.Add("TTTBodySearchEquipment", "DoubleTapCorpseIcon", function(search, eq)
+        search.eq_doubletap = table.HasValue(eq, EQUIP_DOUBLETAP)
+    end)
+
+    hook.Add("TTTBodySearchEquipment", "JuggernogCorpseIcon", function(search, eq)
+        search.eq_juggernog = table.HasValue(eq, EQUIP_JUGGERNOG)
+    end)
+
+    hook.Add("TTTBodySearchEquipment", "PHDCorpseIcon", function(search, eq)
+        search.eq_phd = table.HasValue(eq, EQUIP_PHD)
+    end)
+
+    hook.Add("TTTBodySearchEquipment", "SpeedColaCorpseIcon", function(search, eq)
+        search.eq_speedcola = table.HasValue(eq, EQUIP_SPEEDCOLA)
+    end)
+
+    hook.Add("TTTBodySearchEquipment", "StaminupCorpseIcon", function(search, eq)
+        search.eq_staminup = table.HasValue(eq, EQUIP_STAMINUP)
+    end)
+end
+
+hook.Add("TTTPrepareRound", "PerkFixHooks_Prepare", ApplyFixes)
+hook.Add("Initialize", "PerkFixHooks_Initialize", ApplyFixes)


### PR DESCRIPTION
## Changelog
### Fixes
- Fixed minor typo in vindicator event log entry
- Fixed hive mind all having the same number of credits on their body, allowing their killer to loot many times the credits they should have gotten

### Developer
- Added `TTTBodyCreditsLooted` hook that is called when a player loots credits from a body

## Affected Issues
#611

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
