### PR TITLE
Bodysnatcher fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,11 @@ Includes beta update [2.1.6](#216-beta).
   - Temporarily override `util.BitSet` to be `table.HasValue` and call with the equipment table again
   - Call with a `0` instead of the equipment table
 
+### Fixes
+- Fixed player being turned into a bodysnatcher not getting the bodysnatching device
+- Fixed round restarts not clearing bodysnatcher and spy disguises
+- Fixed players who swap identities with a bodysnatcher sometimes being stuck ducking
+
 ## 2.1.6 (Beta)
 **Released: March 9th, 2024**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,16 +4,20 @@
 **Released: March 11th, 2024**\
 Includes beta update [2.1.6](#216-beta).
 
-### Developer
-- Changed `TTTBodySearchEquipment` so it now has multiple levels of fallback
-  - Call with the equipment table
-  - Temporarily override `util.BitSet` to be `table.HasValue` and call with the equipment table again
-  - Call with a `0` instead of the equipment table
+### Changes
+- Changed bodysnatcher disguise name label to not show to innocents even if they are on the same team as the disguised player
 
 ### Fixes
 - Fixed player being turned into a bodysnatcher not getting the bodysnatching device
 - Fixed round restarts not clearing bodysnatcher and spy disguises
 - Fixed players who swap identities with a bodysnatcher sometimes being stuck ducking
+- Fixed name label when looking at an allied player with a bodysnatcher disguise not showing their real name
+
+### Developer
+- Changed `TTTBodySearchEquipment` so it now has multiple levels of fallback
+  - Call with the equipment table
+  - Temporarily override `util.BitSet` to be `table.HasValue` and call with the equipment table again
+  - Call with a `0` instead of the equipment table
 
 ## 2.1.6 (Beta)
 **Released: March 9th, 2024**

--- a/docs/teams/detective.html
+++ b/docs/teams/detective.html
@@ -639,7 +639,7 @@
                             <td>The time in seconds a player's footsteps should show to the Tracker before fading. <i>(Set to 0 to disable.)</i></td>
                         </tr>
                         <tr>
-                            <td>ttt_tracker_radar_loadout <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_tracker_radar_loadout</td>
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether the Tracker should get the tracking radar automatically for free. <i>(Server or round must be restarted for changes to take effect.)</i></td>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -1064,7 +1064,7 @@
                             <td>Whether a specific jester role should get the spongifier. Replace * with the name of the jester role you want to configure without spaces or capital letters.</td>
                         </tr>
                         <tr>
-                            <td>ttt_sponge_device_for_*_heal <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_sponge_device_for_*_heal</td>
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether a specific jester role should be fully healed when using the spongifier. Replace * with the name of the jester role you want to configure without spaces or capital letters.</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -265,7 +265,7 @@ if CLIENT then
         if team_chat then return end
 
         -- Show the overwritten name alongside their real name for allies
-        if not cli:IsInnocentTeam() and (ply == client or client:IsSameTeam(ply)) then
+        if not client:IsInnocentTeam() and (ply == client or client:IsSameTeam(ply)) then
             return LANG.GetParamTranslation("player_name_disguised", { name=ply:Nick(), disguise=disguiseName })
         end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -124,6 +124,8 @@ if SERVER then
                 if swap_mode == BODYSNATCHER_SWAP_MODE_IDENTITY then
                     -- Respawn the new bodysnatcher
                     ply:SpawnForRound(true)
+                    -- Give them their loadout weapons since SpawnForRound doesn't do that for players being resurrected
+                    RunHook("PlayerLoadout", ply)
 
                     -- Store the former bodysnatcher's position and angles
                     local pos = owner:GetPos()
@@ -180,13 +182,16 @@ if SERVER then
         return "BODYSNATCH ABORTED"
     end
 
-    AddHook("TTTEndRound", "Bodysnatcher_InfoOverride_TTTEndRound", function()
+    local function ClearFullState()
         for _, ply in ipairs(GetAllPlayers()) do
             ClearPlayerInfoOverride(ply)
         end
 
         table.Empty(playerInfos)
-    end)
+    end
+
+    AddHook("TTTEndRound", "Bodysnatcher_InfoOverride_TTTEndRound", ClearFullState)
+    AddHook("TTTPrepareRound", "Bodysnatcher_InfoOverride_TTTPrepareRound", ClearFullState)
 end
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -244,12 +244,8 @@ if CLIENT then
         local disguiseName = ply:GetNWString("TTTBodysnatcherName", nil)
         if not disguiseName or #disguiseName == 0 then return end
 
-        -- Don't override the name for the player or their allies
-        if ply == cli then return end
-        if cli:IsSameTeam(ply) then return end
-
-        -- Show the overwritten name alongside their real name for allies
-        if ply == cli or cli:IsSameTeam(ply) then
+        -- Show the overwritten name alongside their real name for non-innocent allies
+        if not cli:IsInnocentTeam() and (ply == cli or cli:IsSameTeam(ply)) then
             return LANG.GetParamTranslation("player_name_disguised", { name=ply:Nick(), disguise=disguiseName }), clr
         end
 
@@ -269,7 +265,7 @@ if CLIENT then
         if team_chat then return end
 
         -- Show the overwritten name alongside their real name for allies
-        if ply == client or client:IsSameTeam(ply) then
+        if not cli:IsInnocentTeam() and (ply == client or client:IsSameTeam(ply)) then
             return LANG.GetParamTranslation("player_name_disguised", { name=ply:Nick(), disguise=disguiseName })
         end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -245,7 +245,7 @@ if CLIENT then
         if not disguiseName or #disguiseName == 0 then return end
 
         -- Show the overwritten name alongside their real name for non-innocent allies
-        if not cli:IsInnocentTeam() and (ply == cli or cli:IsSameTeam(ply)) then
+        if ply == cli or (not cli:IsInnocentTeam() and cli:IsSameTeam(ply)) then
             return LANG.GetParamTranslation("player_name_disguised", { name=ply:Nick(), disguise=disguiseName }), clr
         end
 
@@ -265,7 +265,7 @@ if CLIENT then
         if team_chat then return end
 
         -- Show the overwritten name alongside their real name for allies
-        if not client:IsInnocentTeam() and (ply == client or client:IsSameTeam(ply)) then
+        if ply == client or (not client:IsInnocentTeam() and client:IsSameTeam(ply)) then
             return LANG.GetParamTranslation("player_name_disguised", { name=ply:Nick(), disguise=disguiseName })
         end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -278,6 +278,7 @@ if CLIENT then
 
     -- Detect the crouching keybinds and tell the server to stop forcing this player to duck
     AddHook("PlayerBindPress", "Bodysnatcher_DuckReset_PlayerBindPress", function(ply, bind, pressed)
+        if not pressed then return end
         if not IsPlayer(ply) then return end
         if not ply:Alive() or ply:IsSpec() then return end
         if not ply:GetNWBool("TTTBodysnatcherForceDuck", false) then return end

--- a/gamemodes/terrortown/gamemode/roles/spy/spy.lua
+++ b/gamemodes/terrortown/gamemode/roles/spy/spy.lua
@@ -92,20 +92,16 @@ hook.Add("PlayerDeath", "Spy_PlayerDeath", function(victim, inflictor, attacker)
     end
 end)
 
--- Reset every spy's disguise at the end of the round
-hook.Add("TTTEndRound", "Spy_TTTEndRound", function()
+local function ClearFullState()
     for _, ply in ipairs(GetAllPlayers()) do
-        if ply:IsSpy() then
-            local sid64 = ply:SteamID64()
-
-            local playerModel = playerModels[sid64]
-            if playerModel then
-                SetMDL(ply, playerModel.model)
-                ply:SetSkin(playerModel.skin)
-                ply:SetColor(playerModel.color)
-                for id, value in pairs(playerModel.bodygroups) do
-                    ply:SetBodygroup(id, value)
-                end
+        local sid64 = ply:SteamID64()
+        local playerModel = playerModels[sid64]
+        if playerModel then
+            SetMDL(ply, playerModel.model)
+            ply:SetSkin(playerModel.skin)
+            ply:SetColor(playerModel.color)
+            for id, value in pairs(playerModel.bodygroups) do
+                ply:SetBodygroup(id, value)
             end
 
             timer.Simple(0.1, function()
@@ -117,4 +113,7 @@ hook.Add("TTTEndRound", "Spy_TTTEndRound", function()
     end
 
     table.Empty(playerModels)
-end)
+end
+
+hook.Add("TTTEndRound", "Spy_TTTEndRound", ClearFullState)
+hook.Add("TTTPrepareRound", "Spy_TTTPrepareRound", ClearFullState)


### PR DESCRIPTION
## Changelog
### Changes
- Changed bodysnatcher disguise name label to not show to innocents even if they are on the same team as the disguised player

### Fixes
- Fixed player being turned into a bodysnatcher not getting the bodysnatching device
- Fixed round restarts not clearing bodysnatcher and spy disguises
- Fixed players who swap identities with a bodysnatcher sometimes being stuck ducking
- Fixed name label when looking at an allied player with a bodysnatcher disguise not showing their real name

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
