### PR TITLE
Misc. fixes and additions

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -524,7 +524,8 @@ ttt_jesters_visible_to_monsters                1       // Whether jesters are re
 
 // Jester
 ttt_jester_win_by_traitors                     1       // Whether the jester will win the round if they are killed by a traitor
-ttt_jester_notify_mode                         0       // The logic to use when notifying players that a jester is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone.
+ttt_jester_notify_mode                         0       // The logic to use when notifying players that a jester was killed. Killer is notified unless "ttt_jester_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone.
+ttt_jester_notify_killer                       1       // Whether to notify a jester's killer
 ttt_jester_notify_sound                        0       // Whether to play a cheering sound when a jester is killed
 ttt_jester_notify_confetti                     0       // Whether to throw confetti when a jester is a killed
 ttt_jester_credits_starting                    0       // The number of credits a jester should start with
@@ -535,7 +536,8 @@ ttt_single_jester_swapper_chance               0.5     // The chance that a jest
 // Swapper
 ttt_swapper_respawn_health                     100     // What amount of health to give the swapper when they are killed and respawned
 ttt_swapper_weapon_mode                        1       // How to handle weapons when the Swapper is killed. 0 - Don't swap anything. 1 - Swap role weapons (if there are any). 2 - Swap all weapons.
-ttt_swapper_notify_mode                        0       // The logic to use when notifying players that a swapper is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_swapper_notify_mode                        0       // The logic to use when notifying players that a swapper was killed. Killer is notified unless "ttt_swapper_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_swapper_notify_killer                      1       // Whether to notify a swapper's killer
 ttt_swapper_notify_sound                       0       // Whether to play a cheering sound when a swapper is killed
 ttt_swapper_notify_confetti                    0       // Whether to throw confetti when a swapper is a killed
 ttt_swapper_killer_swap                        1       // Whether to the swapper's killer should become the new swapper
@@ -570,7 +572,8 @@ ttt_beggar_respawn                             0       // Whether the beggar res
 ttt_beggar_respawn_delay                       3       // The delay to use when respawning the beggar (if "ttt_beggar_respawn" is enabled)
 ttt_beggar_respawn_limit                       0       // The maximum number of times the beggar can respawn (if "ttt_beggar_respawn" is enabled). Set to 0 to allow infinite respawns
 ttt_beggar_respawn_change_role                 0       // Whether to change the role of the respawning the beggar (if "ttt_beggar_respawn" is enabled). Their role will be Traitor if killed by an innocent player and Innocent otherwise
-ttt_beggar_notify_mode                         0       // The logic to use when notifying players that a beggar is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_beggar_notify_mode                         0       // The logic to use when notifying players that a beggar was killed. Killer is notified unless "ttt_beggar_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_beggar_notify_killer                       1       // Whether to notify a beggar's killer
 ttt_beggar_notify_sound                        0       // Whether to play a cheering sound when a beggar is killed
 ttt_beggar_notify_confetti                     0       // Whether to throw confetti when a beggar is a killed
 ttt_beggar_scan                                0       // Whether the beggar can scan players to see if they are traitors. 0 - Disabled. 1 - Can only scan traitors. 2 - Can scan any role that has a shop.
@@ -596,7 +599,8 @@ ttt_bodysnatcher_reveal_jester                 1       // Who the bodysnatcher i
 ttt_bodysnatcher_respawn                       0       // Whether the bodysnatcher respawns when they are killed before joining another team
 ttt_bodysnatcher_respawn_delay                 3       // The delay to use when respawning the bodysnatcher (if "ttt_bodysnatcher_respawn" is enabled)
 ttt_bodysnatcher_respawn_limit                 0       // The maximum number of times the bodysnatcher can respawn (if "ttt_bodysnatcher_respawn" is enabled). Set to 0 to allow infinite respawns
-ttt_bodysnatcher_notify_mode                   0       // The logic to use when notifying players that a bodysnatcher is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_bodysnatcher_notify_mode                   0       // The logic to use when notifying players that a bodysnatcher was killed. Killer is notified unless "ttt_bodysnatcher_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_bodysnatcher_notify_killer                 1       // Whether to notify a bodysnatcher's killer
 ttt_bodysnatcher_notify_sound                  0       // Whether to play a cheering sound when a bodysnatcher is killed
 ttt_bodysnatcher_notify_confetti               0       // Whether to throw confetti when a bodysnatcher is a killed
 ttt_bodysnatcher_device_time                   5       // The amount of time (in seconds) the bodysnatcher's device takes to use
