### PR TITLE
Misc. changes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -1121,6 +1121,7 @@ ttt_round_summary_tabs                         summary,hilite,events,scores // T
 // Misc.
 ttt_death_notifier_enabled                     1       // Whether the name and role of a player's killer should be shown to the victim
 ttt_death_notifier_show_role                   1       // Whether to show the killer's role in death notification messages
+ttt_death_notifier_show_team                   0       // Whether to show the killer's team in death notification messages (only used when "ttt_death_notifier_show_role" is disabled)
 ttt_smokegrenade_extinguish                    1       // Whether smoke grenades should extinguish fire
 ttt_player_set_color                           1       // Whether player colors are set each time that player spawns
 ttt_dna_scan_detectives_loadout                0       // Whether all detectives should be given a DNA scanner. If disabled, only the Detective role will get one

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 2.1.16 (Beta)
 **Released:**
 
+### Additions
+- Added ability to show killer team instead of role in death notification messages (disabled by default)
+
 ### Changes
 - Changed logic for the `ttt_hide_role` convar to be more efficient (Thanks Callum!)
 - Changed logic for recording which players spawned at the start of the round to be more efficient

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 2.1.16 (Beta)
-**Released:**
+**Released: May 25th, 2024**
 
 ### Additions
 - Added ability to show killer team instead of role in death notification messages (disabled by default)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,8 @@
 **Released:**
 
 ### Changes
-- Changed logic surrounding the `ttt_hide_role` convar to be more efficient (Thanks Callum!)
+- Changed logic for the `ttt_hide_role` convar to be more efficient (Thanks Callum!)
+- Changed logic for recording which players spawned at the start of the round to be more efficient
 
 ## 2.1.15 (Beta)
 **Released: May 11th, 2024**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.1.16 (Beta)
+**Released:**
+
+### Changes
+- Changed logic surrounding the `ttt_hide_role` convar to be more efficient (Thanks Callum!)
+
 ## 2.1.15 (Beta)
 **Released: May 11th, 2024**
 

--- a/docs/tutorials/configuring_convars.html
+++ b/docs/tutorials/configuring_convars.html
@@ -323,6 +323,12 @@ ttt_another_string "custom roles for ttt" // This line would set the value of th
                 <td>Whether to show the killer's role in death notification messages.</td>
             </tr>
             <tr>
+                <td>ttt_death_notifier_show_team <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                <td>0</td>
+                <td>Boolean</td>
+                <td>Whether to show the killer's team in death notification messages. <i>(Only used when <code>ttt_death_notifier_show_role</code> is disabled.)</i></td>
+            </tr>
+            <tr>
                 <td>ttt_smokegrenade_extinguish</td>
                 <td>1</td>
                 <td>Boolean</td>

