### PR TITLE
2.1.8 Hotfix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@
 - Fixed players who swap identities with a bodysnatcher sometimes being stuck ducking
 - Fixed name label when looking at an allied player with a bodysnatcher disguise not showing their real name
 - Fixed a few pieces of data getting stuck in bodysnatcher, phantom, and parasite that may have been caused by a change in the march GMod update
-- Fixed "doused" label showing on non-player entities for the arsonist
+- Fixed "doused" label showing for the arsonist on entities that cannot be doused
 
 ### Developer
 - Added `ROLE_BLOCK_SPAWN_CONVARS` table which can be used to prevent `ttt_rolename_enabled`, `ttt_rolename_spawn_weight`, and `ttt_rolename_min_players` ConVars from being created for specific roles

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 - Fixed players who swap identities with a bodysnatcher sometimes being stuck ducking
 - Fixed name label when looking at an allied player with a bodysnatcher disguise not showing their real name
 - Fixed a few pieces of data getting stuck in bodysnatcher, phantom, and parasite that may have been caused by a change in the march GMod update
+- Fixed "doused" label showing on non-player entities for the arsonist
 
 ### Developer
 - Added `ROLE_BLOCK_SPAWN_CONVARS` table which can be used to prevent `ttt_rolename_enabled`, `ttt_rolename_spawn_weight`, and `ttt_rolename_min_players` ConVars from being created for specific roles

--- a/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
@@ -60,6 +60,7 @@ end)
 -- Show "DOUSED" label on players who have been doused
 hook.Add("TTTTargetIDPlayerText", "Arsonist_TTTTargetIDPlayerText", function(ent, cli, text, col, secondaryText)
     if GetRoundState() < ROUND_ACTIVE then return end
+    if not IsPlayer(ent) then return end
     if not cli:IsArsonist() then return end
 
     -- If this is a player, check their doused state

--- a/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
@@ -60,7 +60,7 @@ end)
 -- Show "DOUSED" label on players who have been doused
 hook.Add("TTTTargetIDPlayerText", "Arsonist_TTTTargetIDPlayerText", function(ent, cli, text, col, secondaryText)
     if GetRoundState() < ROUND_ACTIVE then return end
-    if not IsPlayer(ent) then return end
+    if not IsPlayer(ent) and not IsRagdoll(ent) then return end
     if not cli:IsArsonist() then return end
 
     -- If this is a player, check their doused state

--- a/gamemodes/terrortown/gamemode/roles/beggar/cl_beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/cl_beggar.lua
@@ -198,8 +198,8 @@ end)
 
 hook.Add("TTTTargetIDPlayerText", "Beggar_TTTTargetIDPlayerText", function(ent, cli, text, col, secondaryText)
     if GetRoundState() < ROUND_ACTIVE then return end
-    if not cli:IsBeggar() then return end
     if not IsPlayer(ent) then return end
+    if not cli:IsBeggar() then return end
 
     if ent:ShouldRevealRoleWhenActive() and ent:IsRoleActive() then return end
 

--- a/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
@@ -88,8 +88,10 @@ end
 ---------------
 
 hook.Add("TTTTargetIDPlayerText", "Parasite_TTTTargetIDPlayerText", function(ent, cli, text, col, secondary_text)
+    if not IsPlayer(ent) then return end
+
     -- Skip this for Assassin so they can have their own Current Target logic (it also handles parasite infection there)
-    if ((IsPlayer(ent) and ent:GetNWBool("ParasiteInfected", false) and cli:IsTraitorTeam()) or IsLoverInfecting(cli, ent)) and not cli:IsAssassin() then
+    if ((ent:GetNWBool("ParasiteInfected", false) and cli:IsTraitorTeam()) or IsLoverInfecting(cli, ent)) and not cli:IsAssassin() then
         return LANG.GetTranslation("target_infected"), ROLE_COLORS_RADAR[ROLE_PARASITE]
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/phantom/cl_phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/cl_phantom.lua
@@ -87,6 +87,7 @@ end
 ---------------
 
 hook.Add("TTTTargetIDPlayerText", "Phantom_TTTTargetIDPlayerText", function(ent, cli, text, col, secondary_text)
+    if not IsPlayer(ent) then return end
     if IsLoverHaunting(cli, ent) then
         return LANG.GetTranslation("target_haunted"), ROLE_COLORS_RADAR[ROLE_PHANTOM]
     end

--- a/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
@@ -182,15 +182,15 @@ AddHook("TTTTargetIDPlayerRing", "Shadow_TTTTargetIDPlayerRing", function(ent, c
 end)
 
 AddHook("TTTTargetIDPlayerText", "Shadow_TTTTargetIDPlayerText", function(ent, cli, text, clr, secondaryText)
-    if IsPlayer(ent) then
-        if cli:IsActiveShadow() and ent:SteamID64() == cli:GetNWString("ShadowTarget", "") then
-            if text == nil then
-                return LANG.GetTranslation("shadow_target"), ROLE_COLORS_RADAR[ROLE_SHADOW]
-            end
-            return text, clr, LANG.GetTranslation("shadow_target"), ROLE_COLORS_RADAR[ROLE_SHADOW]
-        elseif shadow_target_notify_mode:GetInt() == SHADOW_NOTIFY_IDENTIFY and ent:IsActiveShadow() and ent:GetNWString("ShadowTarget", "") == cli:SteamID64() then
-            return StringUpper(ROLE_STRINGS[ROLE_SHADOW]), ROLE_COLORS_RADAR[ROLE_SHADOW]
+    if not IsPlayer(ent) then return end
+
+    if cli:IsActiveShadow() and ent:SteamID64() == cli:GetNWString("ShadowTarget", "") then
+        if text == nil then
+            return LANG.GetTranslation("shadow_target"), ROLE_COLORS_RADAR[ROLE_SHADOW]
         end
+        return text, clr, LANG.GetTranslation("shadow_target"), ROLE_COLORS_RADAR[ROLE_SHADOW]
+    elseif shadow_target_notify_mode:GetInt() == SHADOW_NOTIFY_IDENTIFY and ent:IsActiveShadow() and ent:GetNWString("ShadowTarget", "") == cli:SteamID64() then
+        return StringUpper(ROLE_STRINGS[ROLE_SHADOW]), ROLE_COLORS_RADAR[ROLE_SHADOW]
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/vindicator/cl_vindicator.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/cl_vindicator.lua
@@ -43,7 +43,7 @@ hook.Add("TTTTargetIDPlayerTargetIcon", "Vindicator_TTTTargetIDPlayerTargetIcon"
 end)
 
 hook.Add("TTTTargetIDPlayerText", "Vindicator_TTTTargetIDPlayerText", function(ent, cli, text, col, secondary_text)
-    if cli:IsVindicator() and IsPlayer(ent) and ent:SteamID64() == cli:GetNWString("VindicatorTarget", "") then
+    if IsPlayer(ent) and cli:IsVindicator() and ent:SteamID64() == cli:GetNWString("VindicatorTarget", "") then
         return LANG.GetTranslation("target_current_target"), ROLE_COLORS_RADAR[ROLE_VINDICATOR]
     end
 end)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
 CR_VERSION = "2.1.8"
-CR_BETA = false
+CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 
 function CRVersion(version)


### PR DESCRIPTION
## Changelog
- Fixed "doused" label showing for the arsonist on entities that cannot be doused

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