@@ -615,7 +619,8 @@ ttt_lootgoblin_weapons_dropped                 8       // How many weapons the l
 ttt_lootgoblin_jingle_enabled                  1       // Whether to play a jingle sound when an activated loot goblin is moving
 ttt_lootgoblin_speed_mult                      1.2     // The multiplier to use on the loot goblin's movement speed when they are activated (e.g. 1.2 = 120% normal speed)
 ttt_lootgoblin_sprint_recovery                 0.12    // The amount of stamina to recover per tick when the loot goblin is activated
-ttt_lootgoblin_notify_mode                     4       // The logic to use when notifying players that a loot goblin is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_lootgoblin_notify_mode                     4       // The logic to use when notifying players that a loot goblin was killed. Killer is notified unless "ttt_loot goblin_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_lootgoblin_notify_killer                   1       // Whether to notify a lootgoblin's killer
 ttt_lootgoblin_notify_sound                    1       // Whether to play a cheering sound when a loot goblin is killed
 ttt_lootgoblin_notify_confetti                 1       // Whether to throw confetti when a loot goblin is a killed
 ttt_lootgoblin_regen_mode                      2       // Whether the loot goblin should regenerate health and using what logic. 0 - No regeneration. 1 - Constant regen while active. 2 - Regen while standing still. 3 - Regen after taking damage
@@ -637,7 +642,8 @@ ttt_cupid_lovers_can_damage_cupid              0       // Whether the lovers sho
 ttt_cupid_lover_vision_enabled                 1       // Whether the lovers can see outlines of each other through walls
 ttt_cupid_arrow_hitscan                        0       // Whether the cupid's arrow should be an instant hit instead of a projectile
 ttt_cupid_arrow_speed_mult                     1       // The speed multiplier for the cupid's arrow (Only applies when ttt_cupid_arrow_hitscan is disabled)
-ttt_cupid_notify_mode                          0       // The logic to use when notifying players that a cupid is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_cupid_notify_mode                          0       // The logic to use when notifying players that a cupid was killed. Killer is notified unless "ttt_cupid_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_cupid_notify_killer                        1       // Whether to notify a cupid's killer
 ttt_cupid_notify_sound                         0       // Whether to play a cheering sound when a cupid is killed
 ttt_cupid_notify_confetti                      0       // Whether to throw confetti when a cupid is a killed
 ttt_cupid_can_see_jesters                      0       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to cupid (Only applies if ttt_cupid_is_independent is enabled)
@@ -645,7 +651,8 @@ ttt_cupid_update_scoreboard                    0       // Whether cupid shows de
 
 // Sponge
 ttt_sponge_aura_radius                         5       // The radius of the sponge's aura in meters
-ttt_sponge_notify_mode                         0       // The logic to use when notifying players that the sponge is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_sponge_notify_mode                         0       // The logic to use when notifying players that a sponge was killed. Killer is notified unless "ttt_sponge_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_sponge_notify_killer                       1       // Whether to notify a sponge's killer
 ttt_sponge_notify_sound                        0       // Whether to play a cheering sound when a sponge is killed
 ttt_sponge_notify_confetti                     0       // Whether to throw confetti when a sponge is a killed
 ttt_sponge_device_time                         8       // The amount of time (in seconds) the spongifier takes to use
@@ -676,7 +683,8 @@ ttt_guesser_can_guess_detectives               0       // Whether the guesser is
 ttt_guesser_minimum_radius                     5       // The minimum radius of the guesser's device in meters. Set to 0 to disable
 ttt_guesser_show_team_threshold                50      // The amount of damage that needs to be dealt to a guesser before they learn the attacker's team
 ttt_guesser_show_role_threshold                100     // The amount of damage that needs to be dealt to a guesser before they learn the attacker's role
