### PR TITLE
Misc. additions

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -301,6 +301,8 @@ ttt_parasite_announce_infection                0       // Whether players are no
 ttt_parasite_cure_mode                         2       // How to handle using a parasite cure on someone who is not infected. 0 - Kill nobody (But use up the cure), 1 - Kill the person who uses the cure, 2 - Kill the person the cure is used on
 ttt_parasite_cure_time                         3       // The amount of time (in seconds) the parasite cure takes to use
 ttt_parasite_infection_saves_lover             1       // Whether the parasite's lover should survive if the parasite is infecting a player
+ttt_parasite_killer_smoke                      0       // Whether to show smoke on the player who killed the parasite
+ttt_parasite_killer_footstep_time              0       // The amount of time a parasite's killer's footsteps should show before fading. Set to 0 to disable
 ttt_parasite_credits_starting                  1       // The number of credits a parasite should start with
 ttt_single_phantom_parasite                    0       // Whether only a single phantom or parasite should spawn in a round
 ttt_single_phantom_parasite_chance             0.5     // The chance that a phantom should have an opportunity to spawn instead of a parasite (e.g. 0.7 = 70% chance for phantom, 30% chance for parasite. Only applies if ttt_single_phantom_parasite is enabled)

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -850,6 +850,9 @@ ttt_arsonist_douse_corpses                     1       // Whether the Arsonist c
 ttt_arsonist_douse_require_los                 1       // Whether the Arsonist requires line of sight with their target in order to douse them
 ttt_arsonist_can_see_jesters                   1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the arsonist
 ttt_arsonist_update_scoreboard                 1       // Whether the arsonist shows dead players as missing in action
+ttt_arsonist_ignite_on_death                   0       // Whether to allow the arsonist to enable automatic triggering of their igniter on death
+ttt_arsonist_ignite_on_death_timer             0       // How long after the arsonist's death to trigger their igniter. Set to 0 to trigger instantly
+ttt_arsonist_ignite_on_death_notify            1       // Whether to notify other players that the arsonist's igniter is going to be triggered
 ttt_detectives_search_only_arsonistdouse       0       // Whether only detectives can see information about whether a corpse was doused by an arsonist and when. Once a detective searches a body, this information will be available to all players. Ignored when "ttt_detectives_search_only" is enabled.
 
 // Hive Mind

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -1140,19 +1140,22 @@ The below role settings are for each player to set individually. They are all av
 
 // TRAITOR TEAM SETTINGS
 // Informant
-ttt_informant_show_scan_radius              0       // Whether to show the ring that shows the approximate radius of the informant's scanner
+ttt_informant_show_scan_radius                 0       // Whether to show the ring that shows the approximate radius of the informant's scanner
 
 // JESTER TEAM SETTINGS
 // Beggar
-ttt_beggar_show_scan_radius                 0       // Whether to show the ring that shows the approximate radius of the beggar's traitor scanner (when it's enabled)
+ttt_beggar_show_scan_radius                    0       // Whether to show the ring that shows the approximate radius of the beggar's traitor scanner (when it's enabled)
+
+// Cupid
+ttt_cupid_bow_viewbob                          1       // Whether viewbob should be enabled for the cupid bow
 
 // Loot Goblin
-ttt_lootgoblin_radar_beep_sound             1       // Whether to play a sound when the loot goblin radar location updates
+ttt_lootgoblin_radar_beep_sound                1       // Whether to play a sound when the loot goblin radar location updates
 
 // ----------------------------------------
 // Misc.
 // ----------------------------------------
