### PR TITLE
Misc. changes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -278,6 +278,30 @@ Called for each player who is alive during the `Tick` hook.\
 *Parameters:*
 - *ply* - The current alive player target
 
+### TTTPlayerCanSendCredits(ply, credits, hasShop, canSend)
+Called when a player opens the equipment window to determine whether the credits transfer tab should show.\
+*Realm*: Client\
+*Added in*: 2.1.14\
+*Parameters*:
+- *ply* - The player that is trying to send credits
+- *credits* - The number of credits the player has
+- *hasShop* - Whether the player has a shop
+- *canSend* - Whether the player can normally send credits
+
+*Return:* `true` if the player should be able to send credits. Don't return anything otherwise.
+
+### TTTPlayerCanSendCreditsTo(ply, target, canSend)
+Called on the client when a player opens the equipment window to determine which other players are valid transfer targets.\
+Called on the server when a player attempts to transfer credits to another player to determine whether the target is valid.\
+*Realm*: Client and Server\
+*Added in*: 2.1.14\
+*Parameters*:
+- *ply* - The player that is trying to send credits
+- *target* - The player that we're checking as a potential target
+- *canSend* - Whether the player can normally send credits
+
+*Return:* `true` if the player should be able to send credits to the target. Don't return anything otherwise. 
+
 ### TTTPlayerCreditsChanged(ply, amount)
 Called whenever a player's credits are added to or subtracted from.\
 *Realm:* Server\

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -393,6 +393,8 @@ ttt_doctor_credits_starting                    1       // The number of credits 
 
 // Paramedic
 ttt_paramedic_defib_as_innocent                0       // Whether the paramedic's defib brings back everyone as a vanilla innocent role
+ttt_paramedic_defib_as_is                      0       // Whether the paramedic's defib brings back everyone as their previous role
+ttt_paramedic_defib_detectives_as_deputy       0       // Whether the paramedic's defib brings back detective roles as a promoted deputy
 ttt_paramedic_device_loadout                   1       // Whether the paramedic's defib should be given to them when they spawn. Server must be restarted for changes to take effect
 ttt_paramedic_device_shop                      0       // Whether the paramedic's defib should be purchasable in the shop (requires "ttt_shop_for_all" to be enabled). Server must be restarted for changes to take effect
 ttt_paramedic_device_shop_rebuyable            0       // Whether the paramedic's defib should be purchaseable multiple times (requires "ttt_paramedic_device_shop" to be enabled). Server must be restarted for changes to take effect

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -526,6 +526,7 @@ ttt_jesters_visible_to_monsters                1       // Whether jesters are re
 
 // Jester
 ttt_jester_win_by_traitors                     1       // Whether the jester will win the round if they are killed by a traitor
+ttt_jester_win_ends_round                      1       // Whether the jester winning causes the round to end
 ttt_jester_notify_mode                         0       // The logic to use when notifying players that a jester was killed. Killer is notified unless "ttt_jester_notify_killer" is disabled. 0 - Don't notify anyone. 1 - Only notify traitors and detective. 2 - Only notify traitors. 3 - Only notify detective. 4 - Notify everyone.
 ttt_jester_notify_killer                       1       // Whether to notify a jester's killer
 ttt_jester_notify_sound                        0       // Whether to play a cheering sound when a jester is killed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,8 @@
 - Added ability for paramedic to revive players as their original role (disabled by default)
 - Added ability for paramedic to revive detective roles as a promoted deputy (disabled by default)
 - Added ability to control whether the jester winning causes the round to end (enabled by default)
+- Added ability to send credits between cupid and lovers if they have equipment shops
+  - This allows Cupid <-> Lover as well as Lover <-> Lover
 
 ### Changes
 - Changed `ttt_corpse_search_not_shared` to behave like searching in vanilla TTT

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 - Fixed "found" bodies not having an expandable scoreboard info section
+- Fixed issue where player who killed someone hosting a parasite would also be killed when `ttt_parasite_infection_time` was `0`
 
 ### Developer
 - Implemented `plymeta:IsRespawning` and `plymeta:StopRespawning` for bodysnatcher

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 - Fixed "found" bodies not having an expandable scoreboard info section
 - Fixed issue where player who killed someone hosting a parasite would also be killed when `ttt_parasite_infection_time` was `0`
 - Fixed cupid lover who is killed receiving message saying their lover killed themselves
