### PR TITLE
Plaguemaster changes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -919,7 +919,7 @@ ttt_hivemind_update_scoreboard                 1       // Whether the hive mind 
 // Plaguemaster
 ttt_plaguemaster_plague_length                 180     // How long (in seconds) before a player with the plague dies
 ttt_plaguemaster_warning_time                  30      // How long (in seconds) before dying to the plague that the target should be warned. Set to 0 to disable
-ttt_plaguemaster_spread_time                   10      // How long (in seconds) someone with the plague needs to be near someone else before it spreads
+ttt_plaguemaster_spread_time                   5       // How long (in seconds) someone with the plague needs to be near someone else before it spreads
 ttt_plaguemaster_spread_distance               500     // The maximum distance away a player can be and still be infected
 ttt_plaguemaster_spread_require_los            1       // Whether players need to be in line-of-sight of a target to spread the plague
 ttt_plaguemaster_immune                        1       // Whether the plaguemaster is immune to the plague

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -923,6 +923,7 @@ ttt_plaguemaster_spread_time                   5       // How long (in seconds) 
 ttt_plaguemaster_spread_distance               500     // The maximum distance away a player can be and still be infected
 ttt_plaguemaster_spread_require_los            1       // Whether players need to be in line-of-sight of a target to spread the plague
 ttt_plaguemaster_immune                        1       // Whether the plaguemaster is immune to the plague
+ttt_plaguemaster_dart_replace_timer            0       // How long (in seconds) after the plaguemaster's infection dies out before they should receive another dart gun. Set to 0 to disable
 ttt_plaguemaster_body_search_mode              1       // Whether dead bodies reveal if they had the plague when searched. 0 - Don't show. 1 - Show if died from plague. 2 - Show if infected with plague.
 ttt_plaguemaster_can_see_jesters               0       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the plaguemaster
 ttt_plaguemaster_update_scoreboard             1       // Whether the plaguemaster shows dead players as missing in action

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Changes
 - Changed plaguemaster's dart gun to be silent
+- Changed plaguemaster's plague to spread faster by default
 
 ### Fixes
 - Fixed plaguemaster's dart gun being droppable

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 2.2.1 (Beta)
 **Released:**
 
+### Changes
+- Changed plaguemaster's dart gun to be silent
+
 ### Fixes
 - Fixed plaguemaster's dart gun being droppable
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,9 @@
 ## 2.2.1 (Beta)
 **Released:**
 
+### Additions
+- Added ability for plaguemaster to get a new dart gun after their last plague victim dies (disabled by default)
+
 ### Changes
 - Changed plaguemaster's dart gun to be silent
 - Changed plaguemaster's plague to spread faster by default

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 ### Changes
 - Changed plaguemaster's dart gun to be silent
 - Changed plaguemaster's plague to spread faster by default
+- Changed the plaguemaster's dart gun to not have any impact effects (blood splatter) from the victim's perspective so it's not immediately obvious
 
 ### Fixes
 - Fixed plaguemaster's dart gun being droppable

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.2.1 (Beta)
+**Released:**
+
+### Fixes
+- Fixed plaguemaster's dart gun being droppable
+
 ## 2.2.0
 **Released: August 12th, 2024**\
 Includes beta updates [2.1.17](#2117-beta) and [2.1.20](#2120-beta).

--- a/addon.json
+++ b/addon.json
@@ -16,6 +16,8 @@
     "scripts*",
     "templates*",
     "images*",
-    "docs*"
+    "docs*",
+    "*.sw.vtx",
+    "*.xbox.vtx"
   ]
 }

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -832,7 +832,7 @@
                         </tr>
                         <tr>
                             <td>ttt_plaguemaster_spread_time</td>
-                            <td>10</td>
+                            <td>5</td>
                             <td>Integer</td>
                             <td>How long (in seconds) someone with the plague needs to be near someone else before it spreads.</td>
                         </tr>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -807,6 +807,12 @@
                             <td>Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the Plaguemaster.</td>
                         </tr>
                         <tr>
+                            <td>ttt_plaguemaster_dart_replace_timer <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Integer</td>
+                            <td>How long (in seconds) after the plaguemaster's infection dies out before they should receive another dart gun. Set to 0 to disable.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_plaguemaster_immune</td>
                             <td>1</td>
                             <td>Boolean</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
