### PR TITLE
Misc. changes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -793,6 +793,10 @@ ttt_arsonist_douse_notify_delay_min         10      // The minimum delay before 
 ttt_arsonist_douse_notify_delay_max         30      // The maximum delay before a player is notified they've been doused
 ttt_arsonist_early_ignite                   0       // Whether to allow the arsonist to use their igniter without dousing everyone first
 ttt_arsonist_corpse_ignite_time             10      // The amount of time (in seconds) to ignite doused dead player corpses for before destroying them
+ttt_arsonist_douse_float_time               1       // The amount of time (in seconds) it takes for the Arsonist to lose their target without after getting out of range
+ttt_arsonist_douse_cooldown                 3       // The amount of time (in seconds) the Arsonist's douse goes on cooldown for after they lose their target
+ttt_arsonist_douse_corpses                  1       // Whether the Arsonist can douse corpses of dead player's to destroy their bodies
+ttt_arsonist_douse_require_los              1       // Whether the Arsonist requires line of sight with their target in order to douse them
 ttt_arsonist_can_see_jesters                1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the arsonist
 ttt_arsonist_update_scoreboard              1       // Whether the arsonist shows dead players as missing in action
 ttt_detectives_search_only_arsonistdouse    0       // Whether only detectives can see information about whether a corpse was doused by an arsonist and when. Once a detective searches a body, this information will be available to all players. Ignored when "ttt_detectives_search_only" is enabled.

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -793,7 +793,7 @@ ttt_arsonist_douse_notify_delay_min         10      // The minimum delay before 
 ttt_arsonist_douse_notify_delay_max         30      // The maximum delay before a player is notified they've been doused
 ttt_arsonist_early_ignite                   0       // Whether to allow the arsonist to use their igniter without dousing everyone first
 ttt_arsonist_corpse_ignite_time             10      // The amount of time (in seconds) to ignite doused dead player corpses for before destroying them
-ttt_arsonist_douse_float_time               1       // The amount of time (in seconds) it takes for the Arsonist to lose their target without after getting out of range
+ttt_arsonist_douse_float_time               1       // The amount of time (in seconds) it takes for the Arsonist to lose their target after getting out of range
 ttt_arsonist_douse_cooldown                 3       // The amount of time (in seconds) the Arsonist's douse goes on cooldown for after they lose their target
 ttt_arsonist_douse_corpses                  1       // Whether the Arsonist can douse corpses of dead players to destroy their bodies
 ttt_arsonist_douse_require_los              1       // Whether the Arsonist requires line of sight with their target in order to douse them

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -795,7 +795,7 @@ ttt_arsonist_early_ignite                   0       // Whether to allow the arso
 ttt_arsonist_corpse_ignite_time             10      // The amount of time (in seconds) to ignite doused dead player corpses for before destroying them
 ttt_arsonist_douse_float_time               1       // The amount of time (in seconds) it takes for the Arsonist to lose their target without after getting out of range
 ttt_arsonist_douse_cooldown                 3       // The amount of time (in seconds) the Arsonist's douse goes on cooldown for after they lose their target
-ttt_arsonist_douse_corpses                  1       // Whether the Arsonist can douse corpses of dead player's to destroy their bodies
+ttt_arsonist_douse_corpses                  1       // Whether the Arsonist can douse corpses of dead players to destroy their bodies
 ttt_arsonist_douse_require_los              1       // Whether the Arsonist requires line of sight with their target in order to douse them
 ttt_arsonist_can_see_jesters                1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the arsonist
 ttt_arsonist_update_scoreboard              1       // Whether the arsonist shows dead players as missing in action

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -1049,6 +1049,7 @@ ttt_dna_scan_on_dialog                      1       // Whether to show a button 
 ttt_spectator_corpse_search                 1       // Whether spectators can search bodies (not shared with other players)
 ttt_corpse_search_not_shared                0       // Whether corpse searches are not shared with other players (only affects non-detective-like searchers)
 ttt_color_mode_override                     "none"  // Forces all players to have a certain role color setting. none (let user decide), default, simple, protan, deutan, tritan