-ttt_guesser_notify_mode                        0       // The logic to use when notifying players that a guesser is killed. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_guesser_notify_mode                        0       // The logic to use when notifying players that a guesser was killed. Killer is notified unless "ttt_guesser_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone
+ttt_guesser_notify_killer                      1       // Whether to notify a guesser's killer
 ttt_guesser_notify_sound                       0       // Whether to play a cheering sound when a guesser is killed
 ttt_guesser_notify_confetti                    0       // Whether to throw confetti when a guesser is a killed
 ttt_guesser_unguessable_roles                  "lootgoblin,zombie" // Names of roles that cannot be guessed by the guesser, separated with commas. Do not include spaces or capital letters.
@@ -855,7 +863,7 @@ ttt_arsonist_can_see_jesters                   1       // Whether jesters are re
 ttt_arsonist_update_scoreboard                 1       // Whether the arsonist shows dead players as missing in action
 ttt_arsonist_ignite_on_death                   0       // Whether to allow the arsonist to enable automatic triggering of their igniter on death
 ttt_arsonist_ignite_on_death_timer             0       // How long after the arsonist's death to trigger their igniter. Set to 0 to trigger instantly
-ttt_arsonist_ignite_on_death_notify            1       // Whether to notify other players that the arsonist's igniter is going to be triggered
+ttt_arsonist_ignite_on_death_notify            1       // Whether to notify other players that a arsonist's igniter is going to be triggered
 ttt_detectives_search_only_arsonistdouse       0       // Whether only detectives can see information about whether a corpse was doused by an arsonist and when. Once a detective searches a body, this information will be available to all players. Ignored when "ttt_detectives_search_only" is enabled.
 
 // Hive Mind

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,6 +28,8 @@
 - Added ability for parasite to only respawn when their host is killed, similar to the phantom (disabled by default)
 - Added ability for parasite's killer to smoke and leave behind footprints, like a phantom's killer (both disabled by default)
 - Added ability to limit the number of times the parasite can respawn (disabled by default)
+- Added note to jester team ttt_*_notify_mode convars that the player's killer is notified
+- Added ability to control whether the killer of a member of the jester team is notified that they killed that role (enabled by default)
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,8 @@
 - Fixed corpse calls duplicating when different players called the detective to the same corpse
 - Fixed corpse calls not expiring after 45 seconds like they do in vanilla TTT
   - This can be adjusted or disabled with a new convar
+- Fixed players who join during the prep phase not getting their default loadout (crowbar, magneto stick, unarmed) until the round starts
+  - This fixes players who don't pick up guns in the prep phase having their role weapons auto-selected when the round starts, giving them away
 
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,7 @@
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused
 - Changed sort order of items when searching a body so that important information is displayed in a consistent order
 - Changed players who use a "kill" console command to not kill their paired cupid lover
+- Changed corpse found messages (in the top-right of the screen) to have their background color match the color of the corpse's role
 - Removed view bob and sway on cupid's bow to be consistent with other role weapons
 
 ### Fixes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,7 +36,8 @@
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused
 - Changed sort order of items when searching a body so that important information is displayed in a consistent order
 - Changed players who use a "kill" console command to not kill their paired cupid lover
-- Changed corpse found messages (in the top-right of the screen) to have their background color match the color of the corpse's role
+- Changed corpse found notification messages (in the top-right of the screen) to have their background color match the color of the corpse's role
+- Changed notification messages colored with a role color to use a version with some transparency to match the uncolored messages
 - Removed view bob and sway on cupid's bow to be consistent with other role weapons
 
 ### Fixes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@
   - This can be adjusted or disabled with a new convar
 - Fixed players who join during the prep phase not getting their default loadout (crowbar, magneto stick, unarmed) until the round starts
   - This fixes players who don't pick up guns in the prep phase having their role weapons auto-selected when the round starts, giving them away
+- Fixed body found messages showing that a corpse was on the "detective team" instead of "innocent team" for detective roles when `ttt_detectives_search_only_role` was enabled
 
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,7 @@
 - Added ability to limit the number of times the parasite can respawn (disabled by default)
 - Added note to jester team ttt_*_notify_mode convars that the player's killer is notified
 - Added ability to control whether the killer of a member of the jester team is notified that they killed that role (enabled by default)