-ttt_distance_unit                           1       // What unit to use when displaying distance. 0 - None (Source). 1 - Meters. 2 - Feet
+ttt_distance_unit                              1       // What unit to use when displaying distance. 0 - None (Source). 1 - Meters. 2 - Feet
 ```
 
 ## Role Weapon Shop

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -1149,9 +1149,6 @@ ttt_informant_show_scan_radius                 0       // Whether to show the ri
 // Beggar
 ttt_beggar_show_scan_radius                    0       // Whether to show the ring that shows the approximate radius of the beggar's traitor scanner (when it's enabled)
 
-// Cupid
-ttt_cupid_bow_viewbob                          1       // Whether viewbob should be enabled for the cupid bow
-
 // Loot Goblin
 ttt_lootgoblin_radar_beep_sound                1       // Whether to play a sound when the loot goblin radar location updates
 

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -290,9 +290,9 @@ ttt_single_doctor_quack_chance                 0.5     // The chance that a doct
 
 // Parasite
 ttt_parasite_is_monster                        0       // Whether the parasite should be treated as a member of the monster team (rather than the traitor team)
-ttt_parasite_infection_time                    45      // The time it takes in seconds for the parasite to fully infect someone
+ttt_parasite_infection_time                    45      // The time it takes in seconds for the parasite to fully infect someone. Set to 0 to only respawn the parasite when their killer is killed
 ttt_parasite_infection_warning_time            0       // The time in seconds after infection to warn the victim with an ambiguous message. Set to 0 to disable.
-ttt_parasite_infection_transfer                0       // Whether the parasite's infection will transfer if the parasite's killer is killed by another player
+ttt_parasite_infection_transfer                0       // Whether the parasite's infection will transfer if the parasite's killer is killed by another player. Only used when ttt_parasite_infection_time is higher than 0
 ttt_parasite_infection_transfer_reset          1       // Whether the parasite's infection progress will reset if their infection is transferred to another player
 ttt_parasite_infection_suicide_mode            0       // The way to handle when a player infected by the parasite kills themselves. 0 - Do nothing. 1 - Respawn the parasite. 2 - Respawn the parasite ONLY IF the infected player killed themselves with a console command like "kill"
 ttt_parasite_respawn_mode                      0       // The way in which the parasite respawns. 0 - Take over host. 1 - Respawn at the parasite's body. 2 - Respawn at a random location.
@@ -328,7 +328,7 @@ ttt_spy_steal_name                             1       // Whether the spy should
 ttt_spy_steal_from_respawning                  1       // Whether the spy should steal the identity of their victim even if that player is respawning
 ttt_spy_flare_gun_loadout                      1       // Whether the spy should have a flare gun given to them when they spawn. Server must be restarted for changes to take effect
 ttt_spy_flare_gun_shop                         0       // Whether the spy should have a flare gun be purchasable in the shop. Server must be restarted for changes to take effect
-ttt_spy_flare_gun_shop_rebuyable               0       // Whether the spy should be able to purchase the flare gun multiple times (requires "ttt_spy_flare_gun_shop" to be enabled). Server must be restarted for changes to take effect
+ttt_spy_flare_gun_shop_rebuyable               0       // Whether the spy should be able to purchase the flare gun multiple times (Requires "ttt_spy_flare_gun_shop" to be enabled). Server must be restarted for changes to take effect
 
 // ----------------------------------------
 

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -297,6 +297,7 @@ ttt_parasite_infection_transfer_reset          1       // Whether the parasite's
 ttt_parasite_infection_suicide_mode            0       // The way to handle when a player infected by the parasite kills themselves. 0 - Do nothing. 1 - Respawn the parasite. 2 - Respawn the parasite ONLY IF the infected player killed themselves with a console command like "kill"
 ttt_parasite_respawn_mode                      0       // The way in which the parasite respawns. 0 - Take over host. 1 - Respawn at the parasite's body. 2 - Respawn at a random location.
 ttt_parasite_respawn_health                    100     // The health on which the parasite respawns
+ttt_parasite_respawn_limit                     0       // The amount of times a parasite can respawn. Set to 0 to have no limit
 ttt_parasite_announce_infection                0       // Whether players are notified immediately when they are infected with the parasite
 ttt_parasite_cure_mode                         2       // How to handle using a parasite cure on someone who is not infected. 0 - Kill nobody (But use up the cure), 1 - Kill the person who uses the cure, 2 - Kill the person the cure is used on
 ttt_parasite_cure_time                         3       // The amount of time (in seconds) the parasite cure takes to use

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,7 @@
   - Automatic trigger can be configured to be on a delay, allowing other players to find and deactivate the igniter
   - Notifications on when the auto-trigger activates can be disabled by configuration as well
 - Added ability for players to disable the view bob on cupid's bow from the cupid section of the roles tab in the F1 menu
+- Added ability for parasite to only respawn when their host is killed, similar to the phantom (disabled by default)
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,6 +28,7 @@
 - Added ability for players to disable the view bob on cupid's bow from the cupid section of the roles tab in the F1 menu
 - Added ability for parasite to only respawn when their host is killed, similar to the phantom (disabled by default)
 - Added ability for parasite's killer to smoke and leave behind footprints, like a phantom's killer (both disabled by default)
+- Added ability to limit the number of times the parasite can respawn (disabled by default)
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,6 @@
 - Added ability for the arsonist to activate their igniter so it automatically triggers upon their death (disabled by default)
   - Automatic trigger can be configured to be on a delay, allowing other players to find and deactivate the igniter
   - Notifications on when the auto-trigger activates can be disabled by configuration as well
-- Added ability for players to disable the view bob on cupid's bow from the cupid section of the roles tab in the F1 menu
 - Added ability for parasite to only respawn when their host is killed, similar to the phantom (disabled by default)
 - Added ability for parasite's killer to smoke and leave behind footprints, like a phantom's killer (both disabled by default)
 - Added ability to limit the number of times the parasite can respawn (disabled by default)
@@ -34,6 +33,7 @@
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused
 - Changed sort order of items when searching a body so that important information is displayed in a consistent order
 - Changed players who use a "kill" console command to not kill their paired cupid lover
+- Removed view bob and sway on cupid's bow to be consistent with other role weapons
 
 ### Fixes
 - Fixed not being able to change role loadouts using `ttt_roleweapons` or `ttt_rolepacks` without changing maps

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,7 @@
 - Added ability for the arsonist to activate their igniter so it automatically triggers upon their death (disabled by default)
   - Automatic trigger can be configured to be on a delay, allowing other players to find and deactivate the igniter
   - Notifications on when the auto-trigger activates can be disabled by configuration as well
+- Added ability for players to disable the view bob on cupid's bow from the cupid section of the roles tab in the F1 menu
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,9 @@
     - This allows the granularity to do something like: Show the team info if a traitor is killed only by a monster or independent
   - Plain text that explicitly states the killer's team can also be enabled in addition to the flavor text
 - Added ability to make the shadow target buff progress bar resumable if they get too far away from their target for a short time (disabled by default)
+- Added ability for the arsonist to activate their igniter so it automatically triggers upon their death (disabled by default)
+  - Automatic trigger can be configured to be on a delay, allowing other players to find and deactivate the igniter
+  - Notifications on when the auto-trigger activates can be disabled by configuration as well
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,6 +27,7 @@
   - Notifications on when the auto-trigger activates can be disabled by configuration as well
 - Added ability for players to disable the view bob on cupid's bow from the cupid section of the roles tab in the F1 menu
 - Added ability for parasite to only respawn when their host is killed, similar to the phantom (disabled by default)
+- Added ability for parasite's killer to smoke and leave behind footprints, like a phantom's killer (both disabled by default)
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -212,6 +212,24 @@
                             <td>Whether to allow the Arsonist to use their igniter without dousing everyone first.</td>
                         </tr>
                         <tr>
+                            <td>ttt_arsonist_ignite_on_death <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether to allow the arsonist to enable automatic triggering of their igniter on death</td>
+                        </tr>
+                        <tr>
+                            <td>ttt_arsonist_ignite_on_death_timer <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Integer</td>
+                            <td>How long after the arsonist's death to trigger their igniter. Set to 0 to trigger instantly</td>
+                        </tr>
+                        <tr>
+                            <td>ttt_arsonist_ignite_on_death_notify <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether to notify other players that the arsonist's igniter is going to be triggered</td>
+                        </tr>
+                        <tr>
                             <td>ttt_arsonist_update_scoreboard</td>
                             <td>1</td>
                             <td>Boolean</td>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -683,6 +683,12 @@
                             <td>The health on which the Parasite respawns.</td>
                         </tr>
                         <tr>
+                            <td>ttt_parasite_respawn_limit <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Integer</td>
+                            <td>The amount of times a Parasite can respawn. Set to 0 to have no limit.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_parasite_respawn_mode</td>
                             <td>0</td>
                             <td>Integer (0-2)</td>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -638,13 +638,13 @@
                             <td>ttt_parasite_infection_time</td>
                             <td>45</td>
                             <td>Integer</td>
-                            <td>The time it takes in seconds for the Parasite to fully infect someone.</td>
+                            <td>The time it takes in seconds for the Parasite to fully infect someone. Set to 0 to only respawn the parasite when their killer is killed <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span>.</td>
                         </tr>
                         <tr>
                             <td>ttt_parasite_infection_transfer</td>
                             <td>0</td>
                             <td>Boolean</td>
-                            <td>Whether the Parasite's infection will transfer if the Parasite's killer is killed by another player.</td>
+                            <td>Whether the Parasite's infection will transfer if the Parasite's killer is killed by another player. <i>(Requires <code>ttt_parasite_infection_time</code> to be higher than 0.)</i></td>
                         </tr>
                         <tr>
                             <td>ttt_parasite_infection_transfer_reset</td>
@@ -818,7 +818,7 @@
                             <td>ttt_spy_flare_gun_shop_rebuyable</td>
                             <td>0</td>
                             <td>Boolean</td>
-                            <td>Whether the Spy should be able to purchase the flare gun multiple times. <i>(requires <code>ttt_spy_flare_gun_shop</code> to be enabled. Server must be restarted for changes to take effect.)</i></td>
+                            <td>Whether the Spy should be able to purchase the flare gun multiple times. <i>(Requires <code>ttt_spy_flare_gun_shop</code> to be enabled. Server must be restarted for changes to take effect.)</i></td>
                         </tr>
                         <tr>
                             <td>ttt_spy_steal_from_respawning</td>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -665,6 +665,18 @@
                             <td>Whether the Parasite should be treated as a member of the monster team.</td>
                         </tr>
                         <tr>
+                            <td>ttt_parasite_killer_footstep_time <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Integer</td>
+                            <td>The time in seconds a Parasite's killer's footsteps should show before fading. <i>(Set to 0 to disable.)</i></td>
+                        </tr>
+                        <tr>
+                            <td>ttt_parasite_killer_smoke <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether to show smoke on the player who killed the Parasite.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_parasite_respawn_health</td>
                             <td>100</td>
                             <td>Integer</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_ars_igniter.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ars_igniter.lua
@@ -1,8 +1,10 @@
 AddCSLuaFile()
 
 local player = player
+local table = table
 
 local PlayerIterator = player.Iterator
+local TableInsert = table.insert
 
 if CLIENT then
     SWEP.PrintName          = "Igniter"
@@ -43,7 +45,7 @@ SWEP.Primary.ClipMax        = -1
 SWEP.Primary.DefaultClip    = -1
 SWEP.Primary.Sound          = ""
 
-SWEP.Secondary.Delay        = 1.25
+SWEP.Secondary.Delay        = 1
 SWEP.Secondary.Automatic    = false
 SWEP.Secondary.Cone         = 0
 SWEP.Secondary.Ammo         = nil
@@ -56,20 +58,89 @@ SWEP.InLoadoutFor           = {ROLE_ARSONIST}
 SWEP.InLoadoutForDefault    = {ROLE_ARSONIST}
 
 local arsonist_early_ignite = CreateConVar("ttt_arsonist_early_ignite", "0", FCVAR_REPLICATED, "Whether to allow the arsonist to use their igniter without dousing everyone first", 0, 1)
+local arsonist_ignite_on_death = CreateConVar("ttt_arsonist_ignite_on_death", "0", FCVAR_REPLICATED, "Whether to allow the arsonist to enable automatic triggering of their igniter on death", 0, 1)
+local arsonist_ignite_on_death_timer = CreateConVar("ttt_arsonist_ignite_on_death_timer", "0", FCVAR_REPLICATED, "How long after the arsonist's death to trigger their igniter. Set to 0 to trigger instantly", 0, 180)
+local arsonist_ignite_on_death_notify = CreateConVar("ttt_arsonist_ignite_on_death_notify", "1", FCVAR_REPLICATED, "Whether to notify other players that the arsonist's igniter is going to be triggered", 0, 1)
 if SERVER then
     CreateConVar("ttt_arsonist_corpse_ignite_time", "10", FCVAR_NONE, "The amount of time (in seconds) to ignite doused dead player corpses for before destroying them", 1, 30)
+end
+
+local function NotifyEveryone(message)
+    for _, v in PlayerIterator() do
+        v:QueueMessage(MSG_PRINTBOTH, message)
+    end
 end
 
 function SWEP:Initialize()
     self:SendWeaponAnim(ACT_SLAM_DETONATOR_DRAW)
     if CLIENT then
-        self:AddHUDHelp("arsonistigniter_help_pri", "arsonistigniter_help_sec", true)
+        local secondary_name = "arsonistigniter_help_sec"
+        if arsonist_ignite_on_death:GetBool() then
+            secondary_name = secondary_name .. "_ondeath"
+        end
+        self:AddHUDHelp("arsonistigniter_help_pri", secondary_name, true)
+    elseif arsonist_ignite_on_death:GetBool() then
+        hook.Add("PlayerDeath", "Arsonist_Trigger_PlayerDeath_" .. self:EntIndex(), function(ply, infl, att)
+            if not IsValid(self) then return end
+            -- Don't run this if it hasn't been activated
+            if not self:GetOnDeath() then return end
+
+            if not IsPlayer(ply) then return end
+            -- We only care if an arsonist has been killed and this igniter has been dropped (no owner)
+            if not ply:IsArsonist() or IsValid(self:GetOwner()) then return end
+
+            -- Don't ignite if all players aren't doused unless early ignition is enabled
+            if not arsonist_early_ignite:GetBool() and not ply:GetNWBool("TTTArsonistDouseComplete", false) then
+                ply:QueueMessage(MSG_PRINTBOTH, "Not all players have been doused in gasoline so your igniter does not trigger")
+                return
+            end
+
+            local death_notify = arsonist_ignite_on_death_notify:GetBool()
+            local death_timer = arsonist_ignite_on_death_timer:GetInt()
+            if death_timer > 0 then
+                if death_notify then
+                    NotifyEveryone(string.Capitalize(ROLE_STRINGS_EXT[ROLE_ARSONIST]) .. "'s igniter activated on their death! You have " .. death_timer .. " seconds to find and de-activate it!")
+                end
+                timer.Create("TTTArsonistAutomaticTrigger_" .. self:EntIndex(), death_timer, 1, function()
+                    if death_notify then
+                        NotifyEveryone("The " .. ROLE_STRINGS[ROLE_ARSONIST] .. "'s igniter was not deactivated in time and has triggered!")
+                    end
+                    self:Trigger(self.OrigOwner or ply, not death_notify)
+                end)
+            else
+                if death_notify then
+                    NotifyEveryone(string.Capitalize(ROLE_STRINGS_EXT[ROLE_ARSONIST]) .. "'s igniter triggered on their death!")
+                end
+                self:Trigger(self.OrigOwner or ply, not death_notify)
+            end
+        end)
     end
     return self.BaseClass.Initialize(self)
 end
 
+function SWEP:SetupDataTables()
+    self:NetworkVar("Bool", 0, "OnDeath")
+end
+
+function SWEP:PreDrop()
+    -- Save the original owner so we can use it in case someone else accidentally triggers the ignition
+    self.OrigOwner = self:GetOwner()
+    return self.BaseClass.PreDrop(self)
+end
+
 function SWEP:OnDrop()
+    -- If ignite-on-death is enabled with a delay and it has been activated on this weapon, let the weapon drop
+    -- so another player can pick it up and try to stop it
+    if arsonist_ignite_on_death:GetBool() and arsonist_ignite_on_death_timer:GetInt() > 0 and self:GetOnDeath() then
+        return
+    end
+
     self:Remove()
+end
+
+function SWEP:OnRemove()
+    timer.Remove("TTTArsonistAutomaticTrigger_" .. self:EntIndex())
+    self.OrigOwner = nil
 end
 
 function SWEP:Deploy()
@@ -77,25 +148,7 @@ function SWEP:Deploy()
     return true
 end
 
-function SWEP:PrimaryAttack()
-    if self:GetNextPrimaryFire() > CurTime() then return end
-    self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
-
-    if GetRoundState() ~= ROUND_ACTIVE then return end
-
-    local owner = self:GetOwner()
-    if not IsPlayer(owner) then return end
-
-    -- Don't ignite if all players aren't doused unless early ignition is enabled
-    if not arsonist_early_ignite:GetBool() and not owner:GetNWBool("TTTArsonistDouseComplete", false) then
-        if SERVER then
-            owner:QueueMessage(MSG_PRINTBOTH, "Not all players have been doused in gasoline yet")
-        end
-        return
-    end
-
-    self:SendWeaponAnim(ACT_SLAM_DETONATOR_DETONATE)
-
+function SWEP:Trigger(owner, notify)
     if CLIENT then return end
 
     local corpseIgniteTime = GetConVar("ttt_arsonist_corpse_ignite_time"):GetInt()
@@ -120,27 +173,106 @@ function SWEP:PrimaryAttack()
         -- Normally we would set the inflictor to be the igniter, but since we're destroying it below it won't be valid anymore
         p.ignite_info = {att=owner, infl=owner}
 
-        p:QueueMessage(MSG_PRINTBOTH, "You have been ignited by the " .. ROLE_STRINGS[ROLE_ARSONIST] .. "!")
+        if notify then
+            p:QueueMessage(MSG_PRINTBOTH, "You have been ignited by the " .. ROLE_STRINGS[ROLE_ARSONIST] .. "!")
+        end
 
         -- Remove the notification delay timer since the message above already tells them the same thing
         timer.Remove("TTTArsonistNotifyDelay_" .. p:SteamID64())
     end
 
-    local message = "You have set " .. igniteCount .. " player(s) on fire!"
-    if igniteCount == 0 then
-        message = "No players were doused so your igniter just fizzles out"
-    end
-    owner:QueueMessage(MSG_PRINTBOTH, message)
-
     -- Log the event
     net.Start("TTT_ArsonistIgnited")
     net.Broadcast()
 
-    -- Set the owner as "complete" so we stop dousing players
-    owner:SetNWBool("TTTArsonistDouseComplete", true)
-    owner:SetNWString("TTTArsonistDouseTarget", "")
-    owner:SetNWFloat("TTTArsonistDouseStartTime", -1)
+    -- Make sure this player still exists in case this was called after a delay
+    if IsPlayer(owner) then
+        local message = "You have set " .. igniteCount .. " player(s) on fire!"
+        if igniteCount == 0 then
+            message = "No players were doused so your igniter just fizzles out"
+        end
+        owner:QueueMessage(MSG_PRINTBOTH, message)
+
+        -- Set the owner as "complete" so we stop dousing players
+        owner:SetNWBool("TTTArsonistDouseComplete", true)
+        owner:SetNWString("TTTArsonistDouseTarget", "")
+        owner:SetNWFloat("TTTArsonistDouseStartTime", -1)
+    end
+
     self:Remove()
 end
 
+function SWEP:PrimaryAttack()
+    if self:GetNextPrimaryFire() > CurTime() then return end
+    self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
+
+    if GetRoundState() ~= ROUND_ACTIVE then return end
+
+    local owner = self:GetOwner()
+    if not IsPlayer(owner) then return end
+
+    -- Don't ignite if all players aren't doused unless early ignition is enabled
+    if not arsonist_early_ignite:GetBool() and not owner:GetNWBool("TTTArsonistDouseComplete", false) then
+        if not owner:IsArsonist() then
+            self:SendWeaponAnim(ACT_SLAM_DETONATOR_DETONATE)
+            self:Remove()
+        elseif SERVER then
+            owner:QueueMessage(MSG_PRINTBOTH, "Not all players have been doused in gasoline yet")
+        end
+        return
+    end
+
+    self:SendWeaponAnim(ACT_SLAM_DETONATOR_DETONATE)
+    -- Use the original owner if there is one because that can only be the arsonist this weapon was given to
+    -- at the start of the round and can only be set if the weapon was dropped which can only happen
+    -- when that arsonist was killed
+    self:Trigger(self.OrigOwner or owner, true)
+end
+
+function SWEP:SecondaryAttack()
+    if CLIENT then return end
+    if not arsonist_ignite_on_death:GetBool() then return end
+
+    if self:GetNextSecondaryFire() > CurTime() then return end
+    self:SetNextSecondaryFire(CurTime() + self.Secondary.Delay)
+
+    if GetRoundState() ~= ROUND_ACTIVE then return end
+
+    local owner = self:GetOwner()
+    if not IsPlayer(owner) then return end
+
+    if timer.Exists("TTTArsonistAutomaticTrigger_" .. self:EntIndex()) then
+        self:SetOnDeath(false)
+        if arsonist_ignite_on_death_notify:GetBool() then
+            NotifyEveryone(owner:Nick() .. " has de-activated the " .. ROLE_STRINGS[ROLE_ARSONIST] .. "'s igniter!")
+        end
+        self:Remove()
+    elseif owner:IsArsonist() then
+        self:SetOnDeath(not self:GetOnDeath())
+    end
+end
+
 function SWEP:DryFire() return false end
+
+if CLIENT then
+    hook.Add("TTTHUDInfoPaint", "Arsonist_Igniter_TTTHUDInfoPaint", function(client, label_left, label_top, active_labels)
+        local igniter = client:GetWeapon("weapon_ars_igniter")
+        if not IsValid(igniter) then return end
+        if not igniter:GetOnDeath() then return end
+
+        surface.SetFont("TabLarge")
+        surface.SetTextColor(255, 255, 255, 230)
+
+        local text = LANG.GetTranslation("arsonist_igniter_ondeath_hud")
+        local _, h = surface.GetTextSize(text)
+
+        -- Move this up based on how many other labels here are
+        label_top = label_top + (20 * #active_labels)
+
+        surface.SetTextPos(label_left, ScrH() - label_top - h)
+        surface.DrawText(text)
+
+        -- Track that the label was added so others can position accurately
+        TableInsert(active_labels, "arsonist_igniter")
+    end)
+end

--- a/gamemodes/terrortown/entities/weapons/weapon_cup_bow.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_cup_bow.lua
@@ -270,6 +270,8 @@ if CLIENT then
     SWEP.LastAngles = Angle(0, 0, 0)
     SWEP.AimFOV = 25
 
+    local cupid_bow_viewbob = CreateClientConVar("ttt_cupid_bow_viewbob", "1", true, false, "Whether viewbob should be enabled for the cupid bow", 0, 1)
+
     function SWEP:PreDrawViewModel(vm, wep, ply)
         vm:InvalidateBoneCache()
         vm_angles = vm:GetAngles()
@@ -341,6 +343,10 @@ if CLIENT then
     }
 
     function SWEP:GetViewModelPosition(origin, angles)
+        if not cupid_bow_viewbob:GetBool() then
+            return origin, angles
+        end
+
         local sway_p = math.NormalizeAngle(self.LastAngles.p - EyeAngles().p) * 0.2
         local sway_y = math.NormalizeAngle(self.LastAngles.y - EyeAngles().y) * 0.2
 
@@ -368,7 +374,7 @@ if CLIENT then
     end
 
     function SWEP:CalcView(ply, origin, angles, fov)
-        if ply:GetViewEntity() ~= ply then
+        if ply:GetViewEntity() ~= ply or not cupid_bow_viewbob:GetBool() then
             return
         end
 

--- a/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/cl_arsonist.lua
@@ -18,8 +18,9 @@ local arsonist_early_ignite = GetConVar("ttt_arsonist_early_ignite")
 
 hook.Add("Initialize", "Arsonist_Translations_Initialize", function()
     -- Weapons
-    LANG.AddToLanguage("english", "arsonistigniter_help_pri", "Press {primaryfire} to ignite doused players.")
-    LANG.AddToLanguage("english", "arsonistigniter_help_sec", "Can only be used once")
+    LANG.AddToLanguage("english", "arsonistigniter_help_pri", "Press {primaryfire} to ignite doused players. Can only be used once.")
+    LANG.AddToLanguage("english", "arsonistigniter_help_sec", "")
+    LANG.AddToLanguage("english", "arsonistigniter_help_sec_ondeath", "Press {secondaryfire} to toggle automatic ignition on death.")
 
     -- Body Search
     LANG.AddToLanguage("english", "arsonist_body_doused", "They were doused {time} ago by {anarsonist}!")
@@ -37,6 +38,7 @@ hook.Add("Initialize", "Arsonist_Translations_Initialize", function()
     LANG.AddToLanguage("english", "arsdouse_doused", "DOUSED")
     LANG.AddToLanguage("english", "arsdouse_failed", "DOUSING FAILED")
     LANG.AddToLanguage("english", "arsonist_hud", "Dousing complete. Igniter active.")
+    LANG.AddToLanguage("english", "arsonist_igniter_ondeath_hud", "Igniter on-death trigger active.")
 
     -- Cheat Sheet
     LANG.AddToLanguage("english", "cheatsheet_desc_arsonist", "Can douse players and set them on fire. They win if they are the last player alive.")

--- a/gamemodes/terrortown/gamemode/roles/arsonist/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/arsonist/shared.lua
@@ -92,3 +92,16 @@ table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
     type = ROLE_CONVAR_TYPE_NUM,
     decimal = 0
 })
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_ignite_on_death",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_ignite_on_death_notify",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_ARSONIST], {
+    cvar = "ttt_arsonist_ignite_on_death_timer",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
+})

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -26,6 +26,9 @@ local cupid_lovers_can_damage_cupid = GetConVar("ttt_cupid_lovers_can_damage_cup
 ------------------
 
 AddHook("Initialize", "Cupid_Translations_Initialize", function()
+    -- ConVars
+    LANG.AddToLanguage("english", "cupid_config_bow_viewbob", "Enable viewbob when holding bow")
+
     -- Win conditions
     LANG.AddToLanguage("english", "win_lovers", "The lovers have outlasted everyone!")
     LANG.AddToLanguage("english", "hilite_lovers_primary", "THE LOVERS WIN")
@@ -328,6 +331,17 @@ AddHook("Think", "Cupid_Highlight_Think", function()
     if lover_vision and not vision_enabled then
         RemoveHook("PreDrawHalos", "Cupid_Highlight_PreDrawHalos")
     end
+end)
+
+-------------
+-- CONVARS --
+-------------
+
+hook.Add("TTTSettingsRolesTabSections", "Cupid_TTTSettingsRolesTabSections", function(role, parentForm)
+    if role ~= ROLE_CUPID then return end
+
+    parentForm:CheckBox(LANG.GetTranslation("cupid_config_bow_viewbob"), "ttt_cupid_bow_viewbob")
+    return true
 end)
 
 --------------

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -26,9 +26,6 @@ local cupid_lovers_can_damage_cupid = GetConVar("ttt_cupid_lovers_can_damage_cup
 ------------------
 
 AddHook("Initialize", "Cupid_Translations_Initialize", function()
-    -- ConVars
-    LANG.AddToLanguage("english", "cupid_config_bow_viewbob", "Enable viewbob when holding bow")
-
     -- Win conditions
     LANG.AddToLanguage("english", "win_lovers", "The lovers have outlasted everyone!")
     LANG.AddToLanguage("english", "hilite_lovers_primary", "THE LOVERS WIN")
@@ -331,17 +328,6 @@ AddHook("Think", "Cupid_Highlight_Think", function()
     if lover_vision and not vision_enabled then
         RemoveHook("PreDrawHalos", "Cupid_Highlight_PreDrawHalos")
     end
-end)
-
--------------
--- CONVARS --
--------------
-
-hook.Add("TTTSettingsRolesTabSections", "Cupid_TTTSettingsRolesTabSections", function(role, parentForm)
-    if role ~= ROLE_CUPID then return end
-
-    parentForm:CheckBox(LANG.GetTranslation("cupid_config_bow_viewbob"), "ttt_cupid_bow_viewbob")
-    return true
 end)
 
 --------------

--- a/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
@@ -158,13 +158,15 @@ end
 hook.Add("TTTSpectatorShowHUD", "Parasite_Infecting_TTTSpectatorShowHUD", function(cli, tgt)
     if not cli:IsParasite() then return end
 
+    local max_power = parasite_infection_time:GetInt()
+    if max_power <= 0 then return end
+
     local L = LANG.GetUnsafeLanguageTable()
     local infection_colors = {
         border = COLOR_WHITE,
         background = Color(191, 91, 22, 222),
         fill = Color(255, 127, 39, 255)
     }
-    local max_power = parasite_infection_time:GetInt()
     local current_power = cli:GetNWInt("ParasiteInfectionProgress", 0)
 
     CRHUD:PaintPowersHUD(nil, max_power, current_power, infection_colors, L.infect_title, L.infect_help)
@@ -186,7 +188,11 @@ hook.Add("TTTTutorialRoleText", "Parasite_TTTTutorialRoleText", function(role, t
 
         -- Respawn
         local infection_time = parasite_infection_time:GetInt()
-        html = html .. "<span style='display: block; margin-top: 10px;'>After " .. infection_time .. " seconds, the <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>infection becomes terminal</span>, respawning the " .. ROLE_STRINGS[ROLE_PARASITE] .. " and killing their killer.</span>"
+        if infection_time > 0 then
+            html = html .. "<span style='display: block; margin-top: 10px;'>After " .. infection_time .. " seconds, the <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>infection becomes terminal</span>, respawning the " .. ROLE_STRINGS[ROLE_PARASITE] .. " and killing their killer.</span>"
+        else
+            html = html .. "<span style='display: block; margin-top: 10px;'>The " .. ROLE_STRINGS[ROLE_PARASITE] .. " will <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>be resurrected</span> if the person that killed them then dies.</span>"
+        end
 
         html = html .. "<span style='display: block; margin-top: 10px;'>Members of the <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>traitor team</span> will know who is infected via text when they look at the player or the scoreboard. This helps to let them know <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>not to kill that person</span> which would prevent the " .. ROLE_STRINGS[ROLE_PARASITE] .. " from respawning.</span>"
 

--- a/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/cl_parasite.lua
@@ -13,6 +13,8 @@ local parasite_infection_transfer = GetConVar("ttt_parasite_infection_transfer")
 local parasite_respawn_mode = GetConVar("ttt_parasite_respawn_mode")
 local parasite_announce_infection = GetConVar("ttt_parasite_announce_infection")
 local parasite_infection_suicide_mode = GetConVar("ttt_parasite_infection_suicide_mode")
+local parasite_killer_smoke = GetConVar("ttt_parasite_killer_smoke")
+local parasite_killer_footstep_time = GetConVar("ttt_parasite_killer_footstep_time")
 
 ------------------
 -- TRANSLATIONS --
@@ -172,6 +174,12 @@ hook.Add("TTTSpectatorShowHUD", "Parasite_Infecting_TTTSpectatorShowHUD", functi
     CRHUD:PaintPowersHUD(nil, max_power, current_power, infection_colors, L.infect_title, L.infect_help)
 end)
 
+hook.Add("TTTShouldPlayerSmoke", "Parasite_Infecting_TTShouldPlayerSmoke", function(v, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)
+    if v:GetNWBool("ParasiteInfected", false) and parasite_killer_smoke:GetBool() then
+        return true
+    end
+end)
+
 --------------
 -- TUTORIAL --
 --------------
@@ -235,6 +243,26 @@ hook.Add("TTTTutorialRoleText", "Parasite_TTTTutorialRoleText", function(role, t
                 html = html .. "using the 'kill' console command "
             end
             html = html .. "then the " .. ROLE_STRINGS[ROLE_PARASITE] .. " <span style='color: rgb(" .. traitorColor.r .. ", " .. traitorColor.g .. ", " .. traitorColor.b .. ")'>will respawn immediately</span>.</span>"
+        end
+
+        local has_smoke = parasite_killer_smoke:GetBool()
+        local has_footsteps = parasite_killer_footstep_time:GetInt() > 0
+        -- Smoke and Killer footsteps
+        if has_smoke or has_footsteps then
+            html = html .. "<span style='display: block; margin-top: 10px;'>After the " .. ROLE_STRINGS[ROLE_PARASITE] .. " is killed, their killer "
+            if has_smoke then
+                html = html .. "is enveloped in a <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>shroud of smoke</span>"
+            end
+
+            if has_smoke and has_footsteps then
+                html = html .. " and "
+            end
+
+            if has_footsteps then
+                html = html .. "leaves behind <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>bloody footprints</span>"
+            end
+
+            html = html .. ", revealing themselves as the " .. ROLE_STRINGS[ROLE_PARASITE] .. "'s killer to other players.</span>"
         end
 
         return html

--- a/gamemodes/terrortown/gamemode/roles/parasite/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/shared.lua
@@ -40,6 +40,8 @@ CreateConVar("ttt_parasite_infection_transfer", 0, FCVAR_REPLICATED)
 CreateConVar("ttt_parasite_respawn_mode", 0, FCVAR_REPLICATED, "The way in which the parasite respawns. 0 - Take over host. 1 - Respawn at the parasite's body. 2 - Respawn at a random location.", 0, 2)
 CreateConVar("ttt_parasite_announce_infection", 0, FCVAR_REPLICATED)
 CreateConVar("ttt_parasite_infection_suicide_mode", 0, FCVAR_REPLICATED, "The way to handle when a player infected by the parasite kills themselves. 0 - Do nothing. 1 - Respawn the parasite. 2 - Respawn the parasite ONLY IF the infected player killed themselves with a console command like \"kill\"", 0, 2)
+CreateConVar("ttt_parasite_killer_smoke", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_parasite_killer_footstep_time", "0", FCVAR_REPLICATED, "The amount of time a parasite's killer's footsteps should show before fading. Set to 0 to disable", 1, 60)
 
 ROLE_CONVARS[ROLE_PARASITE] = {}
 table.insert(ROLE_CONVARS[ROLE_PARASITE], {
@@ -99,6 +101,15 @@ table.insert(ROLE_CONVARS[ROLE_PARASITE], {
 table.insert(ROLE_CONVARS[ROLE_PARASITE], {
     cvar = "ttt_parasite_is_monster",
     type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_PARASITE], {
+    cvar = "ttt_parasite_killer_smoke",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_PARASITE], {
+    cvar = "ttt_parasite_killer_footstep_time",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })
 
 -------------------


### PR DESCRIPTION
## Changelog
- Added ability for the arsonist to activate their igniter so it automatically triggers upon their death (disabled by default)
  - Automatic trigger can be configured to be on a delay, allowing other players to find and deactivate the igniter
  - Notifications on when the auto-trigger activates can be disabled by configuration as well
- Added ability for players to disable the view bob on cupid's bow from the cupid section of the roles tab in the F1 menu
- Added ability for parasite to only respawn when their host is killed, similar to the phantom (disabled by default)
- Added ability for parasite's killer to smoke and leave behind footprints, like a phantom's killer (both disabled by default)
- Added ability to limit the number of times the parasite can respawn (disabled by default)

## Affected Issues
#659
#722

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
