### PR TITLE
2.1.4 Hotfixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,5 @@
 # Release Notes
 
-## 2.1.5 (Beta)
-**Released:**
-
-### Fixes
-- Fixed "press KEY to possess" label showing on corpses for living players after the round has ended
-
 ## 2.1.4 (Beta)
 **Released: March 2nd, 2024**
 
@@ -43,6 +37,7 @@
 - Fixed non-vanilla traitors not seeing the player disguise label on their allies
 - Fixed non-vanilla traitors not being able to pin ragdolls when `ttt_ragdoll_pinning` was enabled but `ttt_ragdoll_pinning_innocents` was disabled
 - Fixed role packs sometimes asking you to save again if you attempt to close the window after saving
+- Fixed "press KEY to possess" label showing on corpses for living players after the round has ended
 
 ### Developer
 - Added `TTTDrawHitMarker` hook that is called when a player damages an entity before hitmarkers are drawn

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.1.5 (Beta)
+**Released:**
+
+### Fixes
+- Fixed "press KEY to possess" label showing on corpses for living players after the round has ended
+
 ## 2.1.4 (Beta)
 **Released: March 2nd, 2024**
 

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -32,7 +32,7 @@ local ClassHint = {
             if DetectiveMode() then
                 local ply = LocalPlayer()
                 -- Handle special labels for spectators
-                if not ply:IsActive() then
+                if not ply:Alive() and ply:IsSpec() then
                     -- Cache the convar reference
                     if not spectator_corpse_search then
                         spectator_corpse_search = GetConVar("ttt_spectator_corpse_search")

--- a/gamemodes/terrortown/gamemode/roleblocks.lua
+++ b/gamemodes/terrortown/gamemode/roleblocks.lua
@@ -177,21 +177,20 @@ local function GreatestCommonDivisor(a, b)
 end
 
 hook.Add("TTTPrepareRound", "OldRoleBlocks_TTTPrepareRound", function()
-    local roleblocks = ROLEBLOCKS.GetBlockedRoles()
+    local roleblocks = ROLEBLOCKS.GetBlockedRoles() or {}
     local changes = false
     for _, v in ipairs(paired_role_blocks) do
         local cvar_name = "ttt_single_" .. v[1] .. "_" .. v[2]
         if cvars.Bool(cvar_name, false) then
             local exists = false
-            if roleblocks then
-                for _, group in ipairs(roleblocks) do
-                    if #group ~= 2 then continue end
-                    if (group[1].role == v[1] and group[2].role == v[2]) or (group[1].role == v[2] and group[2].role == v[1]) then
-                        exists = true
-                        break
-                    end
+            for _, group in ipairs(roleblocks) do
+                if #group ~= 2 then continue end
+                if (group[1].role == v[1] and group[2].role == v[2]) or (group[1].role == v[2] and group[2].role == v[1]) then
+                    exists = true
+                    break
                 end
             end
+
             if not exists then
                 local weight = cvars.Number(cvar_name .. "_chance", 0.5)
                 local n, d = FloatToFraction(weight)
@@ -204,6 +203,7 @@ hook.Add("TTTPrepareRound", "OldRoleBlocks_TTTPrepareRound", function()
             end
         end
     end
+
     if changes then
         local json = util.TableToJSON(roleblocks)
         if json == nil then

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -23,7 +23,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.4"
+CR_VERSION = "2.1.5"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -23,7 +23,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.5"
+CR_VERSION = "2.1.4"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog
- Fixed "press KEY to possess" label showing on corpses for living players after the round has ended
- Fixed error in roleblocks during initial conversion from the old convars

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