+- Fixed placeholder not being replaced in swapper role popup message
 
 ### Developer
 - Implemented `plymeta:IsRespawning` and `plymeta:StopRespawning` for bodysnatcher

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.1.14 (Beta)
+**Released:**
+
+### Changes
+- Changed `ttt_corpse_search_not_shared` to behave like searching in vanilla TTT
+  - The corpse found message is broadcast but body info is not shown on the scoreboard unless the corpse is searched by a detective-like role
+
 ## 2.1.13
 **Released April 29th, 2024**\
 Includes beta update [2.1.12](#2112-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,9 @@
 - Changed `ttt_corpse_search_not_shared` to behave like searching in vanilla TTT
   - The corpse found message is broadcast but body info is not shown on the scoreboard unless the corpse is searched by a detective-like role
 
+### Fixes
+- Fixed "found" bodies not having an expandable scoreboard info section
+
 ## 2.1.13
 **Released April 29th, 2024**\
 Includes beta update [2.1.12](#2112-beta).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Additions
 - Added ability for paramedic to revive players as their original role (disabled by default)
 - Added ability for paramedic to revive detective roles as a promoted deputy (disabled by default)
+- Added ability to control whether the jester winning causes the round to end (enabled by default)
 
 ### Changes
 - Changed `ttt_corpse_search_not_shared` to behave like searching in vanilla TTT

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,8 @@
 
 ### Developer
 - Implemented `plymeta:IsRespawning` and `plymeta:StopRespawning` for bodysnatcher
+- Added `TTTPlayerCanSendCredits` hook to allow overriding who can see the credits transfer tab in the equipment menu
+- Added `TTTPlayerCanSendCreditsTo` hook to allow overriding who a player can send credits to
 
 ## 2.1.13
 **Released April 29th, 2024**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 ### Fixes
 - Fixed "found" bodies not having an expandable scoreboard info section
 - Fixed issue where player who killed someone hosting a parasite would also be killed when `ttt_parasite_infection_time` was `0`
+- Fixed cupid lover who is killed receiving message saying their lover killed themselves
 
 ### Developer
 - Implemented `plymeta:IsRespawning` and `plymeta:StopRespawning` for bodysnatcher

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,10 @@
 ## 2.1.14 (Beta)
 **Released:**
 
+### Additions
+- Added ability for paramedic to revive players as their original role (disabled by default)
+- Added ability for paramedic to revive detective roles as a promoted deputy (disabled by default)
+
 ### Changes
 - Changed `ttt_corpse_search_not_shared` to behave like searching in vanilla TTT
   - The corpse found message is broadcast but body info is not shown on the scoreboard unless the corpse is searched by a detective-like role

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,9 @@
 ### Fixes
 - Fixed "found" bodies not having an expandable scoreboard info section
 
+### Developer
+- Implemented `plymeta:IsRespawning` and `plymeta:StopRespawning` for bodysnatcher
+
 ## 2.1.13
 **Released April 29th, 2024**\
 Includes beta update [2.1.12](#2112-beta).

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -429,6 +429,40 @@
             <li><em>ply</em> - The current alive player target</li>
         </ul>
 
+        <h3><a id="tttplayercansendcreditsply-credits-hasShop-canSend" href="#tttplayercansendcreditsply-credits-hasShop-canSend">TTTPlayerCanSendCredits(ply, credits, hasShop, canSend)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <p>
+            Called when a player opens the equipment window to determine whether the credits transfer tab should show.<br>
+            <em>Realm:</em> Client<br>
+            <em>Added in:</em> 2.1.14<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The player that is trying to send credits</li>
+            <li><em>credits</em> - The number of credits the player has</li>
+            <li><em>hasShop</em> - Whether the player has a shop</li>
+            <li><em>canSend</em> - Whether the player can normally send credits</li>
+        </ul>
+        <p>
+            <em>Return:</em> <code>true</code> if the player should be able to send credits. Don't return anything otherwise.
+        </p>
+
+        <h3><a id="tttplayercansendcreditstoply-target-canSend" href="#tttplayercansendcreditstoply-target-canSend">TTTPlayerCanSendCreditsTo(ply, target, canSend)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <p>
+            Called on the client when a player opens the equipment window to determine which other players are valid transfer targets.<br>
+            Called on the server when a player attempts to transfer credits to another player to determine whether the target is valid.<br>
+            <em>Realm:</em> Client and Server<br>
+            <em>Added in:</em> 2.1.14<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The player that is trying to send credits</li>
+            <li><em>target</em> - The player that we're checking as a potential target</li>
+            <li><em>canSend</em> - Whether the player can normally send credits</li>
+        </ul>
+        <p>
+            <em>Return:</em> <code>true</code> if the player should be able to send credits to the target. Don't return anything otherwise.
+        </p>
+
         <h3><a id="tttplayercreditschangedply-amount" href="#tttplayercreditschangedply-amount">TTTPlayerCreditsChanged(ply, amount)</a></h3>
         <p>
             Called whenever a player's credits are added to or subtracted from.<br>

--- a/docs/teams/innocent.html
+++ b/docs/teams/innocent.html
@@ -448,6 +448,18 @@
                             <td>Whether the Paramedic's defib brings back everyone as a regular Innocent role.</td>
                         </tr>
                         <tr>
+                            <td>ttt_paramedic_defib_as_is <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether the paramedic's defib brings back everyone as their previous role.</td>
+                        </tr>
+                        <tr>
+                            <td>ttt_paramedic_defib_detectives_as_deputy <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether the paramedic's defib brings back detective roles as a promoted deputy.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_paramedic_defib_time</td>
                             <td>8</td>
                             <td>Integer</td>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -829,6 +829,12 @@
                             <td>Whether the jester will win the round if they are killed by a traitor.</td>
                         </tr>
                         <tr>
+                            <td>ttt_jester_win_ends_round <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether the jester winning causes the round to end.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_single_jester_swapper</td>
                             <td>0</td>
                             <td>Boolean</td>

--- a/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -14,6 +14,7 @@ local weapons = weapons
 ---- Traitor equipment menu
 
 local CallHook = hook.Call
+local RunHook = hook.Run
 local GetWeapon = weapons.GetStored
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
@@ -1033,7 +1034,7 @@ local function TraitorMenuPopup()
             local random_panel = buyable_items[math.random(1, #buyable_items)]
             dlist:SelectPanel(random_panel)
             dconfirm.DoClick()
-            hook.Call("TTTShopRandomBought", nil, LocalPlayer(), random_panel.item)
+            CallHook("TTTShopRandomBought", nil, LocalPlayer(), random_panel.item)
         end
 
         FillEquipmentList(GetEquipmentForRole(ply:GetRole(), ply:IsDetectiveLike() and not ply:IsDetectiveTeam(), false))
@@ -1061,13 +1062,16 @@ local function TraitorMenuPopup()
     end
 
     -- Credit transferring, but only for roles that have a shop and are allowed to transfer
-    if credits > 0 and hasShop and (ply:IsTraitorTeam() or ply:IsMonsterTeam()) then
+    local canSend = credits > 0 and hasShop and (ply:IsTraitorTeam() or ply:IsMonsterTeam())
+    local newCanSend = CallHook("TTTPlayerCanSendCredits", nil, ply, credits, hasShop, canSend)
+    if type(newCanSend) == "boolean" then canSend = newCanSend end
+    if canSend then
         local dtransfer = CreateTransferMenu(dsheet)
         dsheet:AddSheet(GetTranslation("xfer_name"), dtransfer, "icon16/group_gear.png", false, false, GetTranslation("equip_tooltip_xfer"))
         show = true
     end
 
-    local new_show = hook.Run("TTTEquipmentTabs", dsheet, dframe)
+    local new_show = RunHook("TTTEquipmentTabs", dsheet, dframe)
     if new_show then show = new_show end
 
     dframe:MakePopup()
@@ -1159,6 +1163,6 @@ local function ReceiveBoughtItem()
     end
 
     -- I can imagine custom equipment wanting this, so making a hook
-    hook.Run("TTTBoughtItem", is_item, id)
+    RunHook("TTTBoughtItem", is_item, id)
 end
 net.Receive("TTT_BoughtItem", ReceiveBoughtItem)

--- a/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/cl_search.lua
@@ -434,9 +434,7 @@ local function ShowSearchScreen(search_raw)
                 btn:SetDisabled(true)
             end,
             disabled = function()
-                return client:IsSpec() or
-                        (not client:IsActiveDetectiveLike() and GetConVar("ttt_corpse_search_not_shared"):GetBool()) or
-                        (not client:KeyDownLast(IN_WALK)) or CORPSE.GetFound(rag, false)
+                return client:IsSpec() or not client:KeyDownLast(IN_WALK) or CORPSE.GetFound(rag, false)
             end
         })
 

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -19,7 +19,6 @@ local StringUpper = string.upper
 local key_params = { usekey = Key("+use", "USE"), walkkey = Key("+walk", "WALK"), adetective = ROLE_STRINGS_EXT[ROLE_DETECTIVE] }
 
 local spectator_corpse_search = nil
-local corpse_search_not_shared = nil
 
 local ClassHint = {
     prop_ragdoll = {
@@ -45,14 +44,9 @@ local ClassHint = {
                     end
                 -- Only show covert search label if the body can be searched
                 elseif CORPSE.CanBeSearched(ply, ent) then
-                    -- Cache the convar reference
-                    if not corpse_search_not_shared then
-                        corpse_search_not_shared = GetConVar("ttt_corpse_search_not_shared")
-                    end
-
                     local ownerEnt = CORPSE.GetPlayer(ent)
                     -- and has not already
-                    if (ply:IsActiveDetectiveLike() or not corpse_search_not_shared:GetBool()) and IsValid(ownerEnt) and not ownerEnt:GetNWBool("body_searched", false) then
+                    if IsValid(ownerEnt) and not ownerEnt:GetNWBool("body_searched", false) then
                         txt = txt .. "_covert"
                     end
                 -- If the body can't be searched, change the label to say "call a Detective" instead

--- a/gamemodes/terrortown/gamemode/cl_transfer.lua
+++ b/gamemodes/terrortown/gamemode/cl_transfer.lua
@@ -1,6 +1,8 @@
+local hook = hook
 local player = player
 local vgui = vgui
 
+local CallHook = hook.Call
 local PlayerIterator = player.Iterator
 
 --- Credit transfer tab for equipment menu
@@ -36,15 +38,14 @@ function CreateTransferMenu(parent)
     dpick:SetWide(250)
 
     -- fill combobox
-    local r = client:GetRole()
     for _, p in PlayerIterator() do
-        if (IsValid(p) and p ~= client) and
-                -- Same role
-                (p:IsActiveRole(r) or
-                -- Traitor team or Glitch
-                (client:IsActiveTraitorTeam() and (p:IsActiveTraitorTeam() or p:IsActiveGlitch())) or
-                -- Monster team
-                (client:IsActiveMonsterTeam() and p:IsActiveMonsterTeam())) then
+        if not IsValid(p) or p == client then continue end
+        if not p:IsActive() then continue end
+
+        local canSend = client:IsSameTeam(p)
+        local newCanSend = CallHook("TTTPlayerCanSendCreditsTo", nil, client, p, canSend)
+        if type(newCanSend) == "boolean" then canSend = newCanSend end
+        if canSend then
             dpick:AddChoice(p:Nick(), p:SteamID64())
         end
     end

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -188,7 +188,10 @@ local function IdentifyBody(ply, rag)
             -- Otherwise the scoreboard gets updated which reveals their name anyway
             if announceName then
                 deadply:SetNWBool("body_found", true)
-                deadply:SetNWBool("body_searched", true)
+                -- Don't set "searched" if we're not sharing this information
+                if ply:IsDetectiveLike() or not GetConVar("ttt_corpse_search_not_shared"):GetBool() then
+                    deadply:SetNWBool("body_searched", true)
+                end
             end
 
             if not deadply:GetNWBool("body_searched_det", false) then

--- a/gamemodes/terrortown/gamemode/incompatible_addons.lua
+++ b/gamemodes/terrortown/gamemode/incompatible_addons.lua
@@ -77,14 +77,12 @@ local incompatible = {
     ["1721137539"] = { reason = "Breaks the tracker's footsteps by always returning a value to PlayerFootstep hook.", alt = "3052896263" }, -- Avengers RandoMat Event by Jenssons
     ["2209392671"] = { reason = "Breaks the weapon switch HUD (and possibly others)."}, -- TTT SimpleHUD by Suphax
     ["1256344426"] = { reason = "Breaks body searching and role-specific features" }, -- TTT Bots 2.0 by immortal man
+    ["2797209031"] = { convars = { { name = "ttt_roundend_slowmo", value = "1", reason = "Breaks roles which use the TTTWinCheckComplete hook for their win logic", alt = "686457995" } } }, -- Misc TTT tweaks and fixes by wget
 
     -- COD Zombie Perk Bottles
     ["842302491"] = { reason = "Incompatible with equipment item changes", alt = "2243578658"}, -- [TTT/2] Zombie Perk Bottles by Hagen
     ["653258161"] = { reason = "Incompatible with equipment item changes"}, -- [TTT/2] Blue Bull by Hagen
     ["2552701051"] = { reason = "Incompatible with equipment item changes", alt = "2243578658"} -- TTT Zombie Perk Bottles Rebalanced by Emzatin.
-
-    -- Example convar config
-    -- ["124567890"] = { convars = { { name = "ttt_broken_convar", value = "1", reason = "Breaks all the things", alt = "987654321" } } } -- An addon by a person
 }
 
 if CR_BETA then

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
@@ -110,6 +110,16 @@ hook.Add("PlayerDeath", "Bodysnatcher_KillCheck_PlayerDeath", function(victim, i
     end
 end)
 
+hook.Add("TTTStopPlayerRespawning", "Bodysnatcher_TTTStopPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if ply:Alive() then return end
+
+    if ply:GetNWBool("BodysnatcherIsRespawning", false) then
+        timer.Remove(ply:Nick() .. "BodysnatcherRespawn")
+        ply:SetNWBool("BodysnatcherIsRespawning", false)
+    end
+end)
+
 ------------------
 -- CUPID LOVERS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/shared.lua
@@ -162,3 +162,12 @@ hook.Add("TTTUpdateRoleState", "Bodysnatcher_Team_TTTUpdateRoleState", function(
     INDEPENDENT_ROLES[ROLE_BODYSNATCHER] = is_independent
     JESTER_ROLES[ROLE_BODYSNATCHER] = not is_independent
 end)
+
+hook.Add("TTTIsPlayerRespawning", "Bodysnatcher_TTTIsPlayerRespawning", function(ply)
+    if not IsPlayer(ply) then return end
+    if ply:Alive() then return end
+
+    if ply:GetNWBool("BodysnatcherIsRespawning", false) then
+        return true
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cl_cupid.lua
@@ -330,6 +330,52 @@ AddHook("Think", "Cupid_Highlight_Think", function()
     end
 end)
 
+---------------------
+-- CREDIT TRANSFER --
+---------------------
+
+local function LoverHasShop(sid64)
+    local ply = player.GetBySteamID64(sid64)
+    if not ply or not IsPlayer(ply) then return false end
+    return ply:CanUseShop()
+end
+
+AddHook("TTTPlayerCanSendCredits", "Cupid_TTTPlayerCanSendCredits", function(ply, credits, hasShop, canSend)
+    -- Don't block a role that can send credits already
+    if canSend then return end
+    -- Make sure they have credits to send
+    if credits <= 0 then return end
+    -- Only roles that have shops can transfer
+    if not hasShop then return end
+
+    -- If this is a cupid
+    if ply:IsActiveCupid() then
+        -- with both targets
+        local target1 = ply:GetNWString("TTTCupidTarget1", "")
+        if not target1 or #target1 == 0 then return end
+        local target2 = ply:GetNWString("TTTCupidTarget2", "")
+        if not target2 or #target2 == 0 then return end
+
+        -- and at least one of them has a shop
+        if not LoverHasShop(target1) and not LoverHasShop(target2) then return end
+
+        -- then they can send
+        return true
+    end
+
+    -- If this is a player with a lover that has a shop then they can send
+    local lover = ply:GetNWString("TTTCupidLover", "")
+    if lover and #lover > 0 and LoverHasShop(lover) then
+        return true
+    end
+
+    -- Or if they have a cupid with a shop then they can send
+    local shooter = ply:GetNWString("TTTCupidShooter", "")
+    if shooter and #shooter > 0 and LoverHasShop(shooter) then
+        return true
+    end
+end)
+
 --------------
 -- TUTORIAL --
 --------------

--- a/gamemodes/terrortown/gamemode/roles/cupid/cupid.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/cupid.lua
@@ -57,10 +57,9 @@ hook.Add("PlayerDeath", "Cupid_Killbind_PlayerDeath", function(victim, infl, att
 
     -- If the victim and the inflictor and the attacker are all the same thing then they probably used the "kill" console command
     if victim == attacker and IsValid(infl) and victim == infl then
-        victim.TTTCupidKillbindUsed = true
-
         local lover = player.GetBySteamID64(lover_sid64)
-        if lover and IsPlayer(lover) then
+        if lover and IsPlayer(lover) and lover:Alive() then
+            victim.TTTCupidKillbindUsed = true
             lover:QueueMessage(MSG_PRINTBOTH, "Your lover has died by their own hand! Try to survive without them...")
         end
     end

--- a/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/cupid/shared.lua
@@ -87,3 +87,38 @@ hook.Add("TTTUpdateRoleState", "Cupid_TTTUpdateRoleState", function()
     INDEPENDENT_ROLES[ROLE_CUPID] = is_independent
     JESTER_ROLES[ROLE_CUPID] = not is_independent
 end)
+
+hook.Add("TTTPlayerCanSendCreditsTo", "Cupid_TTTPlayerCanSendCreditsTo", function(ply, target, canSend)
+    -- Don't block a role that can send credits already
+    if canSend then return end
+    -- Only roles that have shops can transfer
+    if not ply:CanUseShop() then return end
+    -- and be transferred to
+    if not target:CanUseShop() then return end
+
+    local targetSid64 = target:SteamID64()
+
+    -- If this is a cupid
+    if ply:IsActiveCupid() then
+        -- with both targets
+        local target1 = ply:GetNWString("TTTCupidTarget1", "")
+        if not target1 or #target1 == 0 then return end
+        local target2 = ply:GetNWString("TTTCupidTarget2", "")
+        if not target2 or #target2 == 0 then return end
+
+        -- and we're being queried about one of their targets who has a shop, then they can be sent to
+        if targetSid64 == target1 or targetSid64 == target2 then
+            return true
+        end
+    end
+
+    -- If this target is the player's lover then they can be sent to
+    if targetSid64 == ply:GetNWString("TTTCupidLover", "") then
+        return true
+    end
+
+    -- Or if they are the player's cupid then they can be sent to
+    if targetSid64 == ply:GetNWString("TTTCupidShooter", "") then
+        return true
+    end
+end)

--- a/gamemodes/terrortown/gamemode/roles/glitch/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/glitch/shared.lua
@@ -23,6 +23,12 @@ hook.Add("TTTUpdateRoleState", "Glitch_TTTUpdateRoleState", function()
     TRAITOR_BUTTON_ROLES[ROLE_GLITCH] = glitch_use_traps
 end)
 
+hook.Add("TTTPlayerCanSendCreditsTo", "Glitch_TTTPlayerCanSendCreditsTo", function(sender, target, canSend)
+    if sender:IsTraitorTeam() and target:IsGlitch() then
+        return true
+    end
+end)
+
 ------------------
 -- ROLE CONVARS --
 ------------------

--- a/gamemodes/terrortown/gamemode/roles/jester/cl_jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/cl_jester.lua
@@ -38,6 +38,14 @@ hook.Add("TTTScoringWinTitle", "Jester_TTTScoringWinTitle", function(wintype, wi
     end
 end)
 
+-- Track when the jester gets a secondary win
+local jester_secondary_wins = false
+hook.Add("TTTScoringSecondaryWins", "Jester_TTTScoringSecondaryWins", function(wintype, secondary_wins)
+    if jester_secondary_wins then
+        table.insert(secondary_wins, ROLE_JESTER)
+    end
+end)
+
 ------------
 -- EVENTS --
 ------------
@@ -57,6 +65,17 @@ end)
 -------------
 -- SCORING --
 -------------
+
+net.Receive("TTT_UpdateJesterSecondaryWins", function()
+    jester_secondary_wins = true
+end)
+
+local function ResetJesterSecondaryWin()
+    jester_secondary_wins = false
+end
+net.Receive("TTT_ResetJesterSecondaryWins", ResetJesterSecondaryWin)
+hook.Add("TTTPrepareRound", "Jester_WinTracking_TTTPrepareRound", ResetJesterSecondaryWin)
+hook.Add("TTTBeginRound", "Jester_WinTracking_TTTBeginRound", ResetJesterSecondaryWin)
 
 -- Show who killed the jester (if anyone)
 hook.Add("TTTScoringSummaryRender", "Jester_TTTScoringSummaryRender", function(ply, roleFileName, groupingRole, roleColor, name, startingRole, finalRole)

--- a/gamemodes/terrortown/gamemode/roles/jester/jester.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/jester.lua
@@ -5,6 +5,9 @@ local player = player
 
 local PlayerIterator = player.Iterator
 
+util.AddNetworkString("TTT_UpdateJesterSecondaryWins")
+util.AddNetworkString("TTT_ResetJesterSecondaryWins")
+
 -------------
 -- CONVARS --
 -------------
@@ -13,6 +16,7 @@ CreateConVar("ttt_jester_notify_mode", "0", FCVAR_NONE, "The logic to use when n
 CreateConVar("ttt_jester_notify_killer", "1", FCVAR_NONE, "Whether to notify a jester's killer", 0, 1)
 CreateConVar("ttt_jester_notify_sound", "0", FCVAR_NONE, "Whether to play a cheering sound when a jester is killed", 0, 1)
 CreateConVar("ttt_jester_notify_confetti", "0", FCVAR_NONE, "Whether to throw confetti when a jester is a killed", 0, 1)
+local jester_win_ends_round = CreateConVar("ttt_jester_win_ends_round", "1", FCVAR_NONE, "Whether the jester winning causes the round to end", 0, 1)
 
 local jester_win_by_traitors = GetConVar("ttt_jester_win_by_traitors")
 
@@ -44,21 +48,31 @@ hook.Add("PlayerDeath", "Jester_WinCheck_PlayerDeath", function(victim, infl, at
         JesterKilledNotification(attacker, victim)
         victim:SetNWString("JesterKiller", attacker:Nick())
 
+        -- If the attacker was a traitor and the jester doesn't win when killed by a traitor, then don't continue
+        if attacker:IsTraitorTeam() and not jester_win_by_traitors:GetBool() then return end
+
+        -- If we're not ending the round, just reuse the existing variable and
+        -- set it to something valid so the win check logic sees it's been updated
+        if not jester_win_ends_round:GetBool() then
+            jesterWinTime = 1
+            net.Start("TTT_UpdateJesterSecondaryWins")
+            net.Broadcast()
+            return
+        end
+
         -- If we're debugging, don't end the round
         if GetConVar("ttt_debug_preventwin"):GetBool() then
             return
         end
 
-        -- Don't end the round if the jester was killed by a traitor
-        -- and the functionality that blocks Jester wins from traitor deaths is enabled
-        if jester_win_by_traitors:GetBool() or not attacker:IsTraitorTeam() then
-            -- Delay the actual end for a second so the message and sound have a chance to generate a reaction
-            jesterWinTime = CurTime() + 1
-        end
+        -- Delay the actual end for a second so the message and sound have a chance to generate a reaction
+        jesterWinTime = CurTime() + 1
     end
 end)
 
 hook.Add("TTTCheckForWin", "Jester_TTTCheckForWin", function()
+    if not jester_win_ends_round:GetBool() then return end
+
     if jesterWinTime then
         if CurTime() > jesterWinTime then
             jesterWinTime = nil
@@ -77,10 +91,18 @@ hook.Add("TTTPrintResultMessage", "Jester_TTTPrintResultMessage", function(type)
     end
 end)
 
-hook.Add("TTTPrepareRound", "Jester_PrepareRound", function()
+hook.Add("TTTPrepareRound", "Jester_TTTPrepareRound", function()
     jesterWinTime = nil
 
     for _, v in PlayerIterator() do
         v:SetNWString("JesterKiller", "")
     end
+
+    net.Start("TTT_ResetJesterSecondaryWins")
+    net.Broadcast()
+end)
+
+hook.Add("TTTBeginRound", "Jester_TTTBeginRound", function()
+    net.Start("TTT_ResetJesterSecondaryWins")
+    net.Broadcast()
 end)

--- a/gamemodes/terrortown/gamemode/roles/jester/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/jester/shared.lua
@@ -33,6 +33,10 @@ table.insert(ROLE_CONVARS[ROLE_JESTER], {
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_JESTER], {
+    cvar = "ttt_jester_win_ends_round",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_JESTER], {
     cvar = "ttt_jester_healthstation_reduce_max",
     type = ROLE_CONVAR_TYPE_BOOL
 })

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -131,13 +131,11 @@ end)
 local lootgoblin_wins = false
 net.Receive("TTT_UpdateLootGoblinWins", function()
     -- Log the win event with an offset to force it to the end
-    if net.ReadBool() then
-        lootgoblin_wins = true
-        CLSCORE:AddEvent({
-            id = EVENT_FINISH,
-            win = WIN_LOOTGOBLIN
-        }, 1)
-    end
+    lootgoblin_wins = true
+    CLSCORE:AddEvent({
+        id = EVENT_FINISH,
+        win = WIN_LOOTGOBLIN
+    }, 1)
 end)
 
 local function ResetLootGoblinWin()

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/lootgoblin.lua
@@ -302,7 +302,6 @@ local function HandleLootGoblinWinChecks(win_type)
     if not hasLootGoblin then return end
 
     net.Start("TTT_UpdateLootGoblinWins")
-    net.WriteBool(true)
     net.Broadcast()
 end
 hook.Add("TTTWinCheckComplete", "LootGoblin_TTTWinCheckComplete", HandleLootGoblinWinChecks)

--- a/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/cl_oldman.lua
@@ -36,13 +36,11 @@ end)
 local oldman_wins = false
 net.Receive("TTT_UpdateOldManWins", function()
     -- Log the win event with an offset to force it to the end
-    if net.ReadBool() then
-        oldman_wins = true
-        CLSCORE:AddEvent({
-            id = EVENT_FINISH,
-            win = WIN_OLDMAN
-        }, 1)
-    end
+    oldman_wins = true
+    CLSCORE:AddEvent({
+        id = EVENT_FINISH,
+        win = WIN_OLDMAN
+    }, 1)
 end)
 
 local function ResetOldManWin()

--- a/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
+++ b/gamemodes/terrortown/gamemode/roles/oldman/oldman.lua
@@ -34,7 +34,6 @@ local function HandleOldManWinChecks(win_type)
     if not player.IsRoleLiving(ROLE_OLDMAN) then return end
 
     net.Start("TTT_UpdateOldManWins")
-    net.WriteBool(true)
     net.Broadcast()
 end
 hook.Add("TTTWinCheckComplete", "OldMan_TTTWinCheckComplete", HandleOldManWinChecks)

--- a/gamemodes/terrortown/gamemode/roles/paramedic/cl_paramedic.lua
+++ b/gamemodes/terrortown/gamemode/roles/paramedic/cl_paramedic.lua
@@ -5,6 +5,8 @@ local hook = hook
 -------------
 
 local paramedic_defib_as_innocent = GetConVar("ttt_paramedic_defib_as_innocent")
+local paramedic_defib_as_is = GetConVar("ttt_paramedic_defib_as_is")
+local paramedic_defib_detectives_as_deputy = GetConVar("ttt_paramedic_defib_detectives_as_deputy")
 local paramedic_device_loadout = GetConVar("ttt_paramedic_device_loadout")
 local paramedic_device_shop = GetConVar("ttt_paramedic_device_shop")
 
@@ -55,7 +57,14 @@ hook.Add("TTTTutorialRoleText", "Paramedic_TTTTutorialRoleText", function(role, 
         if paramedic_defib_as_innocent:GetBool() then
             html = html .. " is converted to " .. ROLE_STRINGS_EXT[ROLE_INNOCENT]
         else
-            html = html .. " retains their previous role, with the exception of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "-like roles (e.g. " .. ROLE_STRINGS[ROLE_DETECTIVE] .. ", " .. ROLE_STRINGS[ROLE_DEPUTY] .. ", " .. ROLE_STRINGS[ROLE_IMPERSONATOR] .. ", etc.) which are converted to the vanilla role for their team (" .. ROLE_STRINGS[ROLE_INNOCENT] .. ", " .. ROLE_STRINGS[ROLE_TRAITOR] .. ", etc.)"
+            html = html .. " retains their previous role"
+            if not paramedic_defib_as_is:GetBool() then
+                if paramedic_defib_detectives_as_deputy:GetBool() then
+                    html = html .. ", with the exception of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " roles (e.g. " .. ROLE_STRINGS[ROLE_DETECTIVE] .. ", " .. ROLE_STRINGS[ROLE_TRACKER] .. ", " .. ROLE_STRINGS[ROLE_PALADIN] .. ", etc.) which are converted to a promoted ".. ROLE_STRINGS[ROLE_DEPUTY]
+                else
+                    html = html .. ", with the exception of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. "-like roles (e.g. " .. ROLE_STRINGS[ROLE_DETECTIVE] .. ", " .. ROLE_STRINGS[ROLE_DEPUTY] .. ", " .. ROLE_STRINGS[ROLE_IMPERSONATOR] .. ", etc.) which are converted to the vanilla role for their team (" .. ROLE_STRINGS[ROLE_INNOCENT] .. ", " .. ROLE_STRINGS[ROLE_TRAITOR] .. ", etc.)"
+                end
+            end
         end
         html = html .. ".</span>"
 

--- a/gamemodes/terrortown/gamemode/roles/paramedic/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/paramedic/shared.lua
@@ -24,14 +24,24 @@ end)
 -- ROLE CONVARS --
 ------------------
 
-CreateConVar("ttt_paramedic_defib_as_innocent", "0", FCVAR_REPLICATED)
-local paramedic_device_loadout = CreateConVar("ttt_paramedic_device_loadout", "1", FCVAR_REPLICATED)
-local paramedic_device_shop = CreateConVar("ttt_paramedic_device_shop", "0", FCVAR_REPLICATED)
-local paramedic_device_shop_rebuyable = CreateConVar("ttt_paramedic_device_shop_rebuyable", "0", FCVAR_REPLICATED)
+CreateConVar("ttt_paramedic_defib_as_innocent", "0", FCVAR_REPLICATED, "Whether the paramedic's defib brings back everyone as a vanilla innocent role", 0, 1)
+CreateConVar("ttt_paramedic_defib_as_is", "0", FCVAR_REPLICATED, "Whether the paramedic's defib brings back everyone as their previous role", 0, 1)
+CreateConVar("ttt_paramedic_defib_detectives_as_deputy", "0", FCVAR_REPLICATED, "Whether the paramedic's defib brings back detective roles as a promoted deputy", 0, 1)
+local paramedic_device_loadout = CreateConVar("ttt_paramedic_device_loadout", "1", FCVAR_REPLICATED, "Whether the paramedic's defib should be given to them when they spawn", 0, 1)
+local paramedic_device_shop = CreateConVar("ttt_paramedic_device_shop", "0", FCVAR_REPLICATED, "Whether the paramedic's defib should be purchasable in the shop", 0, 1)
+local paramedic_device_shop_rebuyable = CreateConVar("ttt_paramedic_device_shop_rebuyable", "0", FCVAR_REPLICATED, "Whether the paramedic's defib should be purchaseable multiple times", 0, 1)
 
 ROLE_CONVARS[ROLE_PARAMEDIC] = {}
 table.insert(ROLE_CONVARS[ROLE_PARAMEDIC], {
     cvar = "ttt_paramedic_defib_as_innocent",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_PARAMEDIC], {
+    cvar = "ttt_paramedic_defib_as_is",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
+table.insert(ROLE_CONVARS[ROLE_PARAMEDIC], {
+    cvar = "ttt_paramedic_defib_detectives_as_deputy",
     type = ROLE_CONVAR_TYPE_BOOL
 })
 table.insert(ROLE_CONVARS[ROLE_PARAMEDIC], {

--- a/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
+++ b/gamemodes/terrortown/gamemode/roles/parasite/parasite.lua
@@ -321,7 +321,7 @@ hook.Add("DoPlayerDeath", "Parasite_DoPlayerDeath", function(ply, attacker, dmgi
             -- If we're not infecting, but haunting then we just respawning immediately
             if parasite_infection_time:GetInt() <= 0 then
                 deadParasite:QueueMessage(MSG_PRINTCENTER, "Your host has been killed, allowing your infection to take over.")
-                DoParasiteRespawn(deadParasite, attacker, true)
+                DoParasiteRespawn(deadParasite, ply, true)
                 continue
             end
 

--- a/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/cl_shadow.lua
@@ -95,13 +95,11 @@ end
 local shadow_wins = false
 net.Receive("TTT_UpdateShadowWins", function()
     -- Log the win event with an offset to force it to the end
-    if net.ReadBool() then
-        shadow_wins = true
-        CLSCORE:AddEvent({
-            id = EVENT_FINISH,
-            win = WIN_SHADOW
-        }, 1)
-    end
+    shadow_wins = true
+    CLSCORE:AddEvent({
+        id = EVENT_FINISH,
+        win = WIN_SHADOW
+    }, 1)
 end)
 
 local function ResetShadowWin()

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -614,7 +614,6 @@ hook.Add("TTTWinCheckComplete", "Shadow_TTTWinCheckComplete", function(win_type)
     if not player.IsRoleLiving(ROLE_SHADOW) then return end
 
     net.Start("TTT_UpdateShadowWins")
-    net.WriteBool(true)
     net.Broadcast()
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/swapper/cl_swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/cl_swapper.lua
@@ -29,6 +29,12 @@ deal no damage however, if anyone kills you, they become
 the {swapper} and you take their role and can join the fight.]])
 end)
 
+hook.Add("TTTRolePopupParams", "Swapper_TTTRolePopupParams", function(cli)
+    if not cli:IsSwapper() then return end
+
+    return { swapper = ROLE_STRINGS[ROLE_SWAPPER] }
+end)
+
 -------------
 -- SCORING --
 -------------

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.13"
+CR_VERSION = "2.1.14"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/vgui/sb_info.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_info.lua
@@ -105,8 +105,7 @@ function PANEL:UpdatePlayerData(force)
             ic = vgui.Create("SimpleIconLabelled", self.List)
             ic:SetIconText(info.text_icon)
         else
-            local parent = self.List
-            ic = vgui.Create("SimpleIcon", parent)
+            ic = vgui.Create("SimpleIcon", self.List)
             if info.color then
                 ic:SetBackgroundColor(info.color)
             end

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -347,7 +347,7 @@ function PANEL:SetPlayer(ply)
             self.info:SetPlayer(ply)
 
             self:InvalidateLayout()
-        elseif g == GROUP_SEARCHED or g == GROUP_NOTFOUND then
+        elseif g == GROUP_SEARCHED or g == GROUP_FOUND or g == GROUP_NOTFOUND then
             self.info = vgui.Create("TTTScorePlayerInfoSearch", self)
             self.info:SetPlayer(ply)
             self:InvalidateLayout()

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -160,7 +160,9 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
         return ply:GetRole()
     end
 
-    if (ply.search_result and ply.search_result.role > ROLE_NONE) or ply == client then
+    if (ply.search_result and ply.search_result.role > ROLE_NONE) or
+        ply == client or
+        (ply:GetNWBool("body_found", false) and GetConVar("ttt_corpse_search_not_shared"):GetBool()) then
         return ply:GetRole()
     end
 

--- a/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/gamemodes/terrortown/gamemode/weaponry.lua
@@ -726,8 +726,18 @@ local function TransferCredits(ply, cmd, args)
     local sid64 = tostring(args[1])
     local credits = tonumber(args[2])
     if sid64 and credits then
+        -- Make sure the target is a valid player
         local target = player.GetBySteamID64(sid64)
-        if (not IsValid(target)) or (not target:IsActiveSpecial()) or not ply:IsSameTeam(target) or (target == ply) then
+        if not IsValid(target) or not target:IsActive() or target == ply then
+            LANG.Msg(ply, "xfer_no_recip")
+            return
+        end
+
+        -- Then make sure they are a valid role
+        local canSend = ply:IsSameTeam(target)
+        local newCanSend = CallHook("TTTPlayerCanSendCreditsTo", nil, ply, target, canSend)
+        if type(newCanSend) == "boolean" then canSend = newCanSend end
+        if not canSend then
             LANG.Msg(ply, "xfer_no_recip")
             return
         end
@@ -750,14 +760,14 @@ end
 concommand.Add("ttt_transfer_credits", TransferCredits)
 
 local function FakeTransferCredits(ply, cmd, args)
-    if (not IsValid(ply)) or (not ply:IsActiveSpecial()) then return end
+    if not IsValid(ply) or not ply:IsActive() then return end
     if #args ~= 2 then return end
 
     local sid = tostring(args[1])
     local credits = tonumber(args[2])
     if credits then
         local target = player.GetBySteamID64(sid)
-        if (not IsValid(target)) or (target == ply) then
+        if not IsValid(target) or target == ply then
             LANG.Msg(ply, "xfer_no_recip")
             return
         end


### PR DESCRIPTION
## Changelog
### Additions
- Added ability for paramedic to revive players as their original role (disabled by default)
- Added ability for paramedic to revive detective roles as a promoted deputy (disabled by default)
- Added ability to control whether the jester winning causes the round to end (enabled by default)
- Added ability to send credits between cupid and lovers if they have equipment shops
  - This allows Cupid <-> Lover as well as Lover <-> Lover

### Changes
- Changed `ttt_corpse_search_not_shared` to behave like searching in vanilla TTT
  - The corpse found message is broadcast but body info is not shown on the scoreboard unless the corpse is searched by a detective-like role

### Fixes
- Fixed "found" bodies not having an expandable scoreboard info section
- Fixed issue where player who killed someone hosting a parasite would also be killed when `ttt_parasite_infection_time` was `0`
- Fixed cupid lover who is killed receiving message saying their lover killed themselves
- Fixed placeholder not being replaced in swapper role popup message

### Developer
- Implemented `plymeta:IsRespawning` and `plymeta:StopRespawning` for bodysnatcher
- Added `TTTPlayerCanSendCredits` hook to allow overriding who can see the credits transfer tab in the equipment menu
- Added `TTTPlayerCanSendCreditsTo` hook to allow overriding who a player can send credits to

## Affected Issues
#736
#744
#745

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
