### PR TITLE
Misc. additions

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -605,6 +605,7 @@ ttt_cupid_can_damage_lovers                 0       // Whether cupid should be a
 ttt_cupid_lovers_can_damage_lovers          1       // Whether the lovers should be able to damage each other
 ttt_cupid_lovers_can_damage_cupid           0       // Whether the lovers should be able to damage cupid
 ttt_cupid_lover_vision_enabled              1       // Whether the lovers can see outlines of each other through walls
+ttt_cupid_arrow_speed_mult                  1       // The speed multiplier for the cupid's arrow
 ttt_cupid_notify_mode                       0       // The logic to use when notifying players that a cupid is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_cupid_notify_sound                      0       // Whether to play a cheering sound when a cupid is killed
 ttt_cupid_notify_confetti                   0       // Whether to throw confetti when a cupid is a killed

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -605,7 +605,8 @@ ttt_cupid_can_damage_lovers                 0       // Whether cupid should be a
 ttt_cupid_lovers_can_damage_lovers          1       // Whether the lovers should be able to damage each other
 ttt_cupid_lovers_can_damage_cupid           0       // Whether the lovers should be able to damage cupid
 ttt_cupid_lover_vision_enabled              1       // Whether the lovers can see outlines of each other through walls
-ttt_cupid_arrow_speed_mult                  1       // The speed multiplier for the cupid's arrow
+ttt_cupid_arrow_hitscan                     0       // Whether the cupid's arrow should be an instant hit instead of a projectile
+ttt_cupid_arrow_speed_mult                  1       // The speed multiplier for the cupid's arrow (Only applies when ttt_cupid_arrow_hitscan is disabled)
 ttt_cupid_notify_mode                       0       // The logic to use when notifying players that a cupid is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
 ttt_cupid_notify_sound                      0       // Whether to play a cheering sound when a cupid is killed
 ttt_cupid_notify_confetti                   0       // Whether to throw confetti when a cupid is a killed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
   - Roles
   - Identities (role, model, name, location). NOTE: Also respawns the target
 - Added ability to set a multiplier for the speed of cupid's arrow (defaults to 1)
+- Added ability for cupid's bow to use hitscan instead of projectiles to calculate whether something is hit (disabled by default)
 
 ### Changes
 - Changed spy name override to also show in the chat

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
   - Nothing (default)
   - Roles
   - Identities (role, model, name, location). NOTE: Also respawns the target
+- Added ability to set a multiplier for the speed of cupid's arrow (defaults to 1)
 
 ### Changes
 - Changed spy name override to also show in the chat

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -855,7 +855,7 @@
                                 </ol>
                             </td>
                         </tr>
-                        <tr class="betaonly"> 
+                        <tr class="betaonly">
                             <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_shadow_target_buff_show_progress</td>
                             <td>1</td>
                             <td>Boolean</td>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -463,7 +463,7 @@
                             <td>Boolean</td>
                             <td>Whether the bodysnatching device shows the role of the corpse it is used on or not.</td>
                         </tr>
-                        <tr class="betaonly"> 
+                        <tr class="betaonly">
                             <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_bodysnatcher_swap_mode</td>
                             <td>0</td>
                             <td>Integer (0-2)</td>
@@ -643,6 +643,12 @@
                         </tr>
                         </thead>
                         <tbody>
+                        <tr class="betaonly">
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_cupid_arrow_speed_mult</td>
+                            <td>1</td>
+                            <td>Float (0.1-1.5)</td>
+                            <td>The speed multiplier for the cupid's arrow.</td>
+                        </tr>
                         <tr>
                             <td>ttt_cupid_can_damage_lovers</td>
                             <td>0</td>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -466,7 +466,7 @@
                         <tr class="betaonly"> 
                             <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_bodysnatcher_swap_mode</td>
                             <td>0</td>
-                            <td>Boolean</td>
+                            <td>Integer (0-2)</td>
                             <td>What should be swapped when a bodysnatcher uses their device on a corpse:
                                 <ol start="0">
                                     <li>Nothing.</li>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -644,10 +644,16 @@
                         </thead>
                         <tbody>
                         <tr class="betaonly">
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_cupid_arrow_hitscan</td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether the cupid's arrow should be an instant hit instead of a projectile</td>
+                        </tr>
+                        <tr class="betaonly">
                             <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_cupid_arrow_speed_mult</td>
                             <td>1</td>
                             <td>Float (0.1-1.5)</td>
-                            <td>The speed multiplier for the cupid's arrow.</td>
+                            <td>The speed multiplier for the cupid's arrow. <i>(Requires <code>ttt_cupid_arrow_hitscan</code> to be disabled.)</i></td>
                         </tr>
                         <tr>
                             <td>ttt_cupid_can_damage_lovers</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_cup_bow.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_cup_bow.lua
@@ -123,6 +123,10 @@ sound.Add({
     sound = "cupid/zoomout.wav"
 })
 
+if SERVER then
+    CreateConVar("ttt_cupid_arrow_speed_mult", "1", FCVAR_NONE, "The speed multiplier for the cupid's arrow", 0.1, 1.5)
+end
+
 function SWEP:SetupDataTables()
     self:NetworkVar("Int", 0, "WepState")
 end
@@ -179,13 +183,15 @@ function SWEP:Think()
                 local charge = self:GetNextSecondaryFire()
                 charge = math.Clamp(CurTime() - charge, 0, 1)
 
+                local mult = GetConVar("ttt_cupid_arrow_speed_mult"):GetFloat()
+                local speed = 2500 * mult
                 local arrow = ents.Create("ttt_cup_arrow")
                 arrow:SetOwner(owner)
                 arrow:SetPos(pos)
                 arrow:SetAngles(ang)
                 arrow:Spawn()
                 arrow:Activate()
-                arrow:SetVelocity(ang:Forward() * 2500 * charge)
+                arrow:SetVelocity(ang:Forward() * speed * charge)
                 arrow.Weapon = self
             end
         end

--- a/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
@@ -22,6 +22,10 @@ table.insert(ROLE_CONVARS[ROLE_CUPID], {
     decimal = 2
 })
 table.insert(ROLE_CONVARS[ROLE_CUPID], {
+    cvar = "ttt_cupid_arrow_hitscan",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_CUPID], {
     cvar = "ttt_cupid_notify_mode",
     type = ROLE_CONVAR_TYPE_DROPDOWN,
     choices = {"None", "Detective and Traitor", "Traitor", "Detective", "Everyone"},

--- a/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
@@ -17,6 +17,11 @@ CreateConVar("ttt_cupid_lovers_can_damage_cupid", "0", FCVAR_REPLICATED, "Whethe
 
 ROLE_CONVARS[ROLE_CUPID] = {}
 table.insert(ROLE_CONVARS[ROLE_CUPID], {
+    cvar = "ttt_cupid_arrow_speed_mult",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 2
+})
+table.insert(ROLE_CONVARS[ROLE_CUPID], {
     cvar = "ttt_cupid_notify_mode",
     type = ROLE_CONVAR_TYPE_DROPDOWN,
     choices = {"None", "Detective and Traitor", "Traitor", "Detective", "Everyone"},


### PR DESCRIPTION
## Changelog
### Additions
- Added ability to set a multiplier for the speed of cupid's arrow (defaults to 1)
- Added ability for cupid's bow to use hitscan instead of projectiles to calculate whether something is hit (disabled by default)

## Affected Issues
#613

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
