### PR TITLE
Misc. changes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -208,6 +208,15 @@ Called when an informant has scanned additional information from a target player
 - *tgt* - The player being scanned
 - *stage* - The new scan stage
 
+### TTTIsPlayerRespawning(ply)
+Called to check whether a player is currently respawning.\
+*Realm:* Client and Server\
+*Added in:* 2.1.12\
+*Parameters:*
+- *ply*</em>* - The player being queried for respawn status
+
+*Return:* `true` if the player is currently respawning, `false` if they are not. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
+
 ### TTTKarmaGiveReward(ply, reward, victim)
 Called before a player is rewarded with karma. Used to block a player's karma reward.\
 *Realm:* Server\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -716,6 +716,24 @@ Called when a player buys a random item from the shop.\
 - *client* - The player who is buying a random item
 - *item* - The random item that was selected
 
+### TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)
+Called when during a player's `Think`, allowing a player to emit smoke with different visual effects.\
+*Realm:* Client\
+*Added in:* 1.2.7\
+*Parameters:*
+- *ply* - The target player being rendered
+- *client* - The local player
+- *shouldSmoke* - Whether the player would normally emit smoke
+- *smokeColor* - What [Color](https://wiki.facepunch.com/gmod/Color) the smoke will be. (Defaults to `COLOR_BLACK`)
+- *smokeParticle* - What particle the smoke will use. Should be the relative path the the `.vmt` file for the particle. (Defaults to `"particle/snow.vmt"`)
+- *smokeOffset* - A [Vector](https://wiki.facepunch.com/gmod/Vector) representing the relative offset from the player's feet. (Defaults to `Vector(0, 0, 30)`)
+
+*Return:*
+- *shouldSmoke* - The new shouldSmoke value to use or the original passed into the hook
+- *smokeColor* - The new smokeColor value to use or the original passed into the hook
+- *smokeParticle* - The new smokeParticle value to use or the original passed into the hook
+- *smokeOffset* - The new smokeOffset value to use or the original passed into the hook
+
 ### TTTShowSearchScreen(search)
 Called when a body search screen would be shown.\
 *Realm:* Client\
@@ -811,23 +829,10 @@ Called when a player starts or stops sprinting.\
 - *sprinting* - Whether the player is now sprinting
 - *wasSprinting* - Whether the player was sprinting
 
-### TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)
-.\
-*Realm:* Client\
-*Added in:* 1.2.7\
-*Parameters:*
-- *ply* - The target player being rendered
-- *client* - The local player
-- *shouldSmoke* - Whether the player would normally emit smoke
-- *smokeColor* - What [Color](https://wiki.facepunch.com/gmod/Color) the smoke will be. (Defaults to `COLOR_BLACK`)
-- *smokeParticle* - What particle the smoke will use. Should be the relative path the the `.vmt` file for the particle. (Defaults to `"particle/snow.vmt"`)
-- *smokeOffset* - A [Vector](https://wiki.facepunch.com/gmod/Vector) representing the relative offset from the player's feet. (Defaults to `Vector(0, 0, 30)`)
-
-*Return:*
-- *shouldSmoke* - The new shouldSmoke value to use or the original passed into the hook
-- *smokeColor* - The new smokeColor value to use or the original passed into the hook
-- *smokeParticle* - The new smokeParticle value to use or the original passed into the hook
-- *smokeOffset* - The new smokeOffset value to use or the original passed into the hook
+### TTTStopPlayerRespawning(ply)
+Called when something has requested that a player stop respawning due to a role feature.\
+*Realm:* Server\
+*Added in:* 2.1.12
 
 ### TTTSyncEventIDs()
 Called when the server is syncing generated event IDs to the client.\

--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -216,6 +216,11 @@ Whether the entity or position given is on screen for the player, within the giv
 - *ent_or_pos* - The entity or position vector that is being checked
 - *limit* - The maximum value limit before a player is determined to be "off screen" (Defaults to 1)
 
+### plymeta:IsRespawning()
+Whether this player is currently respawning.\
+*Realm:* Client and Server\
+*Added in:* 2.1.12
+
 ### plymeta:IsRoleActive()
 Whether the player's role feature has been activated.\
 *Realm:* Client and Server\

--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -360,6 +360,13 @@ Sets the credits on the player based on their role's starting credits convars.\
 *Parameters:*
 - *keep_existing* - Whether to keep the player's existing credits (Defaults to `false`) *(Added in 1.6.2)*
 
+### plymeta:SetPlayerScale(scale)
+Sets the player's size by adjusting models, step sizes, hulls and view offsets.\
+*Realm:* Server\
+*Added in:* 1.3.1\
+*Parameters:*
+- *scale* - The value with which to scale the players size, relative to their current size.
+
 ### plymeta:SetRoleAndBroadcast(role)
 Sets the player's role to the given one and (if called on the server) broadcasts the change to all clients for scoreboard tracking.\
 *Realm:* Client and Server\
@@ -453,14 +460,14 @@ Runs the logic for when a drunk sobers up and remembers their role.\
 *Parameters:*
 - *team* - Which team to choose a role from (see ROLE_TEAM_* global enumeration)
 
+### plymeta:StopRespawning()
+Stops the player from respawning due to a role feature.\
+*Realm:* Server\
+*Added in:* 2.1.12
+
+*Returns:* `true` if a respawn was stopped, `false` otherwise.
+
 ### plymeta:StripRoleWeapons()
 Strips all weapons from the player whose `Category` property matches the global `WEAPON_CATEGORY_ROLE` value.\
 *Realm:* Client and Server\
 *Added in:* 1.0.5
-
-### plymeta:SetPlayerScale(scale)
-Sets the player's size by adjusting models, step sizes, hulls and view offsets.\
-*Realm:* Server\
-*Added in:* 1.3.1\
-*Parameters:*
-- *scale* - The value with which to scale the players size, relative to their current size.

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -320,6 +320,7 @@ ttt_spy_steal_model                         1       // Whether the spy should ch
 ttt_spy_steal_model_hands                   1       // Whether the spy should change to the victim's playermodel's 1st-person hands after killing a player
 ttt_spy_steal_model_alert                   1       // Whether the spy should see an alert message displaying who they are disguised as after killing a player
 ttt_spy_steal_name                          1       // Whether the spy should change to the victim's name after killing a player (When other players look at the spy and see their info under the crosshair)
+ttt_spy_steal_from_respawning               1       // Whether the spy should steal the identity of their victim even if that player is respawning
 ttt_spy_flare_gun_loadout                   1       // Whether the spy should have a flare gun given to them when they spawn. Server must be restarted for changes to take effect
 ttt_spy_flare_gun_shop                      0       // Whether the spy should have a flare gun be purchasable in the shop. Server must be restarted for changes to take effect
 ttt_spy_flare_gun_shop_rebuyable            0       // Whether the spy should be able to purchase the flare gun multiple times (requires "ttt_spy_flare_gun_shop" to be enabled). Server must be restarted for changes to take effect

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -1089,8 +1089,9 @@ ttt_death_notifier_enabled                  1       // Whether the name and role
 ttt_death_notifier_show_role                1       // Whether to show the killer's role in death notification messages
 ttt_smokegrenade_extinguish                 1       // Whether smoke grenades should extinguish fire
 ttt_player_set_color                        1       // Whether player colors are set each time that player spawns
-ttt_dna_scan_on_dialog                      1       // Whether to show a button to open the DNA scanner on the body search dialog
 ttt_dna_scan_detectives_loadout             0       // Whether all detectives should be given a DNA scanner. If disabled, only the Detective role will get one
+ttt_dna_scan_on_dialog                      1       // Whether to show a button to open the DNA scanner on the body search dialog
+ttt_dna_scan_only_drop_on_death             0       // Whether the DNA scanner should only be droppable when the holder dies
 ttt_spectator_corpse_search                 1       // Whether spectators can search bodies (not shared with other players)
 ttt_corpse_search_not_shared                0       // Whether corpse searches are not shared with other players (only affects non-detective-like searchers)
 ttt_color_mode_override                     "none"  // Forces all players to have a certain role color setting. none (let user decide), default, simple, protan, deutan, tritan

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -1090,6 +1090,7 @@ ttt_death_notifier_show_role                1       // Whether to show the kille
 ttt_smokegrenade_extinguish                 1       // Whether smoke grenades should extinguish fire
 ttt_player_set_color                        1       // Whether player colors are set each time that player spawns
 ttt_dna_scan_on_dialog                      1       // Whether to show a button to open the DNA scanner on the body search dialog
+ttt_dna_scan_detectives_loadout             0       // Whether all detectives should be given a DNA scanner. If disabled, only the Detective role will get one
 ttt_spectator_corpse_search                 1       // Whether spectators can search bodies (not shared with other players)
 ttt_corpse_search_not_shared                0       // Whether corpse searches are not shared with other players (only affects non-detective-like searchers)
 ttt_color_mode_override                     "none"  // Forces all players to have a certain role color setting. none (let user decide), default, simple, protan, deutan, tritan

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -443,6 +443,7 @@ ttt_detectives_glow_enabled                 0       // Whether members of the de
 ttt_special_detectives_armor_loadout        1       // Whether special detectives (all detective roles other than the original detective itself) get armor automatically for free
 ttt_all_search_postround                    1       // Whether non-detectives can search bodies post-round or not
 ttt_all_search_binoc                        0       // Whether non-detectives can search bodies if they are using binoculars
+ttt_all_search_dnascanner                   0       // Whether non-detectives can search bodies if they are hold the DNA scanner
 ttt_detectives_credits_timer                0       // How often in seconds to give members of the detective team a credit. Set to 0 to disable.
 ttt_detectives_search_credits               0       // How many credits a detective should get for searching a corpse. Set to 0 to disable.
 ttt_detectives_search_credits_friendly      0       // Whether detectives should get credits for searching friendly corpses

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
   - When disabled, only the vanilla Detective role will be given the DNA scanner as part of their loadout
 - Added ability to disable DNA Scanner from being dropped, except for when the player holding it dies (disabled by default)
 - Added ability to allow any player holding the DNA scanner to search bodies as if they were a detective (disabled by default)
+- Added ability to control whether a spy who kills a respawning player will steal their identity anyway (enabled by default)
 
 ### Fixes
 - Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,10 @@
 ## 2.1.12 (Beta)
 **Released:**
 
+### Additions
+- Added ability for DNA Scanner to be given to all detective roles (disabled by default)
+  - When disabled, only the vanilla Detective role will be given the DNA scanner as part of their loadout
+
 ### Fixes
 - Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook
+- Added `plymeta:StopRespawning` fed by the new `TTTStopPlayerRespawning` hook
 
 ## 2.1.11
 **Released: April 15th, 2024**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps
+- Fixed potential issues when a parasite or phantom is killed by a role that changes their victim's role
 
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 2.1.12 (Beta)
 **Released:**
 
+### Fixes
+- Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps
+
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - Added ability for DNA Scanner to be given to all detective roles (disabled by default)
   - When disabled, only the vanilla Detective role will be given the DNA scanner as part of their loadout
 - Added ability to disable DNA Scanner from being dropped, except for when the player holding it dies (disabled by default)
+- Added ability to allow any player holding the DNA scanner to search bodies as if they were a detective (disabled by default)
 
 ### Fixes
 - Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook
 - Added `plymeta:StopRespawning` fed by the new `TTTStopPlayerRespawning` hook
+- Added ability to open role tutorial to a specific role via `HELPSCRN:OpenRoleTutorial(ROLE_ID)`
 
 ## 2.1.11
 **Released: April 15th, 2024**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Additions
 - Added ability for DNA Scanner to be given to all detective roles (disabled by default)
   - When disabled, only the vanilla Detective role will be given the DNA scanner as part of their loadout
+- Added ability to disable DNA Scanner from being dropped, except for when the player holding it dies (disabled by default)
 
 ### Fixes
 - Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.1.12 (Beta)
+**Released:**
+
+### Developer
+- Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook
+
 ## 2.1.11
 **Released: April 15th, 2024**\
 Includes beta update [2.1.10](#2110-beta).

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -324,6 +324,20 @@
             <li><em>stage</em> - The new scan stage</li>
         </ul>
 
+        <h3><a id="tttisplayerespawningply" href="#tttisplayerespawningply">TTTIsPlayerRespawning(ply)</a></h3>
+        <p>
+            Called to check whether a player is currently respawning.<br>
+            <em>Realm:</em> Client and Server<br>
+            <em>Added in:</em> 2.1.12<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The player being queried for respawn status</li>
+        </ul>
+        <p>
+            <em>Return:</em> <code>true</code> if the player is currently respawning, <code>false</code> if they are not. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
+        </p>
+
         <h3><a id="tttkarmagiverewardply-reward-victim" href="#tttkarmagiverewardply-reward-victim">TTTKarmaGiveReward(ply, reward, victim)</a></h3>
         <p>
             Called before a player is rewarded with karma. Used to block a player's karma reward.<br>

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -1080,6 +1080,31 @@
             <li><em>item</em> - The random item that was selected</li>
         </ul>
 
+        <h3><a id="tttshouldplayersmokeply-client-shouldsmoke-smokecolor-smokeparticle-smokeoffset" href="#tttshouldplayersmokeply-client-shouldsmoke-smokecolor-smokeparticle-smokeoffset">TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)</a></h3>
+        <p>
+            Called when during a player's `Think`, allowing a player to emit smoke with different visual effects.<br>
+            <em>Realm:</em> Client<br>
+            <em>Added in:</em> 1.2.7<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The target player being rendered</li>
+            <li><em>client</em> - The local player</li>
+            <li><em>shouldSmoke</em> - Whether the player would normally emit smoke</li>
+            <li><em>smokeColor</em> - What <a href="https://wiki.facepunch.com/gmod/Color" target="_blank">Color</a> the smoke will be. (Defaults to <code>COLOR_BLACK</code>)</li>
+            <li><em>smokeParticle</em> - What particle the smoke will use. Should be the relative path the the <code>.vmt</code> file for the particle. (Defaults to <code>"particle/snow.vmt"</code>)</li>
+            <li><em>smokeOffset</em> - A <a href="https://wiki.facepunch.com/gmod/Vector" target="_blank">Vector</a> representing the relative offset from the player's feet. (Defaults to <code>Vector(0, 0, 30)</code>)</li>
+        </ul>
+        <p>
+            <em>Return:</em>
+        </p>
+        <ul>
+            <li><em>shouldSmoke</em> - The new shouldSmoke value to use or the original passed into the hook</li>
+            <li><em>smokeColor</em> - The new smokeColor value to use or the original passed into the hook</li>
+            <li><em>smokeParticle</em> - The new smokeParticle value to use or the original passed into the hook</li>
+            <li><em>smokeOffset</em> - The new smokeOffset value to use or the original passed into the hook</li>
+        </ul>
+
         <h3><a  id="tttshowsearchscreensearch" href="#tttshowsearchscreensearch">TTTShowSearchScreen(search)</a></h3>
         <p>
             Called when a body search screen would be shown.<br>
@@ -1220,30 +1245,12 @@
             <li><em>wasSprinting</em> - Whether the player was sprinting</li>
         </ul>
 
-        <h3><a id="tttshouldplayersmokeply-client-shouldsmoke-smokecolor-smokeparticle-smokeoffset" href="#tttshouldplayersmokeply-client-shouldsmoke-smokecolor-smokeparticle-smokeoffset">TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)</a></h3>
+        <h3><a id="tttstopplayerrespawningply" href="#tttstopplayerrespawningply">TTTStopPlayerRespawning(ply)</a></h3>
         <p>
-            .<br>
-            <em>Realm:</em> Client<br>
-            <em>Added in:</em> 1.2.7<br>
-            <em>Parameters:</em>
+            Called when something has requested that a player stop respawning due to a role feature.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 2.1.12
         </p>
-        <ul>
-            <li><em>ply</em> - The target player being rendered</li>
-            <li><em>client</em> - The local player</li>
-            <li><em>shouldSmoke</em> - Whether the player would normally emit smoke</li>
-            <li><em>smokeColor</em> - What <a href="https://wiki.facepunch.com/gmod/Color" target="_blank">Color</a> the smoke will be. (Defaults to <code>COLOR_BLACK</code>)</li>
-            <li><em>smokeParticle</em> - What particle the smoke will use. Should be the relative path the the <code>.vmt</code> file for the particle. (Defaults to <code>"particle/snow.vmt"</code>)</li>
-            <li><em>smokeOffset</em> - A <a href="https://wiki.facepunch.com/gmod/Vector" target="_blank">Vector</a> representing the relative offset from the player's feet. (Defaults to <code>Vector(0, 0, 30)</code>)</li>
-        </ul>
-        <p>
-            <em>Return:</em>
-        </p>
-        <ul>
-            <li><em>shouldSmoke</em> - The new shouldSmoke value to use or the original passed into the hook</li>
-            <li><em>smokeColor</em> - The new smokeColor value to use or the original passed into the hook</li>
-            <li><em>smokeParticle</em> - The new smokeParticle value to use or the original passed into the hook</li>
-            <li><em>smokeOffset</em> - The new smokeOffset value to use or the original passed into the hook</li>
-        </ul>
 
         <h3><a id="tttsynceventids" href="#tttsynceventids">TTTSyncEventIDs()</a></h3>
         <p>

--- a/docs/api/methods_player_object.html
+++ b/docs/api/methods_player_object.html
@@ -541,6 +541,17 @@
             <li><em>keep_existing</em> - Whether to keep the player's existing credits (Defaults to <code>false</code>) <em>(Added in 1.6.2)</em></li>
         </ul>
 
+        <h3><a id="plymetasetplayerscalescale" href="#plymetasetplayerscalescale">plymeta:SetPlayerScale(scale)</a></h3>
+        <p>
+            Sets the player's size by adjusting models, step sizes, hulls and view offsets.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 1.3.1<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>scale</em> - The value with which to scale the players size, relative to their current size.</li>
+        </ul>
+
         <h3><a id="plymetasetroleandbroadcastrole" href="#plymetasetroleandbroadcastrole">plymeta:SetRoleAndBroadcast(role)</a></h3>
         <p>
             Sets the player's role to the given one and (if called on the server) broadcasts the change to all clients for scoreboard tracking.<br>
@@ -682,23 +693,22 @@
             <li><em>team</em> - Which team to choose a role from (see ROLE_TEAM_* global enumeration)</li>
         </ul>
 
+        <h3><a id="plymetastoprespawning" href="#plymetastoprespawning">plymeta:StopRespawning()</a></h3>
+        <p>
+            Stops the player from respawning due to a role feature.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 2.1.12
+        </p>
+        <p>
+            <em>Returns:</em> <code>true</code> if a respawn was stopped, <code>false</code> otherwise.
+        </p>
+
         <h3><a id="plymetastriproleweapons" href="#plymetastriproleweapons">plymeta:StripRoleWeapons()</a></h3>
         <p>
             Strips all weapons from the player whose <code>Category</code> property matches the global <code>WEAPON_CATEGORY_ROLE</code> value.<br>
             <em>Realm:</em> Client and Server<br>
             <em>Added in:</em> 1.0.5
         </p>
-
-        <h3><a id="plymetasetplayerscalescale" href="#plymetasetplayerscalescale">plymeta:SetPlayerScale(scale)</a></h3>
-        <p>
-            Sets the player's size by adjusting models, step sizes, hulls and view offsets.<br>
-            <em>Realm:</em> Server<br>
-            <em>Added in:</em> 1.3.1<br>
-            <em>Parameters:</em>
-        </p>
-        <ul>
-            <li><em>scale</em> - The value with which to scale the players size, relative to their current size.</li>
-        </ul>
     </div>
     <div class="footerpadding panel"></div>
 </body>

--- a/docs/api/methods_player_object.html
+++ b/docs/api/methods_player_object.html
@@ -327,6 +327,13 @@
             <li><em>limit</em> - The maximum value limit before a player is determined to be "off screen" (Defaults to 1)</li>
         </ul>
 
+        <h3><a id="plymetaisrespawning" href="#plymetaisrespawning">plymeta:IsRespawning()</a></h3>
+        <p>
+            Whether this player is currently respawning.<br>
+            <em>Realm:</em> Client and Server<br>
+            <em>Added in:</em> 2.1.12
+        </p>
+
         <h3><a id="plymetaisroleactive" href="#plymetaisroleactive">plymeta:IsRoleActive()</a></h3>
         <p>
             Whether the player's role feature has been activated.<br>

--- a/docs/teams/detective.html
+++ b/docs/teams/detective.html
@@ -152,6 +152,12 @@
                         <td>Whether non-detectives can search bodies if they are using binoculars.</td>
                     </tr>
                     <tr>
+                        <td>ttt_all_search_dnascanner</td>
+                        <td>0</td>
+                        <td>Boolean</td>
+                        <td>Whether non-detectives can search bodies if they are holding the DNA scanner.</td>
+                    </tr>
+                    <tr>
                         <td>ttt_detectives_disable_looting</td>
                         <td>0</td>
                         <td>Boolean</td>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -791,6 +791,12 @@
                             <td>Whether the Spy should be able to purchase the flare gun multiple times. <i>(requires <code>ttt_spy_flare_gun_shop</code> to be enabled. Server must be restarted for changes to take effect.)</i></td>
                         </tr>
                         <tr>
+                            <td>ttt_spy_steal_from_respawning</td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether the Spy should steal the identity of their victim even if that player is respawning.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_spy_steal_model</td>
                             <td>1</td>
                             <td>Boolean</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
@@ -44,6 +44,7 @@ SWEP.CanBuy                = nil -- no longer a buyable thing
 SWEP.WeaponID              = AMMO_WTESTER
 
 SWEP.InLoadoutFor          = {ROLE_DETECTIVE}
+SWEP.InLoadoutForDefault   = {ROLE_DETECTIVE}
 
 --SWEP.AllowDrop = false
 SWEP.AutoSpawnable         = false
@@ -73,6 +74,17 @@ local dna_scan_on_dialog = CreateConVar("ttt_dna_scan_on_dialog", "1", FCVAR_REP
 if CLIENT then
     CreateClientConVar("ttt_dna_scan_repeat", 1, true, true)
 else
+    local dna_scan_detectives_loadout = CreateConVar("ttt_dna_scan_detectives_loadout", "0", FCVAR_NONE, "Whether all detectives should be given a DNA scanner. If disabled, only the Detective role will get one", 0, 1)
+
+    hook.Add("TTTUpdateRoleState", "DNAScanner_TTTUpdateRoleState", function()
+        local wtester = weapons.GetStored("weapon_ttt_wtester")
+        if dna_scan_detectives_loadout:GetBool() then
+            wtester.InLoadoutFor = GetTeamRoles(DETECTIVE_ROLES)
+        else
+            wtester.InLoadoutFor = wtester.InLoadoutForDefault
+        end
+    end)
+
     function SWEP:GetRepeating()
         local ply = self:GetOwner()
         return IsValid(ply) and ply:GetInfoNum("ttt_dna_scan_repeat", 1) == 1

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
@@ -46,7 +46,7 @@ SWEP.WeaponID              = AMMO_WTESTER
 SWEP.InLoadoutFor          = {ROLE_DETECTIVE}
 SWEP.InLoadoutForDefault   = {ROLE_DETECTIVE}
 
---SWEP.AllowDrop = false
+SWEP.AllowDrop             = true
 SWEP.AutoSpawnable         = false
 SWEP.NoSights              = true
 
@@ -75,6 +75,7 @@ if CLIENT then
     CreateClientConVar("ttt_dna_scan_repeat", 1, true, true)
 else
     local dna_scan_detectives_loadout = CreateConVar("ttt_dna_scan_detectives_loadout", "0", FCVAR_NONE, "Whether all detectives should be given a DNA scanner. If disabled, only the Detective role will get one", 0, 1)
+    local dna_scan_only_drop_on_death = CreateConVar("ttt_dna_scan_only_drop_on_death", "0", FCVAR_NONE, "Whether the DNA scanner should only be droppable when the holder dies", 0, 1)
 
     hook.Add("TTTUpdateRoleState", "DNAScanner_TTTUpdateRoleState", function()
         local wtester = weapons.GetStored("weapon_ttt_wtester")
@@ -83,6 +84,10 @@ else
         else
             wtester.InLoadoutFor = wtester.InLoadoutForDefault
         end
+
+        -- If we disable "AllowDrop", the player cannot drop on purpose
+        -- but when they are killed, the weapon is dropped regardless of "AllowDrop"'s value
+        wtester.AllowDrop = not dna_scan_only_drop_on_death:GetBool()
     end)
 
     function SWEP:GetRepeating()

--- a/gamemodes/terrortown/gamemode/corpse_shd.lua
+++ b/gamemodes/terrortown/gamemode/corpse_shd.lua
@@ -53,9 +53,11 @@ end
 function CORPSE.CanBeSearched(ply, rag)
     if not IsPlayer(ply) then return false end
 
+    local weap_class = WEPS.GetClass(ply.GetActiveWeapon and ply:GetActiveWeapon())
     local ownerEnt = CORPSE.GetPlayer(rag)
     local detectiveSearchOnly = (GetConVar("ttt_detectives_search_only"):GetBool() or IsAllDetectiveOnly()) and
                             not (GetConVar("ttt_all_search_postround"):GetBool() and GetRoundState() ~= ROUND_ACTIVE) and
-                            not (GetConVar("ttt_all_search_binoc"):GetBool() and ply:GetActiveWeapon() and WEPS.GetClass(ply:GetActiveWeapon()) == "weapon_ttt_binoculars")
+                            not (GetConVar("ttt_all_search_binoc"):GetBool() and weap_class == "weapon_ttt_binoculars") and
+                            not (GetConVar("ttt_all_search_dnascanner"):GetBool() and weap_class == "weapon_ttt_wtester")
     return ply:IsActiveDetectiveLike() or not detectiveSearchOnly or (IsValid(ownerEnt) and ownerEnt:GetNWBool("body_searched", false))
 end

--- a/gamemodes/terrortown/gamemode/init_shd.lua
+++ b/gamemodes/terrortown/gamemode/init_shd.lua
@@ -18,6 +18,7 @@ for role = 0, ROLE_MAX do
 end
 
 CreateConVar("ttt_all_search_binoc", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_all_search_dnascanner", "0", FCVAR_REPLICATED)
 CreateConVar("ttt_all_search_postround", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_color_mode_override", "none", FCVAR_REPLICATED)
 

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -222,6 +222,11 @@ end
 function plymeta:IsRespawning()
     return CallHook("TTTIsPlayerRespawning", nil, self) == true
 end
+if SERVER then
+    function plymeta:StopRespawning()
+        return CallHook("TTTStopPlayerRespawning", nil, self) == true
+    end
+end
 
 function plymeta:SetRoleAndBroadcast(role)
     self:SetRole(role)

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -219,6 +219,10 @@ function plymeta:IsVictimChangingRole(victim)
     return false
 end
 
+function plymeta:IsRespawning()
+    return CallHook("TTTIsPlayerRespawning", nil, self) == true
+end
+
 function plymeta:SetRoleAndBroadcast(role)
     self:SetRole(role)
 

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -176,6 +176,16 @@ hook.Add("PlayerDeath", "Beggar_KillCheck_PlayerDeath", function(victim, infl, a
     end
 end)
 
+hook.Add("TTTStopPlayerRespawning", "Beggar_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("BeggarIsRespawning", false) then
+        timer.Remove(ply:Nick() .. "BeggarRespawn")
+        ply:SetNWBool("BeggarIsRespawning", false)
+    end
+end)
+
 ------------------
 -- CUPID LOVERS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -178,7 +178,7 @@ end)
 
 hook.Add("TTTStopPlayerRespawning", "Beggar_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("BeggarIsRespawning", false) then
         timer.Remove(ply:Nick() .. "BeggarRespawn")

--- a/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
@@ -172,7 +172,7 @@ end)
 
 hook.Add("TTTIsPlayerRespawning", "Beggar_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("BeggarIsRespawning", false) then
         return true

--- a/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
@@ -169,3 +169,12 @@ hook.Add("TTTUpdateRoleState", "Beggar_TTTUpdateRoleState", function()
     INDEPENDENT_ROLES[ROLE_BEGGAR] = is_independent
     JESTER_ROLES[ROLE_BEGGAR] = not is_independent
 end)
+
+hook.Add("TTTIsPlayerRespawning", "Beggar_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("BeggarIsRespawning", false) then
+        return true
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
@@ -51,14 +51,20 @@ end)
 
 -- Players killed by the hive mind join the hive mind
 AddHook("PlayerDeath", "HiveMind_Assimilate_PlayerDeath", function(victim, infl, attacker)
-    if not IsPlayer(victim) or victim:IsHiveMind() or victim:IsZombifying() then return end
+    if not IsPlayer(victim) or victim:IsHiveMind() then return end
     if not IsPlayer(attacker) or not attacker:IsHiveMind() then return end
+
+    -- Hive Mind bypasses whatever respawn feature the victim's old role had
+    if victim:IsRespawning() then
+        victim:StopRespawning()
+    end
 
     victim:SetNWBool("HiveMindRespawning", true)
     timer.Create("HiveMindRespawn_" .. victim:SteamID64(), 0.25, 1, function()
         -- Double-check
-        if not IsPlayer(victim) or victim:IsHiveMind() or victim:IsZombifying() then return end
+        if not IsPlayer(victim) or victim:IsHiveMind() then return end
         if not IsPlayer(attacker) or not attacker:IsHiveMind() then return end
+
         victim:SetNWBool("HiveMindRespawning", false)
 
         local body = victim.server_ragdoll or victim:GetRagdollEntity()
@@ -77,6 +83,16 @@ AddHook("PlayerDeath", "HiveMind_Assimilate_PlayerDeath", function(victim, infl,
 
         SendFullStateUpdate()
     end)
+end)
+
+hook.Add("TTTStopPlayerRespawning", "HiveMind_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("HiveMindRespawning", false) then
+        timer.Remove("HiveMindRespawn_" .. ply:SteamID64())
+        ply:SetNWBool("HiveMindRespawning", false)
+    end
 end)
 
 --------------------

--- a/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
@@ -54,10 +54,12 @@ AddHook("PlayerDeath", "HiveMind_Assimilate_PlayerDeath", function(victim, infl,
     if not IsPlayer(victim) or victim:IsHiveMind() or victim:IsZombifying() then return end
     if not IsPlayer(attacker) or not attacker:IsHiveMind() then return end
 
+    victim:SetNWBool("HiveMindRespawning", true)
     timer.Create("HiveMindRespawn_" .. victim:SteamID64(), 0.25, 1, function()
         -- Double-check
         if not IsPlayer(victim) or victim:IsHiveMind() or victim:IsZombifying() then return end
         if not IsPlayer(attacker) or not attacker:IsHiveMind() then return end
+        victim:SetNWBool("HiveMindRespawning", false)
 
         local body = victim.server_ragdoll or victim:GetRagdollEntity()
         victim.HiveMindPreviousMaxHealth = victim:GetMaxHealth()
@@ -364,6 +366,7 @@ AddHook("TTTPrepareRound", "HiveMind_PrepareRound", function()
     primeAssigned = false
     for _, v in PlayerIterator() do
         timer.Remove("HiveMindRespawn_" .. v:SteamID64())
+        v:SetNWBool("HiveMindRespawning", false)
         v.HiveMindPreviousMaxHealth = nil
         v.HiveMindPrime = nil
     end

--- a/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/hivemind.lua
@@ -87,7 +87,7 @@ end)
 
 hook.Add("TTTStopPlayerRespawning", "HiveMind_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("HiveMindRespawning", false) then
         timer.Remove("HiveMindRespawn_" .. ply:SteamID64())

--- a/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
@@ -116,3 +116,12 @@ end)
 AddHook("TTTPrepareRound", "HiveMind_ShopSync_PrepareRound", function()
     table.Empty(ROLE_SHOP_SYNC_ROLES[ROLE_HIVEMIND])
 end)
+
+AddHook("TTTIsPlayerRespawning", "HiveMind_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("HiveMindRespawning", false) then
+        return true
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/hivemind/shared.lua
@@ -119,7 +119,7 @@ end)
 
 AddHook("TTTIsPlayerRespawning", "HiveMind_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("HiveMindRespawning", false) then
         return true

--- a/gamemodes/terrortown/gamemode/roles/infected/infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/infected.lua
@@ -139,11 +139,22 @@ hook.Add("PlayerDeath", "Infected_KillCheck_PlayerDeath", function(victim, infl,
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if not valid_kill then return end
     if not victim:IsInfected() then return end
+
     victim:SetNWBool("InfectedIsZombifying", true)
-    timer.Simple(0.25, function()
+    timer.Create("Infectify_" .. victim:SteamID64(), 0.25, 1, function()
         InfectedSuccumb(victim, true)
         victim:SetNWBool("InfectedIsZombifying", false)
     end)
+end)
+
+hook.Add("TTTStopPlayerRespawning", "Infected_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("InfectedIsZombifying", false) then
+        timer.Remove("Infectify_" .. ply:SteamID64())
+        ply:SetNWBool("InfectedIsZombifying", false)
+    end
 end)
 
 -----------------------
@@ -168,5 +179,6 @@ end)
 hook.Add("TTTPrepareRound", "Infected_PrepareRound", function()
     for _, v in PlayerIterator() do
         v:SetNWBool("InfectedIsZombifying", false)
+        timer.Remove("Infectify_" .. v:SteamID64())
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/infected/infected.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/infected.lua
@@ -149,7 +149,7 @@ end)
 
 hook.Add("TTTStopPlayerRespawning", "Infected_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("InfectedIsZombifying", false) then
         timer.Remove("Infectify_" .. ply:SteamID64())

--- a/gamemodes/terrortown/gamemode/roles/infected/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/shared.lua
@@ -2,6 +2,16 @@ AddCSLuaFile()
 
 local table = table
 
+-- Initialize role features
+hook.Add("TTTIsPlayerRespawning", "Infected_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("InfectedIsZombifying", false) then
+        return true
+    end
+end)
+
 ------------------
 -- ROLE CONVARS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/infected/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/infected/shared.lua
@@ -5,7 +5,7 @@ local table = table
 -- Initialize role features
 hook.Add("TTTIsPlayerRespawning", "Infected_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("InfectedIsZombifying", false) then
         return true

--- a/gamemodes/terrortown/gamemode/roles/medium/medium.lua
+++ b/gamemodes/terrortown/gamemode/roles/medium/medium.lua
@@ -90,8 +90,8 @@ hook.Add("PlayerDeath", "Medium_Spirits_PlayerDeath", function(victim, infl, att
         spirit:Spawn()
         spirits[victim:SteamID64()] = spirit
 
-        -- If there is a medium in the round, let the player who died know there is a medium as long as this player isn't the only medium and they are not turning into a zombie
-        if medium_dead_notify:GetBool() and mediumCount > 0 and (mediumCount > 1 or not victim:IsMedium()) and not victim:IsZombifying() then
+        -- If there is a medium in the round, let the player who died know there is a medium as long as this player isn't the only medium and they are not respawning
+        if medium_dead_notify:GetBool() and mediumCount > 0 and (mediumCount > 1 or not victim:IsMedium()) and not victim:IsRespawning() then
             victim:QueueMessage(MSG_PRINTBOTH, "The " .. ROLE_STRINGS[ROLE_MEDIUM] .. " senses your spirit.")
         end
 

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -214,7 +214,7 @@ end
 
 hook.Add("PlayerDeath", "Parasite_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
-    if valid_kill and victim:IsParasite() and not victim:IsZombifying() then
+    if valid_kill and victim:IsParasite() and not attacker:IsVictimChangingRole(victim) then
         if not attacker:IsActive() then
             victim:QueueMessage(MSG_PRINTBOTH, "Your attacker is already dead, your infection failed to take hold.")
             return

--- a/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
+++ b/gamemodes/terrortown/gamemode/roles/phantom/phantom.lua
@@ -105,7 +105,7 @@ hook.Add("PlayerDeath", "Phantom_PlayerDeath", function(victim, infl, attacker)
     local valid_kill = IsPlayer(attacker) and attacker ~= victim and GetRoundState() == ROUND_ACTIVE
     if valid_kill and victim:IsPhantom() then
         local attacker_alive = attacker:IsActive()
-        local will_posses = phantom_killer_haunt:GetBool() and not victim:IsZombifying() and attacker_alive
+        local will_posses = phantom_killer_haunt:GetBool() and not attacker:IsVictimChangingRole(victim) and attacker_alive
 
         -- Only bother looking this up if we're going to use it
         local loverSID = ""
@@ -121,7 +121,7 @@ hook.Add("PlayerDeath", "Phantom_PlayerDeath", function(victim, infl, attacker)
             end
         end
 
-        if victim:IsZombifying() then return end
+        if attacker:IsVictimChangingRole(victim) then return end
 
         if not attacker_alive then
             victim:QueueMessage(MSG_PRINTBOTH, "Your attacker is already dead so you have nobody to haunt.")

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -385,7 +385,7 @@ hook.Add("PostPlayerDeath", "Shadow_Buff_PostPlayerDeath", function(ply)
     timer.Remove("TTTShadowRegenTimer_" .. ply:SteamID64())
 end)
 
-hook.Add("TTTStopPlayerRespawning", "Zombie_TTTStopPlayerRespawning", function(ply)
+hook.Add("TTTStopPlayerRespawning", "Shadow_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
     if not ply:Alive() or ply:IsSpec() then return end
 

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -387,7 +387,7 @@ end)
 
 hook.Add("TTTStopPlayerRespawning", "Shadow_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("ShadowTargetRespawning", false) then
         -- Find all buff timers for this player and end them

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -145,6 +145,7 @@ local function ClearShadowState(ply)
     ply:SetNWFloat("ShadowBuffTimer", -1)
     ply:SetNWBool("ShadowBuffActive", false)
     ply:SetNWBool("ShadowBuffDepleted", false)
+    ply:SetNWBool("ShadowTargetRespawning", false)
     timer.Remove("TTTShadowWeakenTimer_" .. ply:SteamID64())
     timer.Remove("TTTShadowRegenTimer_" .. ply:SteamID64())
 end
@@ -349,6 +350,7 @@ hook.Add("PostPlayerDeath", "Shadow_Buff_PostPlayerDeath", function(ply)
             ply:QueueMessage(MSG_PRINTBOTH, "Your " .. ROLE_STRINGS[ROLE_SHADOW] .. " will respawn you in " .. respawnDelay .. " seconds")
         end
 
+        ply:SetNWBool("ShadowTargetRespawning", true)
         local timerId = "TTTShadowBuffTimer_" .. shadow:SteamID64() .. "_" .. ply:SteamID64()
         timer.Create(timerId, respawnDelay, 1, function()
             if not IsValid(ply) or ply:Alive() or not ply:IsSpec() then return end
@@ -356,6 +358,7 @@ hook.Add("PostPlayerDeath", "Shadow_Buff_PostPlayerDeath", function(ply)
             -- Respawn them on their body so the shadow doesn't get screwed over
             local corpse = ply.server_ragdoll or ply:GetRagdollEntity()
             ply:SetNWBool("ShadowBuffDepleted", true)
+            ply:SetNWBool("ShadowTargetRespawning", false)
             ply:SpawnForRound(true)
             ply:SetPos(FindRespawnLocation(corpse:GetPos()) or corpse:GetPos())
             ply:SetEyeAngles(Angle(0, corpse:GetAngles().y, 0))

--- a/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
@@ -317,3 +317,12 @@ hook.Add("TTTUpdateRoleState", "Shadow_TTTUpdateRoleState", function()
     JESTER_ROLES[ROLE_SHADOW] = is_jester
     INDEPENDENT_ROLES[ROLE_SHADOW] = not is_jester
 end)
+
+hook.Add("TTTIsPlayerRespawning", "Shadow_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("ShadowTargetRespawning", false) then
+        return true
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shared.lua
@@ -320,7 +320,7 @@ end)
 
 hook.Add("TTTIsPlayerRespawning", "Shadow_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("ShadowTargetRespawning", false) then
         return true

--- a/gamemodes/terrortown/gamemode/roles/spy/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/spy/shared.lua
@@ -41,11 +41,11 @@ end)
 -- ROLE CONVARS --
 ------------------
 
-CreateConVar("ttt_spy_steal_model", "1", FCVAR_REPLICATED)
-local spy_steal_name = CreateConVar("ttt_spy_steal_name", "1", FCVAR_REPLICATED)
-local spy_flare_gun_loadout = CreateConVar("ttt_spy_flare_gun_loadout", "1", FCVAR_REPLICATED)
-local spy_flare_gun_shop = CreateConVar("ttt_spy_flare_gun_shop", "0", FCVAR_REPLICATED)
-local spy_flare_gun_shop_rebuyable = CreateConVar("ttt_spy_flare_gun_shop_rebuyable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_spy_steal_model", "1", FCVAR_REPLICATED, "Whether the spy should change to the victim's playermodel after killing a player", 0, 1)
+local spy_steal_name = CreateConVar("ttt_spy_steal_name", "1", FCVAR_REPLICATED, "Whether the spy should change to the victim's name after killing a player (When other players look at the spy and see their info under the crosshair)", 0, 1)
+local spy_flare_gun_loadout = CreateConVar("ttt_spy_flare_gun_loadout", "1", FCVAR_REPLICATED, "Whether the spy should have a flare gun given to them when they spawn. Server must be restarted for changes to take effect", 0, 1)
+local spy_flare_gun_shop = CreateConVar("ttt_spy_flare_gun_shop", "0", FCVAR_REPLICATED, "Whether the spy should have a flare gun be purchasable in the shop. Server must be restarted for changes to take effect", 0, 1)
+local spy_flare_gun_shop_rebuyable = CreateConVar("ttt_spy_flare_gun_shop_rebuyable", "0", FCVAR_REPLICATED, "Whether the spy should be able to purchase the flare gun multiple times (requires \"ttt_spy_flare_gun_shop\" to be enabled). Server must be restarted for changes to take effect", 0, 1)
 
 ROLE_CONVARS[ROLE_SPY] = {}
 table.insert(ROLE_CONVARS[ROLE_SPY], {
@@ -62,6 +62,10 @@ table.insert(ROLE_CONVARS[ROLE_SPY], {
 })
 table.insert(ROLE_CONVARS[ROLE_SPY], {
     cvar = "ttt_spy_steal_name",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_SPY], {
+    cvar = "ttt_spy_steal_from_respawning",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_SPY], {

--- a/gamemodes/terrortown/gamemode/roles/spy/spy.lua
+++ b/gamemodes/terrortown/gamemode/roles/spy/spy.lua
@@ -12,8 +12,9 @@ local SetMDL = FindMetaTable("Entity").SetModel
 -- CONVARS --
 -------------
 
-local spy_steal_model_hands = CreateConVar("ttt_spy_steal_model_hands", "1")
-local spy_steal_model_alert = CreateConVar("ttt_spy_steal_model_alert", "1")
+local spy_steal_model_hands = CreateConVar("ttt_spy_steal_model_hands", "1", FCVAR_NONE, "Whether the spy should change to the victim's playermodel's 1st-person hands after killing a player", 0, 1)
+local spy_steal_model_alert = CreateConVar("ttt_spy_steal_model_alert", "1", FCVAR_NONE, "Whether the spy should see an alert message displaying who they are disguised as after killing a player", 0, 1)
+local spy_steal_from_respawning = CreateConVar("ttt_spy_steal_from_respawning", "1", FCVAR_NONE, "Whether the spy should steal the identity of their victim even if that player is respawning", 0, 1)
 
 local spy_steal_model = GetConVar("ttt_spy_steal_model")
 local spy_steal_name = GetConVar("ttt_spy_steal_name")
@@ -38,57 +39,58 @@ local playerModels = {}
 -- The spy steals the identity of the victim on killing a player
 hook.Add("PlayerDeath", "Spy_PlayerDeath", function(victim, inflictor, attacker)
     if not IsPlayer(attacker) or attacker == victim or GetRoundState() ~= ROUND_ACTIVE then return end
+    if not attacker:IsSpy() then return end
+    -- Don't steal the identity of players who are respawning if we're told not to do that
+    if not spy_steal_from_respawning:GetBool() and victim:IsRespawning() then return end
 
-    if attacker:IsSpy() and not victim:IsZombifying() then
-        local stealModel = spy_steal_model:GetBool()
-        local stealHands = spy_steal_model_hands:GetBool()
+    local stealModel = spy_steal_model:GetBool()
+    local stealHands = spy_steal_model_hands:GetBool()
 
-        -- Stealing model
-        if stealModel then
-            local attackerSid64 = attacker:SteamID64()
+    -- Stealing model
+    if stealModel then
+        local attackerSid64 = attacker:SteamID64()
 
-            -- If the spy hasn't swapped models yet, we need to store their original model
-            if not playerModels[attackerSid64] then
-                playerModels[attackerSid64] = {
-                    model = attacker:GetModel(),
-                    skin = attacker:GetSkin(),
-                    bodygroups = {},
-                    color = attacker:GetColor()
-                }
+        -- If the spy hasn't swapped models yet, we need to store their original model
+        if not playerModels[attackerSid64] then
+            playerModels[attackerSid64] = {
+                model = attacker:GetModel(),
+                skin = attacker:GetSkin(),
+                bodygroups = {},
+                color = attacker:GetColor()
+            }
 
-                for _, value in pairs(attacker:GetBodyGroups()) do
-                    playerModels[attackerSid64].bodygroups[value.id] = attacker:GetBodygroup(value.id)
+            for _, value in pairs(attacker:GetBodyGroups()) do
+                playerModels[attackerSid64].bodygroups[value.id] = attacker:GetBodygroup(value.id)
+            end
+        end
+
+        SetMDL(attacker, victim:GetModel())
+        attacker:SetSkin(victim:GetSkin())
+        attacker:SetColor(victim:GetColor())
+        for _, value in pairs(victim:GetBodyGroups()) do
+            attacker:SetBodygroup(value.id, victim:GetBodygroup(value.id))
+        end
+
+        -- Stealing 1st-person hands (There is no point in doing this if stealing model is not enabled)
+        if stealHands then
+            timer.Simple(0.1, function()
+                if IsValid(attacker) then
+                    attacker:SetupHands()
                 end
-            end
-
-            SetMDL(attacker, victim:GetModel())
-            attacker:SetSkin(victim:GetSkin())
-            attacker:SetColor(victim:GetColor())
-            for _, value in pairs(victim:GetBodyGroups()) do
-                attacker:SetBodygroup(value.id, victim:GetBodygroup(value.id))
-            end
-
-            -- Stealing 1st-person hands (There is no point in doing this if stealing model is not enabled)
-            if stealHands then
-                timer.Simple(0.1, function()
-                    if IsValid(attacker) then
-                        attacker:SetupHands()
-                    end
-                end)
-            end
+            end)
         end
+    end
 
-        -- Stealing Name
-        local stealName = spy_steal_name:GetBool()
+    -- Stealing Name
+    local stealName = spy_steal_name:GetBool()
 
-        if stealName then
-            attacker:SetNWString("TTTSpyDisguiseName", victim:GetName())
-        end
+    if stealName then
+        attacker:SetNWString("TTTSpyDisguiseName", victim:GetName())
+    end
 
-        -- Displaying alert message on who the spy is now disguised as
-        if spy_steal_model_alert:GetBool() and (stealModel or stealName) then
-            attacker:QueueMessage(MSG_PRINTBOTH, "Disguised as " .. victim:Nick())
-        end
+    -- Displaying alert message on who the spy is now disguised as
+    if spy_steal_model_alert:GetBool() and (stealModel or stealName) then
+        attacker:QueueMessage(MSG_PRINTBOTH, "Disguised as " .. victim:Nick())
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/swapper/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/shared.lua
@@ -7,6 +7,16 @@ SWAPPER_WEAPON_NONE = 0
 SWAPPER_WEAPON_ROLE = 1
 SWAPPER_WEAPON_ALL = 2
 
+-- Initialize role features
+hook.Add("TTTIsPlayerRespawning", "Swapper_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("IsSwapping", false) then
+        return true
+    end
+end)
+
 ------------------
 -- ROLE CONVARS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/swapper/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/shared.lua
@@ -10,7 +10,7 @@ SWAPPER_WEAPON_ALL = 2
 -- Initialize role features
 hook.Add("TTTIsPlayerRespawning", "Swapper_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("IsSwapping", false) then
         return true

--- a/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
@@ -256,7 +256,7 @@ end)
 
 hook.Add("TTTStopPlayerRespawning", "Swapper_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("IsSwapping", false) then
         timer.Remove("Swapping_" .. ply:SteamID64())

--- a/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
@@ -154,7 +154,7 @@ hook.Add("PlayerDeath", "Swapper_KillCheck_PlayerDeath", function(victim, infl, 
     end
     local victim_weapons = GetPlayerWeaponInfo(victim)
 
-    timer.Simple(0.01, function()
+    timer.Create("Swapping_" .. victim:SteamID64(), 0.01, 1, function()
         local body = victim.server_ragdoll or victim:GetRagdollEntity()
         victim:SetRole(attacker:GetRole())
         victim:SpawnForRound(true)
@@ -254,6 +254,16 @@ hook.Add("PlayerDeath", "Swapper_KillCheck_PlayerDeath", function(victim, infl, 
     net.Broadcast()
 end)
 
+hook.Add("TTTStopPlayerRespawning", "Swapper_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("IsSwapping", false) then
+        timer.Remove("Swapping_" .. ply:SteamID64())
+        ply:SetNWBool("IsSwapping", false)
+    end
+end)
+
 hook.Add("TTTCupidShouldLoverSurvive", "Swapper_TTTCupidShouldLoverSurvive", function(ply, lover)
     if ply:GetNWBool("IsSwapping", false) or lover:GetNWBool("IsSwapping", false) then
         return true
@@ -264,5 +274,6 @@ hook.Add("TTTPrepareRound", "Swapper_PrepareRound", function()
     for _, v in PlayerIterator() do
         v:SetNWString("SwappedWith", "")
         v:SetNWBool("IsSwapping", false)
+        timer.Remove("Swapping_" .. v:SteamID64())
     end
 end)

--- a/gamemodes/terrortown/gamemode/roles/vindicator/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/shared.lua
@@ -14,7 +14,7 @@ end
 
 hook.Add("TTTIsPlayerRespawning", "Vindicator_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("VindicatorIsRespawning", false) then
         return true

--- a/gamemodes/terrortown/gamemode/roles/vindicator/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/shared.lua
@@ -12,6 +12,15 @@ ROLE_IS_ACTIVE[ROLE_VINDICATOR] = function(ply)
     return ply:IsIndependentTeam()
 end
 
+hook.Add("TTTIsPlayerRespawning", "Vindicator_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("VindicatorIsRespawning", false) then
+        return true
+    end
+end)
+
 function SetVindicatorTeam(independent)
     INDEPENDENT_ROLES[ROLE_VINDICATOR] = independent
     INNOCENT_ROLES[ROLE_VINDICATOR] = not independent

--- a/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
@@ -158,6 +158,16 @@ hook.Add("PlayerDeath", "Vindicator_PlayerDeath", function(victim, infl, attacke
     end
 end)
 
+hook.Add("TTTStopPlayerRespawning", "Vindicator_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:GetNWBool("VindicatorIsRespawning", false) then
+        timer.Remove("VindicatorRespawn" .. ply:SteamID64())
+        ply:SetNWBool("VindicatorIsRespawning", false)
+    end
+end)
+
 hook.Add("TTTDeathNotifyOverride", "Vindicator_TTTDeathNotifyOverride", function(victim, inflictor, attacker, reason, killerName, role)
     if GetRoundState() ~= ROUND_ACTIVE then return end
     if not IsValid(inflictor) or not IsValid(attacker) then return end

--- a/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
@@ -36,6 +36,7 @@ local function ActivateVindicator(vindicator, target)
     -- Change their team and set their target even if the target is already dead
     SetVindicatorTeam(true)
     vindicator:SetNWString("VindicatorTarget", target:SteamID64())
+    vindicator:SetNWBool("VindicatorIsRespawning", false)
 
     net.Start("TTT_VindicatorActive")
     net.WriteString(vindicator:Nick())
@@ -96,6 +97,8 @@ hook.Add("PlayerDeath", "Vindicator_PlayerDeath", function(victim, infl, attacke
     if valid_kill then
         if victim:IsVindicator() and not victim:IsRoleActive() and attacker ~= victim then
             if attacker:IsVictimChangingRole(victim) then return end
+
+            victim:SetNWBool("VindicatorIsRespawning", true)
 
             local delay = vindicator_respawn_delay:GetInt()
             if delay == 0 then
@@ -299,6 +302,7 @@ hook.Add("TTTPrepareRound", "Vindicator_PrepareRound", function()
     for _, ply in PlayerIterator() do
         ply:SetNWString("VindicatorTarget", "")
         ply:SetNWBool("VindicatorSuccess", false)
+        ply:SetNWBool("VindicatorIsRespawning", false)
         timer.Remove("VindicatorRespawn" .. ply:SteamID64())
     end
     timer.Remove("TTTVindicatorTimer")

--- a/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
@@ -160,7 +160,7 @@ end)
 
 hook.Add("TTTStopPlayerRespawning", "Vindicator_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:GetNWBool("VindicatorIsRespawning", false) then
         timer.Remove("VindicatorRespawn" .. ply:SteamID64())

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -18,6 +18,15 @@ ROLE_VICTIM_CHANGING_ROLE[ROLE_ZOMBIE] = function(ply, victim)
     return victim:IsZombifying()
 end
 
+hook.Add("TTTIsPlayerRespawning", "Zombie_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:IsZombifying() then
+        return true
+    end
+end)
+
 hook.Add("TTTRoleSpawnsArtificially", "Zombie_TTTRoleSpawnsArtificially", function(role)
     if role == ROLE_ZOMBIE then
         local madScientistEnabled = util.CanRoleSpawn(ROLE_MADSCIENTIST) and

--- a/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/shared.lua
@@ -20,7 +20,7 @@ end
 
 hook.Add("TTTIsPlayerRespawning", "Zombie_TTTIsPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:IsZombifying() then
         return true

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -334,6 +334,16 @@ function plymeta:RespawnAsZombie(prime)
     end)
 end
 
+hook.Add("TTTStopPlayerRespawning", "Zombie_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if not ply:Alive() or ply:IsSpec() then return end
+
+    if ply:IsZombifying() then
+        timer.Remove("Zombify_" .. ply:SteamID64())
+        ply:SetNWBool("IsZombifying", false)
+    end
+end)
+
 hook.Add("TTTCupidShouldLoverSurvive", "Zombie_TTTCupidShouldLoverSurvive", function(ply, lover)
     if ply:IsZombifying() or lover:IsZombifying() then
         return true

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -336,7 +336,7 @@ end
 
 hook.Add("TTTStopPlayerRespawning", "Zombie_TTTStopPlayerRespawning", function(ply)
     if not IsPlayer(ply) then return end
-    if not ply:Alive() or ply:IsSpec() then return end
+    if ply:Alive() then return end
 
     if ply:IsZombifying() then
         timer.Remove("Zombify_" .. ply:SteamID64())

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.11"
+CR_VERSION = "2.1.12"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -177,17 +177,17 @@ ROLE_VINDICATOR = 45
 ROLE_MAX = 45
 ROLE_EXTERNAL_START = ROLE_MAX + 1
 
-local function AddRoleAssociations(list, roles)
+local function AddRoleAssociations(tbl, roles)
     -- Use an associative array so we can do a O(1) lookup by role
     -- See: https://wiki.facepunch.com/gmod/table.HasValue
     for _, r in ipairs(roles) do
-        list[r] = true
+        tbl[r] = true
     end
 end
 
-function GetTeamRoles(list, excludes)
+function GetTeamRoles(tbl, excludes)
     local roles = {}
-    for r, v in pairs(list) do
+    for r, v in pairs(tbl) do
         if v and (not excludes or not excludes[r]) then
             table.insert(roles, r)
         end

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -806,6 +806,7 @@ end
 -- If this logic or the list of roles who can buy is changed, it must also be updated in OrderEquipment above and cl_equip.lua
 -- This also sends a cache reset request to every client so that things like shop randomization happen every round
 function WEPS.HandleRoleEquipment(ply)
+    loadout_weapons = nil
     local handled = false
     for id, name in pairs(ROLE_STRINGS_RAW) do
         WEPS.PrepWeaponsLists(id)


### PR DESCRIPTION
## Changelog
### Additions
- Added ability for DNA Scanner to be given to all detective roles (disabled by default)
  - When disabled, only the vanilla Detective role will be given the DNA scanner as part of their loadout
- Added ability to disable DNA Scanner from being dropped, except for when the player holding it dies (disabled by default)
- Added ability to allow any player holding the DNA scanner to search bodies as if they were a detective (disabled by default)
- Added ability to control whether a spy who kills a respawning player will steal their identity anyway (enabled by default)

### Fixes
- Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps
- Fixed potential issues when a parasite or phantom is killed by a role that changes their victim's role

### Developer
- Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook
- Added `plymeta:StopRespawning` fed by the new `TTTStopPlayerRespawning` hook
- Added ability to open role tutorial to a specific role via `HELPSCRN:OpenRoleTutorial(ROLE_ID)`

## Affected Issues
#695
#713

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
  - https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX/pull/111