--- a/gamemodes/terrortown/gamemode/cl_deathnotify.lua
+++ b/gamemodes/terrortown/gamemode/cl_deathnotify.lua
@@ -14,6 +14,8 @@ AddHook("Initialize", "DeathNotify_Initialize", function()
     LANG.AddToLanguage("english", "deathnotify_ply_mid", ", they were ")
     LANG.AddToLanguage("english", "deathnotify_ply_end", "!")
     LANG.AddToLanguage("english", "deathnotify_team_mid", ", they were on the ")
+    LANG.AddToLanguage("english", "deathnotify_team_mid_hidden", ", they were on a ")
+    LANG.AddToLanguage("english", "deathnotify_team_mid_hidden_name", "hidden")
     LANG.AddToLanguage("english", "deathnotify_team_end", " team!")
     LANG.AddToLanguage("english", "deathnotify_fell", "You fell to your death!")
     LANG.AddToLanguage("english", "deathnotify_water", "You drowned!")
@@ -33,9 +35,18 @@ net.Receive("TTT_ClientDeathNotify", function()
         local col = ROLE_COLORS_HIGHLIGHT[role]
         chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_ply_start"), col, name, COLOR_WHITE, GetTranslation("deathnotify_ply_mid"), col, roleString, COLOR_WHITE, GetTranslation("deathnotify_ply_end"))
     elseif reason == "team" then
-        local teamName, teamColor = GetRoleTeamInfo(role, true)
-        print(role, teamName, teamColor)
-        chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_ply_start"), teamColor, name, COLOR_WHITE, GetTranslation("deathnotify_team_mid"), teamColor, teamName, COLOR_WHITE, GetTranslation("deathnotify_team_end"))
+        local midTranslation = "deathnotify_team_mid"
+        local teamName, teamColor
+        -- Special logic for if the role of the player is hidden
+        if role == ROLE_NONE then
+            midTranslation = midTranslation .. "_hidden"
+            teamName = GetTranslation("deathnotify_team_mid_hidden_name")
+            teamColor = ROLE_COLORS_HIGHLIGHT[role]
+        else
+            teamName, teamColor = GetRoleTeamInfo(role, true)
+        end
+
+        chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_ply_start"), teamColor, name, COLOR_WHITE, GetTranslation(midTranslation), teamColor, teamName, COLOR_WHITE, GetTranslation("deathnotify_team_end"))
     else
         chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_" .. reason))
     end

--- a/gamemodes/terrortown/gamemode/cl_deathnotify.lua
+++ b/gamemodes/terrortown/gamemode/cl_deathnotify.lua
@@ -13,6 +13,8 @@ AddHook("Initialize", "DeathNotify_Initialize", function()
     LANG.AddToLanguage("english", "deathnotify_ply_start", "You were killed by ")
     LANG.AddToLanguage("english", "deathnotify_ply_mid", ", they were ")
     LANG.AddToLanguage("english", "deathnotify_ply_end", "!")
+    LANG.AddToLanguage("english", "deathnotify_team_mid", ", they were on the ")
+    LANG.AddToLanguage("english", "deathnotify_team_end", " team!")
     LANG.AddToLanguage("english", "deathnotify_fell", "You fell to your death!")
     LANG.AddToLanguage("english", "deathnotify_water", "You drowned!")
     LANG.AddToLanguage("english", "deathnotify_nil", "You died!")
@@ -29,7 +31,11 @@ net.Receive("TTT_ClientDeathNotify", function()
         -- Format the number role into a human readable role and identifying color
         local roleString = ROLE_STRINGS_EXT[role]
         local col = ROLE_COLORS_HIGHLIGHT[role]
-        chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_ply_start"), col, name, COLOR_WHITE, GetTranslation("deathnotify_ply_mid"), col, roleString .. GetTranslation("deathnotify_ply_end"))
+        chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_ply_start"), col, name, COLOR_WHITE, GetTranslation("deathnotify_ply_mid"), col, roleString, COLOR_WHITE, GetTranslation("deathnotify_ply_end"))
+    elseif reason == "team" then
+        local teamName, teamColor = GetRoleTeamInfo(role, true)
+        print(role, teamName, teamColor)
+        chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_ply_start"), teamColor, name, COLOR_WHITE, GetTranslation("deathnotify_team_mid"), teamColor, teamName, COLOR_WHITE, GetTranslation("deathnotify_team_end"))
     else
         chat.AddText(COLOR_WHITE, GetTranslation("deathnotify_" .. reason))
     end

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -167,9 +167,11 @@ local function RoundStateChange(o, n)
         VOICE.CycleMuteState(MUTE_NONE)
 
         CLSCORE:ClearPanel()
+        CLSCORE:ResetScoreboard()
 
-        -- people may have died and been searched during prep
         for _, p in PlayerIterator() do
+            CLSCORE:PlayerSpawned(p)
+            -- people may have died and been searched during prep
             p.search_result = nil
         end
 

--- a/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -95,10 +95,29 @@ local PT = LANG.GetParamTranslation
 local spawnedPlayers = {}
 local disconnected = {}
 local customEvents = {}
+local secondary_win_roles = {}
+
+function CLSCORE:ResetScoreboard()
+    spawnedPlayers = {}
+    disconnected = {}
+    customEvents = {}
+    secondary_win_roles = {}
+end
 
 function CLSCORE:AddEvent(e, offset)
     e["t"] = math.Round(CurTime() + (offset or 0), 2)
     table.insert(customEvents, e)
+end
+
+function CLSCORE:PlayerSpawned(ply)
+    local name = ply:Nick()
+    local role = ply:GetRole()
+    table.insert(spawnedPlayers, name)
+    CLSCORE:AddEvent({
+        id = EVENT_SPAWN,
+        ply = name,
+        rol = role
+    })
 end
 
 local function FitNicknameLabel(nicklbl, maxwidth, getstring, args)
@@ -127,26 +146,6 @@ net.Receive("TTT_PlayerDisconnected", function(len)
         id = EVENT_DISCONNECTED,
         vic = name
     })
-end)
-
-net.Receive("TTT_ResetScoreboard", function(len)
-    spawnedPlayers = {}
-    disconnected = {}
-    customEvents = {}
-end)
-
-local secondary_win_roles = {}
-net.Receive("TTT_SpawnedPlayers", function(len)
-    local name = net.ReadString()
-    local role = net.ReadInt(8)
-    table.insert(spawnedPlayers, name)
-    CLSCORE:AddEvent({
-        id = EVENT_SPAWN,
-        ply = name,
-        rol = role
-    })
-
-    table.Empty(secondary_win_roles)
 end)
 
 net.Receive("TTT_LogInfo", function(len)

--- a/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -367,6 +367,9 @@ local MAX_TRACE_LENGTH = math.sqrt(3) * 2 * 16384
 
 function GM:HUDDrawTargetID()
     client = LocalPlayer()
+    if not hide_role then
+        hide_role = GetConVar("ttt_hide_role")
+    end
 
     local L = GetLang()
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -275,11 +275,9 @@ util.AddNetworkString("TTT_Radar")
 util.AddNetworkString("TTT_Spectate")
 util.AddNetworkString("TTT_TeleportMark")
 util.AddNetworkString("TTT_ClearRadarExtras")
-util.AddNetworkString("TTT_SpawnedPlayers")
 util.AddNetworkString("TTT_Defibrillated")
 util.AddNetworkString("TTT_RoleChanged")
 util.AddNetworkString("TTT_LogInfo")
-util.AddNetworkString("TTT_ResetScoreboard")
 util.AddNetworkString("TTT_BuyableWeapons")
 util.AddNetworkString("TTT_UpdateBuyableWeapons")
 util.AddNetworkString("TTT_ResetBuyableWeaponsCache")
@@ -861,18 +859,6 @@ function BeginRound()
         v:BeginRoleChecks()
 
         SetRoleHealth(v)
-    end
-
-    net.Start("TTT_ResetScoreboard")
-    net.Broadcast()
-
-    for _, v in PlayerIterator() do
-        if v:Alive() and v:IsTerror() then
-            net.Start("TTT_SpawnedPlayers")
-            net.WriteString(v:Nick())
-            net.WriteInt(v:GetRole(), 8)
-            net.Broadcast()
-        end
     end
 
     -- Give the StateUpdate messages ample time to arrive

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.1.15"
+CR_VERSION = "2.1.16"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog
### Additions
- Added ability to show killer team instead of role in death notification messages (disabled by default)

### Changes
- Changed logic for the `ttt_hide_role` convar to be more efficient (Thanks Callum!)
- Changed logic for recording which players spawned at the start of the round to be more efficient

## Affected Issues
#753

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
  - https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX/pull/119