+- Added short message to lovers and cupid informing them which teams they can win with for clarity
 
 ### Changes
 - Changed body search icon for when a player has been doused by the arsonist to show the time since that player was doused

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,6 +51,7 @@
 - Fixed players who join during the prep phase not getting their default loadout (crowbar, magneto stick, unarmed) until the round starts
   - This fixes players who don't pick up guns in the prep phase having their role weapons auto-selected when the round starts, giving them away
 - Fixed body found messages showing that a corpse was on the "detective team" instead of "innocent team" for detective roles when `ttt_detectives_search_only_role` was enabled
+- Fixed arm color of player who was spectated as a zombie not being reset when the round ended
 
 ### Developer
 - Added `plymeta:IsRespawning` fed by the new `TTTIsPlayerRespawning` hook

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -94,6 +94,12 @@
                         <td>Whether to throw confetti when this role is killed. Replace * with the name of the jester role you want to configure without spaces or capital letters. <i>(Does not apply to the Clown.)</i></td>
                     </tr>
                     <tr>
+                        <td>ttt_*_notify_killer <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                        <td>0</td>
+                        <td>Boolean</td>
+                        <td>Whether to notify the killer when this role is killed. Replace * with the name of the jester role you want to configure without spaces or capital letters. <i>(Does not apply to the Clown.)</i></td>
+                    </tr>
+                    <tr>
                         <td>ttt_*_notify_mode</td>
                         <td>0</td>
                         <td>Integer (0-4)</td>
@@ -105,7 +111,8 @@
                                 <li>Only notify detectives.</li>
                                 <li>Notify everyone.</li>
                             </ol>
-                            Replace * with the name of the jester role you want to configure without spaces or capital letters. <i>(Does not apply to the Clown.)</i>
+                            Replace * with the name of the jester role you want to configure without spaces or capital letters. <i>(Does not apply to the Clown.)</i><br>
+                            Killer is notified unless <code>ttt_*_notify_killer</code> is disabled.
                         </td>
                     </tr>
                     <tr>

--- a/gamemodes/terrortown/entities/entities/ttt_cup_arrow.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cup_arrow.lua
@@ -142,10 +142,24 @@ function ENT:Touch(ent)
                         ent:SetNWString("TTTCupidLover", target1)
                         ent2:SetNWString("TTTCupidLover", ent:SteamID64())
                         owner:SetNWString("TTTCupidTarget2", ent:SteamID64())
+                        owner:StripWeapon("weapon_cup_bow")
+
                         owner:QueueMessage(MSG_PRINTBOTH, ent:Nick() .. " has fallen in love with " .. ent2:Nick() .. ".")
                         ent2:QueueMessage(MSG_PRINTBOTH, "You have fallen in love with " .. ent:Nick() .. "!")
                         ent:QueueMessage(MSG_PRINTBOTH, "You have fallen in love with " .. ent2:Nick() .. "!")
-                        owner:StripWeapon("weapon_cup_bow")
+
+                        if ent:IsSameTeam(ent2) then
+                            ent:QueueMessage(MSG_PRINTBOTH, "The " .. ROLE_STRINGS[ROLE_CUPID] .. " will now win with your team!")
+                            ent2:QueueMessage(MSG_PRINTBOTH, "The " .. ROLE_STRINGS[ROLE_CUPID] .. " will now win with your team!")
+
+                            local roleTeam = ent:GetRoleTeam()
+                            local teamName = GetRawRoleTeamName(roleTeam)
+                            owner:QueueMessage(MSG_PRINTBOTH, "You will now win with the " .. teamName .. "s!")
+                        else
+                            ent:QueueMessage(MSG_PRINTBOTH, "You can now win independently!")
+                            ent2:QueueMessage(MSG_PRINTBOTH, "You can now win independently!")
+                            owner:QueueMessage(MSG_PRINTBOTH, "You can now win independently!")
+                        end
 
                         net.Start("TTT_CupidPaired")
                         net.WriteString(owner:Nick())

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -297,12 +297,6 @@ function GM:ClearClientState()
     client.radio = nil
     client.called_corpses = {}
 
-    -- Reset the player's viewmodel color
-    local vm = client:GetViewModel()
-    if IsValid(vm) then
-        vm:SetColor(COLOR_WHITE)
-    end
-
     VOICE.InitBattery()
 
     for _, p in PlayerIterator() do
