### PR TITLE
Changed round summary to show who was bodysnatched by who if `ttt_bodysnatcher_swap_mode` is configured so that the dead player becomes a bodysnatcher

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,14 @@
 # Release Notes
 
-## 2.1.8 (Beta)
-**Released: March 16th, 2024**
+## 2.1.8
+**Released: March 17th, 2024**
 
 ### Additions
 - Added immune and jester hitmarkers to the old man and jester roles revealed by the informant
 
 ### Changes
 - Changed bodysnatcher disguise name label to not show to innocents even if they are on the same team as the disguised player
+- Changed round summary to show who was bodysnatched by who if `ttt_bodysnatcher_swap_mode` is configured so that the dead player becomes a bodysnatcher
 - Changed drunk sobering with `ttt_drunk_any_role` enabled so that they can only sober into a role that spawns naturally
   - e.g. If the mad scientist was enabled but not the zombie, the drunk would only be able to become the mad scientist
 

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -126,6 +126,7 @@ if SERVER then
             local swap_mode = GetConVar("ttt_bodysnatcher_swap_mode"):GetInt()
             if swap_mode > BODYSNATCHER_SWAP_MODE_NOTHING then
                 ply:SetRole(ROLE_BODYSNATCHER)
+                ply:SetNWString("TTTBodysnatcherSwappedWith", owner:Nick())
                 body.was_role = ROLE_BODYSNATCHER
                 SetRoleMaxHealth(ply)
 
@@ -205,7 +206,13 @@ if SERVER then
     end
 
     AddHook("TTTEndRound", "Bodysnatcher_InfoOverride_TTTEndRound", ClearFullState)
-    AddHook("TTTPrepareRound", "Bodysnatcher_InfoOverride_TTTPrepareRound", ClearFullState)
+    AddHook("TTTPrepareRound", "Bodysnatcher_InfoOverride_TTTPrepareRound", function()
+        for _, ply in ipairs(GetAllPlayers()) do
+            -- We want this info to show up in the round summary so we can't clear it on round end
+            ply:SetNWString("TTTBodysnatcherSwappedWith", "")
+        end
+        ClearFullState()
+    end)
 
     -- If a client tells us to stop them being forced to duck... do it
     net.Receive("TTT_BodysnatcherUnforceDuck", function(len, ply)

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/cl_bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/cl_bodysnatcher.lua
@@ -34,6 +34,9 @@ hook.Add("Initialize", "Bodysnatcher_Translations_Initialize", function()
     LANG.AddToLanguage("english", "bodysnatcher_hidden_all_hud", "You still appear as {bodysnatcher} to others")
     LANG.AddToLanguage("english", "bodysnatcher_hidden_team_hud", "Only your team knows you are no longer {bodysnatcher}")
 
+    -- Scoring
+    LANG.AddToLanguage("english", "score_bodysnatcher_bodysnatched", "Bodysnatched by")
+
     -- Popups
     LANG.AddToLanguage("english", "info_popup_bodysnatcher_jester", [[You are {role}! {traitors} think you are {ajester} and you
 deal no damage. Use your body snatching device on a corpse
@@ -115,8 +118,15 @@ end)
 hook.Add("TTTScoringSummaryRender", "Bodysnatcher_TTTScoringSummaryRender", function(ply, roleFileName, groupingRole, roleColor, name, startingRole, finalRole)
     if not IsPlayer(ply) then return end
 
-    if startingRole == ROLE_BODYSNATCHER then
-        return ROLE_STRINGS_SHORT[ROLE_BODYSNATCHER]
+    if GetConVar("ttt_bodysnatcher_swap_mode"):GetInt() == BODYSNATCHER_SWAP_MODE_NOTHING then
+        if startingRole == ROLE_BODYSNATCHER then
+            return ROLE_STRINGS_SHORT[ROLE_BODYSNATCHER]
+        end
+    elseif ply:IsBodysnatcher() then
+        local swappedWith = ply:GetNWString("TTTBodysnatcherSwappedWith", "")
+        if swappedWith and #swappedWith > 0 then
+            return roleFileName, groupingRole, roleColor, name, swappedWith, LANG.GetTranslation("score_bodysnatcher_bodysnatched")
+        end
     end
 end)
 


### PR DESCRIPTION
## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