@@ -22,8 +22,6 @@ SWEP.Primary.Automatic     = true
 SWEP.Primary.DefaultClip   = 1
 SWEP.Primary.ClipMax       = 1
 SWEP.Primary.Ammo          = "none"
-SWEP.Primary.Sound         = Sound("Weapon_USP.SilencedShot")
-SWEP.Primary.SoundLevel    = 50
 
 SWEP.Kind                  = WEAPON_ROLE
 SWEP.InLoadoutFor          = {ROLE_PLAGUEMASTER}
@@ -77,12 +75,6 @@ function SWEP:PrimaryAttack()
     end
 
     owner:FireBullets(bullet)
-
-    if not worldsnd then
-        self:EmitSound( self.Primary.Sound, self.Primary.SoundLevel )
-    elseif SERVER then
-        sound.Play(self.Primary.Sound, self:GetPos(), self.Primary.SoundLevel)
-    end
 
     if owner:IsNPC() or (not owner.ViewPunch) then return end
     owner:ViewPunch(Angle(util.SharedRandom(self:GetClass(), -0.2, -0.1, 0) * self.Primary.Recoil, util.SharedRandom(self:GetClass(), -0.1, 0.1, 1) * self.Primary.Recoil, 0))

--- a/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
@@ -65,11 +65,18 @@ function SWEP:PrimaryAttack()
 
         if SERVER and tr.Hit and tr.HitNonWorld and IsPlayer(tr.Entity) then
             local victim = tr.Entity
+            -- If the target already has the plague, don't try to give it to them again
+            if victim.TTTPlaguemasterStartTime then
+                owner:QueueMessage(MSG_PRINTBOTH, victim:Nick() .. " already has the plague, find someone new!")
+                return
+            end
+
             net.Start("TTT_PlaguemasterPlagued")
                 net.WriteString(victim:Nick())
                 net.WriteString(owner:Nick())
             net.Broadcast()
             victim:SetProperty("TTTPlaguemasterStartTime", CurTime())
+            victim.TTTPlaguemasterOriginalSource = owner:SteamID64()
             self:Remove()
         end
     end

--- a/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
@@ -61,16 +61,16 @@ function SWEP:PrimaryAttack()
     bullet.Force      = 2
     bullet.Damage     = self.Primary.Damage
     bullet.Callback   = function(attacker, tr, dmginfo)
+        if not SERVER then return end
         if not IsValid(owner) then return end
+        if not tr.Hit or not tr.HitNonWorld then return end
+        if not IsPlayer(tr.Entity) then return end
 
-        if SERVER and tr.Hit and tr.HitNonWorld and IsPlayer(tr.Entity) then
-            local victim = tr.Entity
-            -- If the target already has the plague, don't try to give it to them again
-            if victim.TTTPlaguemasterStartTime then
-                owner:QueueMessage(MSG_PRINTBOTH, victim:Nick() .. " already has the plague, find someone new!")
-                return
-            end
-
+        local victim = tr.Entity
+        -- If the target already has the plague, don't try to give it to them again
+        if victim.TTTPlaguemasterStartTime then
+            owner:QueueMessage(MSG_PRINTBOTH, victim:Nick() .. " already has the plague, find someone new!")
+        else
             net.Start("TTT_PlaguemasterPlagued")
                 net.WriteString(victim:Nick())
                 net.WriteString(owner:Nick())
@@ -79,6 +79,9 @@ function SWEP:PrimaryAttack()
             victim.TTTPlaguemasterOriginalSource = owner:SteamID64()
             self:Remove()
         end
+
+        -- Disable effects so the victim doesn't know they got shot by something
+        return { effects = false, damage = false }
     end
 
     owner:FireBullets(bullet)

--- a/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_plm_dartgun.lua
@@ -28,6 +28,7 @@ SWEP.Primary.SoundLevel    = 50
 SWEP.Kind                  = WEAPON_ROLE
 SWEP.InLoadoutFor          = {ROLE_PLAGUEMASTER}
 
+SWEP.AllowDrop             = false
 SWEP.IsSilent              = true
 
 SWEP.UseHands              = true