@@ -310,6 +304,12 @@ function GM:ClearClientState()
             p.sb_tag = nil
             p:SetRole(ROLE_INNOCENT)
             p.search_result = nil
+
+            -- Reset the player's viewmodel color
+            local vm = p:GetViewModel()
+            if IsValid(vm) and vm:GetColor() ~= COLOR_WHITE then
+                vm:SetColor(COLOR_WHITE)
+            end
         end
     end
 

--- a/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -226,26 +226,33 @@ function LANG.GetLanguageNames()
 -- Table of styles that can take a string and display it in some position,
 -- colour, etc.
 LANG.Styles = {
-    default = function(text)
+    default = function(text, params)
         MSTACK:AddMessage(text)
         print("TTT:   " .. text)
     end,
 
-    rolecolour = function(text)
-        local hide_role = false
-        if ConVarExists("ttt_hide_role") then
-            hide_role = GetConVar("ttt_hide_role"):GetBool()
+    rolecolour = function(text, params)
+        local color = nil
+        if params and params.color_role then
+            local role = tonumber(params.color_role)
+            if role > ROLE_NONE and role <= ROLE_MAX then
+                color = ROLE_COLORS[role]
+            end
+        else
+            if not cvars.Bool("ttt_hide_role", false) then
+                color = ROLE_COLORS[LocalPlayer():GetDisplayedRole()]
+            end
         end
 
-        if hide_role then
+        if color == nil then
             MSTACK:AddMessage(text)
         else
-            MSTACK:AddColoredBgMessage(text, ROLE_COLORS[LocalPlayer():GetDisplayedRole()])
+            MSTACK:AddColoredBgMessage(text, color)
         end
         print("TTT:   " .. text)
     end,
 
-    chat_warn = function(text)
+    chat_warn = function(text, params)
         chat.AddText(COLOR_RED, text)
     end,
 
@@ -271,8 +278,8 @@ function LANG.SetStyle(name, style)
     LANG.MsgStyle[name] = style
 end
 
-function LANG.ShowStyledMsg(text, style)
-    style(text)
+function LANG.ShowStyledMsg(text, style, params)
+    style(text, params)
 end
 
 function LANG.ProcessMsg(name, params)
@@ -294,7 +301,7 @@ function LANG.ProcessMsg(name, params)
         text = interp(raw, params)
     end
 
-    LANG.ShowStyledMsg(text, LANG.GetStyle(name))
+    LANG.ShowStyledMsg(text, LANG.GetStyle(name), params)
 end
 
 --- Message style declarations
@@ -311,6 +318,9 @@ local styledmessages = {
     rolecolour = {
         "round_traitors_one",
         "round_traitors_more",
+
+        "body_found",
+        "body_found_updated",
 
         "buy_no_stock",
         "buy_pending",

--- a/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -236,11 +236,11 @@ LANG.Styles = {
         if params and params.color_role then
             local role = tonumber(params.color_role)
             if role > ROLE_NONE and role <= ROLE_MAX then
-                color = ROLE_COLORS[role]
+                color = ROLE_COLORS_SPRITE[role]
             end
         else
             if not cvars.Bool("ttt_hide_role", false) then
-                color = ROLE_COLORS[LocalPlayer():GetDisplayedRole()]
+                color = ROLE_COLORS_SPRITE[LocalPlayer():GetDisplayedRole()]
             end
         end
 

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -156,7 +156,7 @@ local function IdentifyBody(ply, rag)
         if fullSearch or AnnounceBodyRole(ply, round_state, deadply) then
             role_string = ROLE_STRINGS_EXT[role]
         elseif AnnounceBodyTeam(ply, round_state, deadply) then
-            local roleTeam = player.GetRoleTeam(role)
+            local roleTeam = player.GetRoleTeam(role, true)
             local teamName = GetRoleTeamName(roleTeam)
             role_string = "on the " .. teamName .. " team"
         end

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -169,7 +169,7 @@ local function IdentifyBody(ply, rag)
             elseif roleTeam == ROLE_TEAM_TRAITOR then
                 color_role = ROLE_TRAITOR
             else
-                color_colr = role
+                color_role = role
             end
         end
 

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -153,18 +153,31 @@ local function IdentifyBody(ply, rag)
             name = nick
         end
         local role_string = "an unknown role"
+        local color_role = ROLE_NONE
         if fullSearch or AnnounceBodyRole(ply, round_state, deadply) then
             role_string = ROLE_STRINGS_EXT[role]
+            -- Use the role's color for the message background
+            color_role = role
         elseif AnnounceBodyTeam(ply, round_state, deadply) then
             local roleTeam = player.GetRoleTeam(role, true)
             local teamName = GetRoleTeamName(roleTeam)
             role_string = "on the " .. teamName .. " team"
+
+            -- Show the base team color for innocents and traitors
+            if roleTeam == ROLE_TEAM_INNOCENT then
+                color_role = ROLE_INNOCENT
+            elseif roleTeam == ROLE_TEAM_TRAITOR then
+                color_role = ROLE_TRAITOR
+            else
+                color_colr = role
+            end
         end
 
         LANG.Msg("body_found", {
             finder = finder,
             victim = name,
-            role = role_string
+            role = role_string,
+            color_role = tostring(color_role)
         })
     end
 
@@ -213,7 +226,8 @@ local function IdentifyBody(ply, rag)
             LANG.Msg("body_found_updated", {
                 finder = finder,
                 victim = nick,
-                role = ROLE_STRINGS_EXT[role]
+                role = ROLE_STRINGS_EXT[role],
+                color_role = role
             })
         end
     end

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -406,6 +406,12 @@ function plymeta:InitialSpawn()
 
     -- We never have weapons here, but this inits our equipment state
     self:StripAll()
+
+    -- If round prep has started, call SpawnForRound on the player so all the same logic
+    -- that has been ran against the other players is run against this new player as well
+    if GetRoundState() == ROUND_PREP then
+        self:SpawnForRound(false)
+    end
 end
 
 function plymeta:KickBan(length, reason)

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -16,7 +16,8 @@ util.AddNetworkString("TTT_BeggarKilled")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_beggar_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the beggar is killed", 0, 4)
+CreateConVar("ttt_beggar_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a beggar was killed. Killer is notified unless \"ttt_beggar_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_beggar_notify_killer", "1", FCVAR_NONE, "Whether to notify a beggar's killer", 0, 1)
 CreateConVar("ttt_beggar_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a beggar is killed", 0, 1)
 CreateConVar("ttt_beggar_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a beggar is a killed", 0, 1)
 

--- a/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
@@ -75,6 +75,10 @@ table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
+    cvar = "ttt_beggar_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
     cvar = "ttt_beggar_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
@@ -15,7 +15,8 @@ util.AddNetworkString("TTT_BodysnatcherKilled")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_bodysnatcher_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the bodysnatcher is killed", 0, 4)
+CreateConVar("ttt_bodysnatcher_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a bodysnatcher was killed. Killer is notified unless \"ttt_bodysnatcher_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_bodysnatcher_notify_killer", "1", FCVAR_NONE, "Whether to notify a bodysnatcher's killer", 0, 1)
 CreateConVar("ttt_bodysnatcher_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a bodysnatcher is killed", 0, 1)
 CreateConVar("ttt_bodysnatcher_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a bodysnatcher is a killed", 0, 1)
 

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
@@ -66,6 +66,10 @@ table.insert(ROLE_CONVARS[ROLE_BODYSNATCHER], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_BODYSNATCHER], {
+    cvar = "ttt_bodysnatcher_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_BODYSNATCHER], {
     cvar = "ttt_bodysnatcher_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/cupid/cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cupid.lua
@@ -13,7 +13,8 @@ resource.AddFile("materials/particle/heart.vmt")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_cupid_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a cupid was killed", 0, 4)
+CreateConVar("ttt_cupid_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a cupid was killed. Killer is notified unless \"ttt_cupid_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_cupid_notify_killer", "1", FCVAR_NONE, "Whether to notify a cupid's killer", 0, 1)
 CreateConVar("ttt_cupid_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a cupid is killed", 0, 1)
 CreateConVar("ttt_cupid_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a cupid is a killed", 0, 1)
 

--- a/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
@@ -32,6 +32,10 @@ table.insert(ROLE_CONVARS[ROLE_CUPID], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_CUPID], {
+    cvar = "ttt_cupid_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_CUPID], {
     cvar = "ttt_cupid_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/guesser/guesser.lua
+++ b/gamemodes/terrortown/gamemode/roles/guesser/guesser.lua
@@ -15,7 +15,8 @@ util.AddNetworkString("TTT_GuesserGuessed")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_guesser_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a guesser was killed", 0, 4)
+CreateConVar("ttt_guesser_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a guesser was killed. Killer is notified unless \"ttt_guesser_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_guesser_notify_killer", "1", FCVAR_NONE, "Whether to notify a guesser's killer", 0, 1)
 CreateConVar("ttt_guesser_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a guesser is killed", 0, 1)
 CreateConVar("ttt_guesser_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a guesser is a killed", 0, 1)
 

--- a/gamemodes/terrortown/gamemode/roles/guesser/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/guesser/shared.lua
@@ -24,6 +24,10 @@ table.insert(ROLE_CONVARS[ROLE_GUESSER], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_GUESSER], {
+    cvar = "ttt_guesser_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_GUESSER], {
     cvar = "ttt_guesser_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/jester/jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/jester.lua
@@ -9,7 +9,8 @@ local PlayerIterator = player.Iterator
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_jester_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the jester is killed", 0, 4)
+CreateConVar("ttt_jester_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a jester was killed. Killer is notified unless \"ttt_jester_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_jester_notify_killer", "1", FCVAR_NONE, "Whether to notify a jester's killer", 0, 1)
 CreateConVar("ttt_jester_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a jester is killed", 0, 1)
 CreateConVar("ttt_jester_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a jester is a killed", 0, 1)
 

--- a/gamemodes/terrortown/gamemode/roles/jester/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/shared.lua
@@ -17,6 +17,10 @@ table.insert(ROLE_CONVARS[ROLE_JESTER], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_JESTER], {
+    cvar = "ttt_jester_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_JESTER], {
     cvar = "ttt_jester_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -39,9 +39,10 @@ resource.AddSingleFile("sound/lootgoblin/jingle8.wav")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_lootgoblin_notify_mode", "4", FCVAR_NONE, "The logic to use when notifying players that the lootgoblin is killed", 0, 4)
-CreateConVar("ttt_lootgoblin_notify_sound", "1")
-CreateConVar("ttt_lootgoblin_notify_confetti", "1")
+CreateConVar("ttt_lootgoblin_notify_mode", "4", FCVAR_NONE, "The logic to use when notifying players that a lootgoblin was killed. Killer is notified unless \"ttt_lootgoblin_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_lootgoblin_notify_killer", "1", FCVAR_NONE, "Whether to notify a lootgoblin's killer", 0, 1)
+CreateConVar("ttt_lootgoblin_notify_sound", "1", FCVAR_NONE, "Whether to play a cheering sound when a loot goblin is killed", 0, 1)
+CreateConVar("ttt_lootgoblin_notify_confetti", "1", FCVAR_NONE, "Whether to throw confetti when a loot goblin is a killed", 0, 1)
 local lootgoblin_activation_timer = CreateConVar("ttt_lootgoblin_activation_timer", "30", FCVAR_NONE, "Minimum time in seconds before the loot goblin is revealed", 0, 120)
 local lootgoblin_activation_timer_max = CreateConVar("ttt_lootgoblin_activation_timer_max", "60", FCVAR_NONE, "Maximum time in seconds before the loot goblin is revealed", 0, 120)
 local lootgoblin_size = CreateConVar("ttt_lootgoblin_size", "0.5", FCVAR_NONE, "The size multiplier for the loot goblin to use when they are revealed (e.g. 0.5 = 50% size)", 0, 1)

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/shared.lua
@@ -35,6 +35,10 @@ table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
+    cvar = "ttt_lootgoblin_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_LOOTGOBLIN], {
     cvar = "ttt_lootgoblin_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/sponge/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/sponge/shared.lua
@@ -35,6 +35,10 @@ table.insert(ROLE_CONVARS[ROLE_SPONGE], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_SPONGE], {
+    cvar = "ttt_sponge_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_SPONGE], {
     cvar = "ttt_sponge_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/sponge/sponge.lua
+++ b/gamemodes/terrortown/gamemode/roles/sponge/sponge.lua
@@ -10,7 +10,8 @@ resource.AddFile("materials/particle/sponge.vmt")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_sponge_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the sponge is killed", 0, 4)
+CreateConVar("ttt_sponge_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a sponge was killed. Killer is notified unless \"ttt_sponge_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_sponge_notify_killer", "1", FCVAR_NONE, "Whether to notify a sponge's killer", 0, 1)
 CreateConVar("ttt_sponge_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a sponge is killed", 0, 1)
 CreateConVar("ttt_sponge_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a sponge is a killed", 0, 1)
 local sponge_aura_float_time = CreateConVar("ttt_sponge_aura_float_time", "0", FCVAR_NONE, "The amount of time (in seconds) a player can spend outside the Sponge's aura before they are no longer considered inside", 0, 10)

--- a/gamemodes/terrortown/gamemode/roles/swapper/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/shared.lua
@@ -33,6 +33,10 @@ table.insert(ROLE_CONVARS[ROLE_SWAPPER], {
     isNumeric = true
 })
 table.insert(ROLE_CONVARS[ROLE_SWAPPER], {
+    cvar = "ttt_swapper_notify_killer",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_SWAPPER], {
     cvar = "ttt_swapper_notify_sound",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
@@ -17,7 +17,8 @@ util.AddNetworkString("TTT_SwapperSwapped")
 -- CONVARS --
 -------------
 
-CreateConVar("ttt_swapper_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that the swapper is killed", 0, 4)
+CreateConVar("ttt_swapper_notify_mode", "0", FCVAR_NONE, "The logic to use when notifying players that a swapper was killed. Killer is notified unless \"ttt_swapper_notify_killer\" is disabled", 0, 4)
+CreateConVar("ttt_swapper_notify_killer", "1", FCVAR_NONE, "Whether to notify a swapper's killer", 0, 1)
 CreateConVar("ttt_swapper_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a swapper is killed", 0, 1)
 CreateConVar("ttt_swapper_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a swapper is a killed", 0, 1)
 local swapper_respawn_health = CreateConVar("ttt_swapper_respawn_health", "100", FCVAR_NONE, "What amount of health to give the swapper when they are killed and respawned", 1, 200)

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1704,8 +1704,9 @@ if SERVER then
         local mode = GetConVar("ttt_" .. cvar_role .. "_notify_mode"):GetInt()
         local play_sound = GetConVar("ttt_" .. cvar_role .. "_notify_sound"):GetBool()
         local show_confetti = GetConVar("ttt_" .. cvar_role .. "_notify_confetti"):GetBool()
+        local notify_killer = cvars.Bool("ttt_" .. cvar_role .. "_notify_killer", false)
         for _, ply in PlayerIterator() do
-            if ply == attacker then
+            if ply == attacker and notify_killer then
                 local role_string = ROLE_STRINGS[role]
                 ply:QueueMessage(MSG_PRINTCENTER, "You killed the " .. role_string .. "!")
             elseif (shouldshow == nil or shouldshow(ply)) and ShouldShowJesterNotification(ply, mode) then


### PR DESCRIPTION
## Changelog
### Additions
- Added note to jester team ttt_*_notify_mode convars that the player's killer is notified
- Added ability to control whether the killer of a member of the jester team is notified that they killed that role (enabled by default)
- Added short message to lovers and cupid informing them which teams they can win with for clarity

### Changes
- Changed corpse found notification messages (in the top-right of the screen) to have their background color match the color of the corpse's role
- Changed notification messages colored with a role color to use a version with some transparency to match the uncolored messages

### Fixes
- Fixed players who join during the prep phase not getting their default loadout (crowbar, magneto stick, unarmed) until the round starts
  - This fixes players who don't pick up guns in the prep phase having their role weapons auto-selected when the round starts, giving them away
- Fixed body found messages showing that a corpse was on the "detective team" instead of "innocent team" for detective roles when `ttt_detectives_search_only_role` was enabled
- Fixed arm color of player who was spectated as a zombie not being reset when the round ended

## Affected Issues
#677
#731

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
  - https://github.com/Custom-Roles-for-TTT/TTT-Jingle-Jam-Roles-2022/pull/55