+ttt_spectators_see_roles                    0       // Whether spectators (not dead players) should be able to see the roles of all players
 ```
 
 Thanks to [KarlOfDuty](https://github.com/KarlOfDuty) for their original version of this document, [here](https://github.com/KarlOfDuty/TTT-Custom-Roles/blob/patch-1/README.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.1.3 (Beta)
+**Released:**
+
+## Additions
+- Added option for spectators (not dead players) to be able to see the roles of all players
+
 ## 2.1.2 (Beta)
 **Released: February 17th, 2024**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,11 @@
 **Released:**
 
 ## Additions
-- Added option for spectators (not dead players) to be able to see the roles of all players
+- Added an option to require the Arsonist to have line of sight with their target to douse them (enabled by default)
+- Added an option to prevent the Arsonist from being able to douse corpses (disabled by default)
+- Added an option for the Arsonist to have a brief window of time after leaving range or losing line of sight of their target before dousing is cancelled (1 second by default)
+- Added an option to change the amount of time after an Arsonist fails to douse a target before they can start dousing again (3 seconds by default)
+- Added option for spectators (not dead players) to be able to see the roles of all players (disabled by default)
 
 ## 2.1.2 (Beta)
 **Released: February 17th, 2024**

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -328,7 +328,7 @@ h1 > #betalabel {
     position: relative;
 }
 
-.betaonly {
+.betaicon {
     background-image: url("../img/beta.svg");
     width: 16px;
     height: 16px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
     <script type="text/javascript" src="js/shared.js" defer></script>
     <script src="https://kit.fontawesome.com/ac21f50553.js" crossorigin="anonymous"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
     <button onclick="backToTop()" id="totop">Back to Top</button>

--- a/docs/js/shared.js
+++ b/docs/js/shared.js
@@ -109,7 +109,7 @@ if (betalabel) {
 }
 
 // Remove the betaonly elements if we're not on beta
-// betaonly looks like this:
+// beta only icons looks like this:
 //   <span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span>
 window.addEventListener("DOMContentLoaded", function() {
     if (isOnBeta()) return;

--- a/docs/js/shared.js
+++ b/docs/js/shared.js
@@ -110,7 +110,7 @@ if (betalabel) {
 
 // Remove the betaonly elements if we're not on beta
 // beta only icons looks like this:
-//   <span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span>
+//   <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span>
 window.addEventListener("DOMContentLoaded", function() {
     if (isOnBeta()) return;
 

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -179,7 +179,7 @@
                             <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_arsonist_douse_float_time</td>
                             <td>1</td>
                             <td>Integer</td>
-                            <td>The amount of time (in seconds) it takes for the Arsonist to lose their target without after getting out of range.</td>
+                            <td>The amount of time (in seconds) it takes for the Arsonist to lose their target after getting out of range.</td>
                         </tr>
                         <tr>
                             <td>ttt_arsonist_douse_notify_delay_max</td>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -151,8 +151,8 @@
                             <td>Boolean</td>
                             <td>Whether jesters are revealed (via overhead icons, color/icon on the scoreboard, etc.) to the Arsonist.</td>
                         </tr>
-                        <tr>
-                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_cooldown</td>
+                        <tr class="betaonly">
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_arsonist_douse_cooldown</td>
                             <td>3</td>
                             <td>Integer</td>
                             <td>The amount of time (in seconds) the Arsonist's douse goes on cooldown for after they lose their target.</td>
@@ -163,8 +163,8 @@
                             <td>Integer</td>
                             <td>The amount of time in seconds to ignite doused dead player corpses for before destroying them.</td>
                         </tr>
-                        <tr>
-                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_corpses</td>
+                        <tr class="betaonly">
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_arsonist_douse_corpses</td>
                             <td>1</td>
                             <td>Boolean</td>
                             <td>Whether the Arsonist can douse corpses of dead player's to destroy their bodies.</td>
@@ -175,8 +175,8 @@
                             <td>Integer</td>
                             <td>The maximum distance away the dousing target can be.</td>
                         </tr>
-                        <tr>
-                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_float_time</td>
+                        <tr class="betaonly">
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_arsonist_douse_float_time</td>
                             <td>1</td>
                             <td>Integer</td>
                             <td>The amount of time (in seconds) it takes for the Arsonist to lose their target without after getting out of range.</td>
@@ -193,8 +193,8 @@
                             <td>Integer</td>
                             <td>The minimum delay before a player is notified they've been doused.</td>
                         </tr>
-                        <tr>
-                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_require_los</td>
+                        <tr class="betaonly">
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_arsonist_douse_require_los</td>
                             <td>1</td>
                             <td>Boolean</td>
                             <td>Whether the Arsonist requires line of sight with their target in order to douse them.</td>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -152,16 +152,34 @@
                             <td>Whether jesters are revealed (via overhead icons, color/icon on the scoreboard, etc.) to the Arsonist.</td>
                         </tr>
                         <tr>
+                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_cooldown</td>
+                            <td>3</td>
+                            <td>Integer</td>
+                            <td>The amount of time (in seconds) the Arsonist's douse goes on cooldown for after they lose their target.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_arsonist_corpse_ignite_time</td>
                             <td>10</td>
                             <td>Integer</td>
                             <td>The amount of time in seconds to ignite doused dead player corpses for before destroying them.</td>
                         </tr>
                         <tr>
+                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_corpses</td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether the Arsonist can douse corpses of dead player's to destroy their bodies.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_arsonist_douse_distance</td>
                             <td>250</td>
                             <td>Integer</td>
                             <td>The maximum distance away the dousing target can be.</td>
+                        </tr>
+                        <tr>
+                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_float_time</td>
+                            <td>1</td>
+                            <td>Integer</td>
+                            <td>The amount of time (in seconds) it takes for the Arsonist to lose their target without after getting out of range.</td>
                         </tr>
                         <tr>
                             <td>ttt_arsonist_douse_notify_delay_max</td>
@@ -174,6 +192,12 @@
                             <td>10</td>
                             <td>Integer</td>
                             <td>The minimum delay before a player is notified they've been doused.</td>
+                        </tr>
+                        <tr>
+                            <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_arsonist_douse_require_los</td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether the Arsonist requires line of sight with their target in order to douse them.</td>
                         </tr>
                         <tr>
                             <td>ttt_arsonist_douse_time</td>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -167,7 +167,7 @@
                             <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_arsonist_douse_corpses</td>
                             <td>1</td>
                             <td>Boolean</td>
-                            <td>Whether the Arsonist can douse corpses of dead player's to destroy their bodies.</td>
+                            <td>Whether the Arsonist can douse corpses of dead players to destroy their bodies.</td>
                         </tr>
                         <tr>
                             <td>ttt_arsonist_douse_distance</td>

--- a/docs/tutorials/configuring_convars.html
+++ b/docs/tutorials/configuring_convars.html
@@ -352,8 +352,8 @@ ttt_another_string "custom roles for ttt" // This line would set the value of th
                 <td>String</td>
                 <td>Forces all players to have a certain role color setting. none (let user decide), default, simple, protan, deutan, tritan</td>
             </tr>
-            <tr>
-                <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_spectators_see_roles</td>
+            <tr class="betaonly">
+                <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_spectators_see_roles</td>
                 <td>0</td>
                 <td>Boolean</td>
                 <td>Whether spectators (not dead players) should be able to see the roles of all players</td>

--- a/docs/tutorials/configuring_convars.html
+++ b/docs/tutorials/configuring_convars.html
@@ -352,6 +352,12 @@ ttt_another_string "custom roles for ttt" // This line would set the value of th
                 <td>String</td>
                 <td>Forces all players to have a certain role color setting. none (let user decide), default, simple, protan, deutan, tritan</td>
             </tr>
+            <tr>
+                <td>ttt_spectators_see_roles</td>
+                <td>0</td>
+                <td>Boolean</td>
+                <td>Whether spectators (not dead players) should be able to see the roles of all players</td>
+            </tr>
             </tbody>
         </table>
     </div>

--- a/docs/tutorials/configuring_convars.html
+++ b/docs/tutorials/configuring_convars.html
@@ -353,7 +353,7 @@ ttt_another_string "custom roles for ttt" // This line would set the value of th
                 <td>Forces all players to have a certain role color setting. none (let user decide), default, simple, protan, deutan, tritan</td>
             </tr>
             <tr>
-                <td>ttt_spectators_see_roles</td>
+                <td><span data-text="Beta Only" class="betaonly tooltip">&nbsp;</span> ttt_spectators_see_roles</td>
                 <td>0</td>
                 <td>Boolean</td>
                 <td>Whether spectators (not dead players) should be able to see the roles of all players</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_ars_igniter.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ars_igniter.lua
@@ -56,7 +56,7 @@ SWEP.Secondary.Sound        = ""
 SWEP.InLoadoutFor           = {ROLE_ARSONIST}
 SWEP.InLoadoutForDefault    = {ROLE_ARSONIST}
 
-local arsonist_early_ignite = CreateConVar("ttt_arsonist_early_ignite", "0", FCVAR_NONE, "Whether to allow the arsonist to use their igniter without dousing everyone first", 0, 1)
+local arsonist_early_ignite = CreateConVar("ttt_arsonist_early_ignite", "0", FCVAR_REPLICATED, "Whether to allow the arsonist to use their igniter without dousing everyone first", 0, 1)
 if SERVER then
     CreateConVar("ttt_arsonist_corpse_ignite_time", "10", FCVAR_NONE, "The amount of time (in seconds) to ignite doused dead player corpses for before destroying them", 1, 30)
 end

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -185,6 +185,7 @@ end
 function GM:PostDrawTranslucentRenderables()
     client = LocalPlayer()
     plys = GetAllPlayers()
+    local spectatorOverride = client:GetRole() == ROLE_NONE and client:IsSpec() and GetConVar("ttt_spectators_see_roles"):GetBool()
 
     dir = client:GetForward() * -1
 
@@ -198,7 +199,7 @@ function GM:PostDrawTranslucentRenderables()
     for _, v in pairs(plys) do
         -- Compatibility with the disguises, Dead Ringer (810154456), and Prop Disguiser (310403737 and 2127939503)
         local hidden = v:GetNWBool("disguised", false) or (v.IsFakeDead and v:IsFakeDead()) or v:GetNWBool("PD_Disguised", false)
-        if v:IsActive() and v ~= client and not hidden and not CallHook("TTTTargetIDPlayerBlockIcon", nil, v, client) then
+        if v:IsActive() and v ~= client and (not hidden or spectatorOverride) and not CallHook("TTTTargetIDPlayerBlockIcon", nil, v, client) then
             pos = v:GetPos()
             pos.z = pos.z + v:GetHeight() + 15
 
@@ -209,59 +210,63 @@ function GM:PostDrawTranslucentRenderables()
             local role = nil
             local color_role = nil
             local noz = false
-            if v:IsDetectiveTeam() then
-                local disp_role, changed = v:GetDisplayedRole()
-                -- If the displayed role was changed, use it for the color but use the question mark for the icon
-                if changed then
-                    color_role = disp_role
-                    role = ROLE_NONE
-                else
-                    role = disp_role
-                end
-            elseif v:IsDetectiveLike() and not (v:IsImpersonator() and client:IsTraitorTeam()) then
-                role = GetDetectiveIconRole(false)
-            end
-            if not hide_roles then
-                if v:ShouldRevealRoleWhenActive() and v:IsRoleActive() then
-                    role = v:GetRole()
-                elseif client:IsTraitorTeam() then
-                    noz = true
-                    if showJester then
+            if spectatorOverride then
+                role = v:GetRole()
+            else
+                if v:IsDetectiveTeam() then
+                    local disp_role, changed = v:GetDisplayedRole()
+                    -- If the displayed role was changed, use it for the color but use the question mark for the icon
+                    if changed then
+                        color_role = disp_role
                         role = ROLE_NONE
-                        color_role = ROLE_JESTER
-                        noz = false
-                    elseif v:IsTraitorTeam() then
-                        if glitchRound then
-                            role, color_role = GetGlitchedRole(v, glitchMode)
-                        -- If the impersonator is promoted, use the Detective's icon with the Impersonator's color
-                        elseif v:IsImpersonator() and v:IsRoleActive() then
-                            role = GetDetectiveIconRole(true)
-                            color_role = ROLE_IMPERSONATOR
-                        else
-                            role = v:GetRole()
-                        end
-                    elseif v:IsGlitch() then
-                        if client:IsZombie() then
-                            role = ROLE_ZOMBIE
-                        else
-                            role, color_role = GetGlitchedRole(v, glitchMode)
-                        end
-                    -- Disable "No Z" for other icons like the Detective-like roles
                     else
-                        noz = false
+                        role = disp_role
                     end
-                elseif client:IsMonsterTeam() then
-                    if showJester then
-                        role = ROLE_NONE
-                        color_role = ROLE_JESTER
-                    elseif v:IsMonsterTeam() then
+                elseif v:IsDetectiveLike() and not (v:IsImpersonator() and client:IsTraitorTeam()) then
+                    role = GetDetectiveIconRole(false)
+                end
+                if not hide_roles then
+                    if v:ShouldRevealRoleWhenActive() and v:IsRoleActive() then
                         role = v:GetRole()
+                    elseif client:IsTraitorTeam() then
                         noz = true
-                    end
-                elseif client:IsIndependentTeam() then
-                    if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
-                        role = ROLE_NONE
-                        color_role = ROLE_JESTER
+                        if showJester then
+                            role = ROLE_NONE
+                            color_role = ROLE_JESTER
+                            noz = false
+                        elseif v:IsTraitorTeam() then
+                            if glitchRound then
+                                role, color_role = GetGlitchedRole(v, glitchMode)
+                                -- If the impersonator is promoted, use the Detective's icon with the Impersonator's color
+                            elseif v:IsImpersonator() and v:IsRoleActive() then
+                                role = GetDetectiveIconRole(true)
+                                color_role = ROLE_IMPERSONATOR
+                            else
+                                role = v:GetRole()
+                            end
+                        elseif v:IsGlitch() then
+                            if client:IsZombie() then
+                                role = ROLE_ZOMBIE
+                            else
+                                role, color_role = GetGlitchedRole(v, glitchMode)
+                            end
+                            -- Disable "No Z" for other icons like the Detective-like roles
+                        else
+                            noz = false
+                        end
+                    elseif client:IsMonsterTeam() then
+                        if showJester then
+                            role = ROLE_NONE
+                            color_role = ROLE_JESTER
+                        elseif v:IsMonsterTeam() then
+                            role = v:GetRole()
+                            noz = true
+                        end
+                    elseif client:IsIndependentTeam() then
+                        if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
+                            role = ROLE_NONE
+                            color_role = ROLE_JESTER
+                        end
                     end
                 end
             end
@@ -462,37 +467,43 @@ function GM:HUDDrawTargetID()
             _, color = util.HealthToString(ent:Health(), ent:GetMaxHealth())
         end
 
-        if not hide_roles and GetRoundState() == ROUND_ACTIVE then
-            local hideBeggar = ent:GetNWBool("WasBeggar", false) and not client:ShouldRevealBeggar(ent)
-            local hideBodysnatcher = ent:GetNWBool("WasBodysnatcher", false) and not client:ShouldRevealBodysnatcher(ent)
-            local showJester = (ent:ShouldActLikeJester() or ((ent:GetTraitor() or ent:GetInnocent()) and hideBeggar) or hideBodysnatcher) and not client:ShouldHideJesters()
-            if ent:ShouldRevealRoleWhenActive() and ent:IsRoleActive() then
-                target_role = true
-            elseif client:IsTraitorTeam() then
-                if showJester then
-                    target_jester = showJester
-                else
-                    target_traitor = ent:IsTraitor()
-                    target_special_traitor = ent:IsTraitorTeam() and not ent:IsTraitor()
-                    target_glitch = ent:IsGlitch()
+        local spectatorOverride = client:GetRole() == ROLE_NONE and client:IsSpec() and GetConVar("ttt_spectators_see_roles"):GetBool()
 
-                    if glitchRound and (target_traitor or target_special_traitor or (target_glitch and not GetGlobalBool("ttt_zombie_round", false))) then
-                        local role, color_role = GetGlitchedRole(ent, glitchMode)
-                        target_traitor = role == ROLE_TRAITOR
-                        target_unknown_traitor = role == ROLE_NONE and color_role == ROLE_TRAITOR
-                        target_special_traitor = role ~= ROLE_NONE and role ~= ROLE_TRAITOR
-                        target_unknown_special_traitor = role == ROLE_NONE and color_role ~= ROLE_TRAITOR
+        if (not hide_roles or spectatorOverride) and GetRoundState() == ROUND_ACTIVE then
+            if spectatorOverride then
+                target_role = true
+            else
+                local hideBeggar = ent:GetNWBool("WasBeggar", false) and not client:ShouldRevealBeggar(ent)
+                local hideBodysnatcher = ent:GetNWBool("WasBodysnatcher", false) and not client:ShouldRevealBodysnatcher(ent)
+                local showJester = (ent:ShouldActLikeJester() or ((ent:GetTraitor() or ent:GetInnocent()) and hideBeggar) or hideBodysnatcher) and not client:ShouldHideJesters()
+                if ent:ShouldRevealRoleWhenActive() and ent:IsRoleActive() then
+                    target_role = true
+                elseif client:IsTraitorTeam() then
+                    if showJester then
+                        target_jester = showJester
+                    else
+                        target_traitor = ent:IsTraitor()
+                        target_special_traitor = ent:IsTraitorTeam() and not ent:IsTraitor()
+                        target_glitch = ent:IsGlitch()
+
+                        if glitchRound and (target_traitor or target_special_traitor or (target_glitch and not GetGlobalBool("ttt_zombie_round", false))) then
+                            local role, color_role = GetGlitchedRole(ent, glitchMode)
+                            target_traitor = role == ROLE_TRAITOR
+                            target_unknown_traitor = role == ROLE_NONE and color_role == ROLE_TRAITOR
+                            target_special_traitor = role ~= ROLE_NONE and role ~= ROLE_TRAITOR
+                            target_unknown_special_traitor = role == ROLE_NONE and color_role ~= ROLE_TRAITOR
+                        end
                     end
-                end
-            elseif client:IsMonsterTeam() then
-                if showJester then
-                    target_jester = showJester
-                elseif ent:IsMonsterTeam() then
-                    target_monster = ent:GetRole()
-                end
-            elseif client:IsIndependentTeam() then
-                if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
-                    target_jester = showJester
+                elseif client:IsMonsterTeam() then
+                    if showJester then
+                        target_jester = showJester
+                    elseif ent:IsMonsterTeam() then
+                        target_monster = ent:GetRole()
+                    end
+                elseif client:IsIndependentTeam() then
+                    if showJester and cvars.Bool("ttt_" .. ROLE_STRINGS_RAW[client:GetRole()] .. "_can_see_jesters", false) then
+                        target_jester = showJester
+                    end
                 end
             end
         end

--- a/gamemodes/terrortown/gamemode/init_shd.lua
+++ b/gamemodes/terrortown/gamemode/init_shd.lua
@@ -48,6 +48,9 @@ CreateConVar("ttt_shop_random_percent", "50", FCVAR_REPLICATED, "The percent cha
 CreateConVar("ttt_shop_random_position", "0", FCVAR_REPLICATED, "Whether to randomize the position of the items in the shop")
 
 CreateConVar("ttt_role_pack", "", FCVAR_REPLICATED)
+
+CreateConVar("ttt_spectators_see_roles", "0", FCVAR_REPLICATED)
+
 -- Shop parameters
 CreateConVar("ttt_shop_for_all", 0, FCVAR_REPLICATED)
 -- Add any convars that are missing once shop-for-all is enabled

--- a/gamemodes/terrortown/gamemode/roles/arsonist/arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/arsonist.lua
@@ -14,7 +14,7 @@ local MathRandom = math.random
 -- CONVARS --
 -------------
 
-local arsonist_douse_float_time = CreateConVar("ttt_arsonist_douse_float_time", "1", FCVAR_NONE, "The amount of time (in seconds) it takes for the arsonist to lose their target without after getting out of range", 0, 60)
+local arsonist_douse_float_time = CreateConVar("ttt_arsonist_douse_float_time", "1", FCVAR_NONE, "The amount of time (in seconds) it takes for the arsonist to lose their target after getting out of range", 0, 60)
 local arsonist_douse_cooldown = CreateConVar("ttt_arsonist_douse_cooldown", "3", FCVAR_NONE, "The amount of time (in seconds) the arsonist's douse goes on cooldown for after they lose their target", 0, 60)
 local arsonist_douse_require_los = CreateConVar("ttt_arsonist_douse_require_los", "1")
 local arsonist_douse_distance = CreateConVar("ttt_arsonist_douse_distance", "250", FCVAR_NONE, "The maximum distance away the dousing target can be", 50, 1000)

--- a/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
@@ -9,6 +9,8 @@ local client
 local arsonist_douse_time = GetConVar("ttt_arsonist_douse_time")
 local arsonist_douse_notify_delay_min = GetConVar("ttt_arsonist_douse_notify_delay_min")
 local arsonist_douse_notify_delay_max = GetConVar("ttt_arsonist_douse_notify_delay_max")
+local arsonist_douse_corpses = GetConVar("ttt_arsonist_douse_corpses")
+local arsonist_early_ignite = GetConVar("ttt_arsonist_early_ignite")
 
 ------------------
 -- TRANSLATIONS --
@@ -250,7 +252,7 @@ hook.Add("TTTHUDInfoPaint", "Arsonist_TTTHUDInfoPaint", function(cli, label_left
 
     if hide_role then return end
 
-    if cli:IsArsonist() and cli:GetNWBool("TTTArsonistDouseComplete", false) then
+    if cli:IsArsonist() and cli:GetNWBool("TTTArsonistDouseComplete", false) and not arsonist_early_ignite:GetBool() then
         surface.SetFont("TabLarge")
         surface.SetTextColor(255, 255, 255, 230)
 
@@ -299,11 +301,13 @@ hook.Add("TTTTutorialRoleText", "Arsonist_TTTTutorialRoleText", function(role, t
             html = html .. "<span style='display: block; margin-top: 10px;'>Be careful though! Players <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>are notified when they are doused</span> after a short delay. Be sure to be sneaky or blend in with other players to disguise that you are the " .. ROLE_STRINGS[ROLE_ARSONIST] .. ".</span>"
         end
 
-        html = html .. "<span style='display: block; margin-top: 10px;'>You can also <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>douse player corpses</span>"
-        if not early_ignite then
-            html = html .. ", but they are not required to activate your igniter"
+        if arsonist_douse_corpses:GetBool() then
+            html = html .. "<span style='display: block; margin-top: 10px;'>You can also <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>douse player corpses</span>"
+            if not early_ignite then
+                html = html .. ", but they are not required to activate your igniter"
+            end
+            html = html .. ".</span>"
         end
-        html = html .. ".</span>"
 
         return html
     end

--- a/gamemodes/terrortown/gamemode/roles/arsonist/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/shared.lua
@@ -19,6 +19,7 @@ ROLE_CAN_SEE_MIA[ROLE_ARSONIST] = true
 CreateConVar("ttt_arsonist_douse_time", "8", FCVAR_REPLICATED, "The amount of time (in seconds) the arsonist takes to douse someone", 0, 60)
 CreateConVar("ttt_arsonist_douse_notify_delay_min", "10", FCVAR_REPLICATED, "The minimum delay before a player is notified they've been doused", 0, 30)
 CreateConVar("ttt_arsonist_douse_notify_delay_max", "30", FCVAR_REPLICATED, "The delay delay before a player is notified they've been doused", 3, 60)
+CreateConVar("ttt_arsonist_douse_corpses", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_detectives_search_only_arsonistdouse", "0", FCVAR_REPLICATED)
 
 ROLE_CONVARS[ROLE_ARSONIST] = {}
@@ -72,4 +73,22 @@ table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
 table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
     cvar = "ttt_arsonist_update_scoreboard",
     type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_douse_require_los",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_douse_corpses",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_douse_float_time",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
+})
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_douse_cooldown",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -23,7 +23,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.2"
+CR_VERSION = "2.1.3"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -152,6 +152,10 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
     if not IsValid(ply) or GetRoundState() == ROUND_WAIT or GetRoundState() == ROUND_PREP then return defaultcolor end
 
     local client = LocalPlayer()
+    if client:GetRole() == ROLE_NONE and client:IsSpec() and GetConVar("ttt_spectators_see_roles"):GetBool() then
+        return ply:GetRole()
+    end
+
     if (ply.search_result and ply.search_result.role > ROLE_NONE) or ply == client then
         return ply:GetRole()
     end


### PR DESCRIPTION
## Additions
- Added an option to require the Arsonist to have line of sight with their target to douse them (enabled by default)
- Added an option to prevent the Arsonist from being able to douse corpses (disabled by default)
- Added an option for the Arsonist to have a brief window of time after leaving range or losing line of sight of their target before dousing is cancelled (1 second by default)
- Added an option to change the amount of time after an Arsonist fails to douse a target before they can start dousing again (3 seconds by default)
- Added option for spectators (not dead players) to be able to see the roles of all players (disabled by default)

## Affected Issues
#616 
#618

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo 

Custom-Roles-for-TTT/TTT-Custom-Roles-ULX#98