--- a/gamemodes/terrortown/gamemode/roles/plaguemaster/plaguemaster.lua
+++ b/gamemodes/terrortown/gamemode/roles/plaguemaster/plaguemaster.lua
@@ -19,16 +19,19 @@ local plaguemaster_spread_distance = GetConVar("ttt_plaguemaster_spread_distance
 local plaguemaster_spread_require_los = GetConVar("ttt_plaguemaster_spread_require_los")
 local plaguemaster_spread_time = GetConVar("ttt_plaguemaster_spread_time")
 local plaguemaster_warning_time = GetConVar("ttt_plaguemaster_warning_time")
+local plaguemaster_dart_replace_timer = GetConVar("ttt_plaguemaster_dart_replace_timer")
 
 ------------
 -- PLAGUE --
 ------------
 
-local function SetSpreadStart(ply, sid64)
+local function SetSpreadStart(ply, source)
     local time = CurTime()
+    local sid64 = source:SteamID64()
     ply.TTTPlaguemasterSpreadStartTimes[sid64] = time
     if not ply.TTTPlaguemasterCurrentSource then
         ply.TTTPlaguemasterCurrentSource = sid64
+        ply.TTTPlaguemasterOriginalSource = source.TTTPlaguemasterOriginalSource
         ply:SetProperty("TTTPlaguemasterSpreadStart", time, ply)
     end
 end
@@ -44,9 +47,13 @@ local function ClearSpreadStart(ply, sid64)
     if ply.TTTPlaguemasterCurrentSource == sid64 then
         local earliest = nil
         for src64, t in pairs(ply.TTTPlaguemasterSpreadStartTimes) do
+            local source = player.GetBySteamID64(src64)
+            if not source then continue end
+
             if not earliest or earliest.time < t then
                 earliest = {
                     source = src64,
+                    origSource = source.TTTPlaguemasterOriginalSource,
                     time = t
                 }
             end
@@ -55,10 +62,12 @@ local function ClearSpreadStart(ply, sid64)
         -- If there was one, save it
         if earliest then
             ply.TTTPlaguemasterCurrentSource = earliest.source
+            ply.TTTPlaguemasterOriginalSource = earliest.origSource
             ply:SetProperty("TTTPlaguemasterSpreadStart", earliest.time, ply)
         -- If not, clear it
         else
             ply.TTTPlaguemasterCurrentSource = nil
+            ply.TTTPlaguemasterOriginalSource = nil
             ply:ClearProperty("TTTPlaguemasterSpreadStart", ply)
         end
     end
@@ -111,7 +120,7 @@ AddHook("TTTPlayerAliveThink", "Plaguemaster_Plague_TTTPlayerAliveThink", functi
 
         -- If we haven't started spreading to this target, mark the start time
         if not v.TTTPlaguemasterSpreadStartTimes[sid64] then
-            SetSpreadStart(v, sid64)
+            SetSpreadStart(v, ply)
 
             -- If this is a plaguemaster that hasn't been warned, warn them
             if v:IsPlaguemaster() and not v.TTTPlaguemasterWarned then
@@ -138,11 +147,38 @@ AddHook("PostPlayerDeath", "Plaguemaster_PostPlayerDeath", function(ply)
     if not plague_start then return end
 
     local sid64 = ply:SteamID64()
+    local plague_active = false
+    local living_players = 0
+    local original_source = ply.TTTPlaguemasterOriginalSource
     for _, v in PlayerIterator() do
         if v == ply then continue end
+
+        -- Keep track if anyone still has the plague started by the original source
+        if v:Alive() and not v:IsSpec() then
+            living_players = living_players + 1
+            if v.TTTPlaguemasterOriginalSource == original_source then
+                plague_active = true
+            end
+        end
+
         if v.TTTPlaguemasterSpreadStartTimes[sid64] then
             ClearSpreadStart(v, sid64)
         end
+    end
+
+    local dart_replace_timer = plaguemaster_dart_replace_timer:GetInt()
+    -- If nobody has theplague and we're set to replace their dart gun, let them know and start the timer
+    if living_players > 1 and not plague_active and dart_replace_timer > 0 then
+        local source = player.GetBySteamID64(original_source)
+        if not IsPlayer(source) then return end
+
+        source:QueueMessage(MSG_PRINTBOTH, "Your plague has died out. You will be given a replacement dart gun in " .. dart_replace_timer .. " seconds.")
+        timer.Create("TTTPlaguemasterDartReplace_" .. original_source, dart_replace_timer, 1, function()
+            if not IsPlayer(source) then return end
+
+            source:QueueMessage(MSG_PRINTBOTH, "You have been given a replacement dart gun. Choose a new victim and restart your plague.")
+            source:Give("weapon_plm_dartgun")
+        end)
     end
 end)
 
@@ -189,6 +225,8 @@ local function ClearPlaguemasterState(ply)
     ply.TTTPlaguemasterWarned = false
     ply.TTTPlaguemasterSpreadStartTimes = {}
     ply.TTTPlaguemasterCurrentSource = nil
+    ply.TTTPlaguemasterOriginalSource = nil
+    timer.Remove("TTTPlaguemasterDartReplace_" .. ply:SteamID64())
 end
 
 AddHook("TTTPrepareRound", "Plaguemaster_PrepareRound", function()

--- a/gamemodes/terrortown/gamemode/roles/plaguemaster/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/plaguemaster/shared.lua
@@ -20,6 +20,7 @@ CreateConVar("ttt_plaguemaster_spread_require_los", 1, FCVAR_REPLICATED, "Whethe
 CreateConVar("ttt_plaguemaster_spread_time", 5, FCVAR_REPLICATED, "How long (in seconds) someone with the plague needs to be near someone else before it spreads", 0, 180)
 CreateConVar("ttt_plaguemaster_warning_time", 30, FCVAR_REPLICATED, "How long (in seconds) before dying to the plague that the target should be warned. Set to 0 to disable", 0, 180)
 CreateConVar("ttt_plaguemaster_body_search_mode", 1, FCVAR_REPLICATED, "Whether dead bodies reveal if they had the plague when searched", 0, 2)
+CreateConVar("ttt_plaguemaster_dart_replace_timer", 0, FCVAR_REPLICATED, "How long (in seconds) after the plaguemaster's infection dies out before they should receive another dart gun. Set to 0 to disable", 0, 180)
 
 ROLE_CONVARS[ROLE_PLAGUEMASTER] = {}
 table.insert(ROLE_CONVARS[ROLE_PLAGUEMASTER], {
@@ -55,6 +56,11 @@ table.insert(ROLE_CONVARS[ROLE_PLAGUEMASTER], {
     type = ROLE_CONVAR_TYPE_DROPDOWN,
     choices = {"Don't show", "Show if died from plague", "Show if infected"},
     isNumeric = true
+})
+table.insert(ROLE_CONVARS[ROLE_PLAGUEMASTER], {
+    cvar = "ttt_plaguemaster_dart_replace_timer",
+    type = ROLE_CONVAR_TYPE_NUM,
+    decimal = 0
 })
 
 -------------------

--- a/gamemodes/terrortown/gamemode/roles/plaguemaster/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/plaguemaster/shared.lua
@@ -17,7 +17,7 @@ CreateConVar("ttt_plaguemaster_immune", 1, FCVAR_REPLICATED, "Whether the plague
 CreateConVar("ttt_plaguemaster_plague_length", 180, FCVAR_REPLICATED, "How long (in seconds) before a player with the plague dies", 1, 300)
 CreateConVar("ttt_plaguemaster_spread_distance", 500, FCVAR_REPLICATED, "The maximum distance away a player can be and still be infected", 50, 2000)
 CreateConVar("ttt_plaguemaster_spread_require_los", 1, FCVAR_REPLICATED, "Whether players need to be in line-of-sight of a target to spread the plague", 0, 1)
-CreateConVar("ttt_plaguemaster_spread_time", 10, FCVAR_REPLICATED, "How long (in seconds) someone with the plague needs to be near someone else before it spreads", 0, 180)
+CreateConVar("ttt_plaguemaster_spread_time", 5, FCVAR_REPLICATED, "How long (in seconds) someone with the plague needs to be near someone else before it spreads", 0, 180)
 CreateConVar("ttt_plaguemaster_warning_time", 30, FCVAR_REPLICATED, "How long (in seconds) before dying to the plague that the target should be warned. Set to 0 to disable", 0, 180)
 CreateConVar("ttt_plaguemaster_body_search_mode", 1, FCVAR_REPLICATED, "Whether dead bodies reveal if they had the plague when searched", 0, 2)
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.2.0"
+CR_VERSION = "2.2.1"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog
### Additions
- Added ability for plaguemaster to get a new dart gun after their last plague victim dies (disabled by default)

### Changes
- Changed plaguemaster's dart gun to be silent
- Changed plaguemaster's plague to spread faster by default
- Changed the plaguemaster's dart gun to not have any impact effects (blood splatter) from the victim's perspective so it's not immediately obvious

### Fixes
- Fixed plaguemaster's dart gun being droppable

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
