### PR TITLE
Misc. changes and fixes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -452,6 +452,7 @@ ttt_paladin_credits_starting                1       // The number of credits a p
 ttt_tracker_footstep_time                   15      // The amount of time players' footsteps should show to the tracker before fading. Set to 0 to disable
 ttt_tracker_footstep_color                  1       // Whether players' footsteps should have different colors
 ttt_tracker_credits_starting                1       // The number of credits a tracker should start with
+ttt_tracker_radar_loadout                   0       // Whether the Tracker should get the tracking radar automatically for free. Server or round must be restarted for changes to take effect
 
 // Medium
 ttt_medium_spirit_color                     1       // Whether players' spirits should have different colors

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 2.1.6
+**Released:**
+
+### Additions
+- Added the option for the Tracker to have the tracking radar as part of their loadout (disabled by default)
+
+### Changes
+- Changed player color generation for the Medium and the Tracker to use the golden ratio so that colors are not too similar
+
+### Fixes
+- Fixed `ttt_spectators_see_roles` not working sometimes when a hook overwrote the target ID and/or scoreboard row information
+
 ## 2.1.5
 **Released: March 4th, 2024**\
 Includes beta updates [2.1.2](#212-beta) to [2.1.4](#214-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Fixed `ttt_spectators_see_roles` not working sometimes when a hook overwrote the target ID and/or scoreboard row information
+- Fixed `ttt_drunk_join_losing_team` not taking role packs into account when calculating the losing team
 
 ## 2.1.5
 **Released: March 4th, 2024**\

--- a/docs/teams/detective.html
+++ b/docs/teams/detective.html
@@ -639,7 +639,7 @@
                             <td>The time in seconds a player's footsteps should show to the Tracker before fading. <i>(Set to 0 to disable.)</i></td>
                         </tr>
                         <tr>
-                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_tracker_radar_loadout</td>
+                            <td>ttt_tracker_radar_loadout <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether the Tracker should get the tracking radar automatically for free. <i>(Server or round must be restarted for changes to take effect.)</i></td>

--- a/docs/teams/detective.html
+++ b/docs/teams/detective.html
@@ -638,6 +638,12 @@
                             <td>Integer</td>
                             <td>The time in seconds a player's footsteps should show to the Tracker before fading. <i>(Set to 0 to disable.)</i></td>
                         </tr>
+                        <tr>
+                            <td><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> ttt_tracker_radar_loadout</td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether the Tracker should get the tracking radar automatically for free. <i>(Server or round must be restarted for changes to take effect.)</i></td>
+                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>

--- a/gamemodes/terrortown/entities/weapons/ttt_trk_trackingradar/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/ttt_trk_trackingradar/shared.lua
@@ -6,6 +6,8 @@ end
 local hook = hook
 local table = table
 
+CreateConVar("ttt_tracker_radar_loadout", "0", FCVAR_REPLICATED)
+
 EQUIP_TRK_TRACKRADAR = EQUIP_TRK_TRACKRADAR or GenerateNewEquipmentID()
 local function InitializeEquipment()
     if DefaultEquipment then
@@ -19,10 +21,18 @@ local function InitializeEquipment()
             EquipmentItems[ROLE_TRACKER] = {}
         end
 
-        -- If we haven't already registered this item, add it to the list
-        if not table.HasItemWithPropertyValue(EquipmentItems[ROLE_TRACKER], "id", EQUIP_TRK_TRACKRADAR) then
+        -- If we haven't already registered this item, add it to the list. Otherwise, update if it should be in the Tracker's loadout or not
+        if table.HasItemWithPropertyValue(EquipmentItems[ROLE_TRACKER], "id", EQUIP_TRK_TRACKRADAR) then
+            for _, i in ipairs(EquipmentItems[ROLE_TRACKER]) do
+                if i.id == EQUIP_TRK_TRACKRADAR then
+                    i.loadout = cvars.Bool("ttt_tracker_radar_loadout", false)
+                    break
+                end
+            end
+        else
             table.insert(EquipmentItems[ROLE_TRACKER], {
                 id = EQUIP_TRK_TRACKRADAR,
+                loadout = cvars.Bool("ttt_tracker_radar_loadout", false),
                 type = "item_active",
                 material = "vgui/ttt/icon_track_radar",
                 name = "item_track_radar",

--- a/gamemodes/terrortown/entities/weapons/ttt_trk_trackingradar/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/ttt_trk_trackingradar/shared.lua
@@ -6,7 +6,7 @@ end
 local hook = hook
 local table = table
 
-CreateConVar("ttt_tracker_radar_loadout", "0", FCVAR_REPLICATED)
+local tracker_radar_loadout = CreateConVar("ttt_tracker_radar_loadout", "0", FCVAR_REPLICATED)
 
 EQUIP_TRK_TRACKRADAR = EQUIP_TRK_TRACKRADAR or GenerateNewEquipmentID()
 local function InitializeEquipment()
@@ -23,16 +23,12 @@ local function InitializeEquipment()
 
         -- If we haven't already registered this item, add it to the list. Otherwise, update if it should be in the Tracker's loadout or not
         if table.HasItemWithPropertyValue(EquipmentItems[ROLE_TRACKER], "id", EQUIP_TRK_TRACKRADAR) then
-            for _, i in ipairs(EquipmentItems[ROLE_TRACKER]) do
-                if i.id == EQUIP_TRK_TRACKRADAR then
-                    i.loadout = cvars.Bool("ttt_tracker_radar_loadout", false)
-                    break
-                end
-            end
+            local item = GetEquipmentItem(ROLE_TRACKER, EQUIP_TRK_TRACKRADAR)
+            item.loadout = tracker_radar_loadout:GetBool()
         else
             table.insert(EquipmentItems[ROLE_TRACKER], {
                 id = EQUIP_TRK_TRACKRADAR,
-                loadout = cvars.Bool("ttt_tracker_radar_loadout", false),
+                loadout = tracker_radar_loadout:GetBool(),
                 type = "item_active",
                 material = "vgui/ttt/icon_track_radar",
                 name = "item_track_radar",

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -833,6 +833,7 @@ local function InitRoundEndTime()
     SetRoundEnd(endtime)
 end
 
+local colorGenerationHue = MathRand(0, 360)
 function BeginRound()
     GAMEMODE:SyncGlobals()
 
@@ -870,8 +871,11 @@ function BeginRound()
 
     for _, v in pairs(GetAllPlayers()) do
         -- Player color
-        -- Generate a random color, but make sure it's not too bright or too dark
-        local col = HSLToColor(MathRand(0, 360), MathRand(0.5, 1), MathRand(0.25, 0.75))
+        -- Generate a new color, but make sure it's not too bright or too dark
+        local col = HSLToColor(colorGenerationHue, MathRand(0.5, 1), MathRand(0.25, 0.75))
+        -- Add the golden ratio conjugate (multiplied by 360) to the previous hue to get the next one
+        colorGenerationHue = colorGenerationHue + (0.61803 * 360)
+        colorGenerationHue = colorGenerationHue % 360
         local vec = Vector(col.r / 255, col.g / 255, col.b / 255)
         v:SetNWVector("PlayerColor", vec)
 

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -237,14 +237,14 @@ function plymeta:DrunkJoinLosingTeam()
                     -- If there should be more jesters/independents then fill as many empty slots as required with jesters/independents
                     if rolePackJestersIndependents < jestersIndependents and remainingSlots > 0 then
                         local requiredExtraJestersIndependents = math.min(jestersIndependents - rolePackJestersIndependents, remainingSlots)
-                        rolePackJestersIndependents = rolePackJestersIndependents + requiredExtraJestersIndependents
+                        -- We don't actually need to know how many jesters/independents there are but we do need to know if any slots have been taken up
                         remainingSlots = remainingSlots - requiredExtraJestersIndependents
                     end
 
                     -- If there should be more monsters then fill as many empty slots as required with monsters
                     if rolePackMonsters < monsters and remainingSlots > 0 then
                         local requiredExtraMonsters = math.min(monsters - rolePackMonsters, remainingSlots)
-                        rolePackMonsters = rolePackMonsters + requiredExtraMonsters
+                        -- We don't actually need to know how many monsters there are but we do need to know if any slots have been taken up
                         remainingSlots = remainingSlots - requiredExtraMonsters
                     end
 

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -217,10 +217,11 @@ function plymeta:DrunkJoinLosingTeam()
                     end
 
                     -- From the summed weights, add the percentage change that this slot will be filled by a role of each team to the totals
-                    rolePackInnocents = rolePackInnocents + (slotInnocents / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
-                    rolePackTraitors = rolePackTraitors + (slotTraitors / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
-                    rolePackMonsters = rolePackMonsters + (slotMonsters / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
-                    rolePackJestersIndependents = rolePackJestersIndependents + (slotJestersIndependents / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
+                    local totalSlotWeight = slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents
+                    rolePackInnocents = rolePackInnocents + (slotInnocents / totalSlotWeight)
+                    rolePackTraitors = rolePackTraitors + (slotTraitors / totalSlotWeight)
+                    rolePackMonsters = rolePackMonsters + (slotMonsters / totalSlotWeight)
+                    rolePackJestersIndependents = rolePackJestersIndependents + (slotJestersIndependents / totalSlotWeight)
                 end
 
                 -- If we didn't fill enough slots for each player then we need to calculate what teams would fill the remaining slots using the same order used in regular role spawning (traitor>jester/independent>monster>innocent)

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -166,6 +166,102 @@ function plymeta:DrunkJoinLosingTeam()
     -- Find the average percentage of players that are traitors in each round ignoring jesters, independents, and monsters
     local traitorPct = traitors / (players - jestersIndependents - monsters)
 
+    -- If a role pack is enabled calculate the expected ratio of innocents to traitors
+    local rolePack = GetConVar("ttt_role_pack"):GetString()
+    if #rolePack > 0 then
+        local json = file.Read("rolepacks/" .. rolePack .. "/roles.json", "DATA")
+        if json then
+            local rolePackTable = util.JSONToTable(json)
+            if rolePackTable then
+                local filledSlotCount = 0
+
+                local rolePackInnocents = 0
+                local rolePackTraitors = 0
+                local rolePackMonsters = 0
+                local rolePackJestersIndependents = 0
+
+                for _, slot in ipairs(rolePackTable.slots) do
+                    -- If the slot is empty then we dont need to do any calculations
+                    if #slot == 0 then continue end
+
+                    -- If we have already filled enough slots for each player then don't include later slots in the calculation
+                    if filledSlotCount >= players then
+                        break
+                    end
+                    filledSlotCount = filledSlotCount + 1
+
+                    -- Calculate the number of roles and their weights within this slot that belong to each team
+                    local slotInnocents = 0
+                    local slotTraitors = 0
+                    local slotMonsters = 0
+                    local slotJestersIndependents = 0
+                    for _, roleslot in ipairs(slot) do
+                        local role = ROLE_NONE
+                        for r = ROLE_INNOCENT, ROLE_MAX do
+                            if ROLE_STRINGS_RAW[r] == roleslot.role then
+                                role = r
+                                break
+                            end
+                        end
+                        if role > ROLE_NONE then
+                            if INNOCENT_ROLES[role] then
+                                slotInnocents = slotInnocents + roleslot.weight
+                            elseif TRAITOR_ROLES[role] then
+                                slotTraitors = slotTraitors + roleslot.weight
+                            elseif MONSTER_ROLES[role] then
+                                slotMonsters = slotMonsters + roleslot.weight
+                            else
+                                slotJestersIndependents = slotJestersIndependents + roleslot.weight
+                            end
+                        end
+                    end
+
+                    -- From the summed weights, add the percentage change that this slot will be filled by a role of each team to the totals
+                    rolePackInnocents = rolePackInnocents + (slotInnocents / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
+                    rolePackTraitors = rolePackTraitors + (slotTraitors / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
+                    rolePackMonsters = rolePackMonsters + (slotMonsters / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
+                    rolePackJestersIndependents = rolePackJestersIndependents + (slotJestersIndependents / (slotInnocents + slotTraitors + slotMonsters + slotJestersIndependents))
+                end
+
+                -- If we didn't fill enough slots for each player then we need to calculate what teams would fill the remaining slots using the same order used in regular role spawning (traitor>jester/independent>monster>innocent)
+                if filledSlotCount < players then
+                    local remainingSlots = players - filledSlotCount
+
+                    -- If there should be more traitors then fill as many empty slots as required with traitors
+                    if rolePackTraitors < traitors and remainingSlots > 0 then
+                        local requiredExtraTraitors = math.min(traitors - rolePackTraitors, remainingSlots)
+                        rolePackTraitors = rolePackTraitors + requiredExtraTraitors
+                        remainingSlots = remainingSlots - requiredExtraTraitors
+                    end
+
+                    -- If there should be more jesters/independents then fill as many empty slots as required with jesters/independents
+                    if rolePackJestersIndependents < jestersIndependents and remainingSlots > 0 then
+                        local requiredExtraJestersIndependents = math.min(jestersIndependents - rolePackJestersIndependents, remainingSlots)
+                        rolePackJestersIndependents = rolePackJestersIndependents + requiredExtraJestersIndependents
+                        remainingSlots = remainingSlots - requiredExtraJestersIndependents
+                    end
+
+                    -- If there should be more monsters then fill as many empty slots as required with monsters
+                    if rolePackMonsters < monsters and remainingSlots > 0 then
+                        local requiredExtraMonsters = math.min(monsters - rolePackMonsters, remainingSlots)
+                        rolePackMonsters = rolePackMonsters + requiredExtraMonsters
+                        remainingSlots = remainingSlots - requiredExtraMonsters
+                    end
+
+                    -- Any remaining slots would be innocents
+                    rolePackInnocents = rolePackInnocents + remainingSlots
+                end
+
+                -- Find the average percentage of players that are traitors in each round ignoring jesters, independents, and monsters
+                traitorPct = rolePackTraitors / (rolePackInnocents + rolePackTraitors)
+            else
+                ErrorNoHalt("Table decoding failed!\n")
+            end
+        else
+            ErrorNoHalt("No role pack named '" .. rolePack .. "' found!\n")
+        end
+    end
+
     -- Find whether the drunk joining the innocent, traitor, or another team will bring the ratio of traitor health to traitor and innocent health closest to the value calculated above
     local drunkHealth = self:Health()
 

--- a/gamemodes/terrortown/gamemode/roles/tracker/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/tracker/shared.lua
@@ -36,3 +36,7 @@ table.insert(ROLE_CONVARS[ROLE_TRACKER], {
     cvar = "ttt_tracker_footstep_color",
     type = ROLE_CONVAR_TYPE_BOOL
 })
+table.insert(ROLE_CONVARS[ROLE_TRACKER], {
+    cvar = "ttt_tracker_radar_loadout",
+    type = ROLE_CONVAR_TYPE_BOOL
+})

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -23,7 +23,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.5"
+CR_VERSION = "2.1.6"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog
### Additions
- Added the option for the Tracker to have the tracking radar as part of their loadout (disabled by default)

### Changes
- Changed player color generation for the Medium and the Tracker to use the golden ratio so that colors are not too similar

### Fixes
- Fixed `ttt_spectators_see_roles` not working sometimes when a hook overwrote the target ID and/or scoreboard row information
- Fixed `ttt_drunk_join_losing_team` not taking role packs into account when calculating the losing team

## Affected Issues
- Closes #601

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
