### PR TITLE
Added method for clearing specific queued messages

### DIFF
--- a/API/METHODS_PLAYER_OBJECT.md
+++ b/API/METHODS_PLAYER_OBJECT.md
@@ -51,6 +51,13 @@ Clears the value of the property with the given `name` on this player then synch
 - *name* - The name of the property being cleared.
 - *targets* - The targets that should have this value cleared on their clients. *(Defaults to sending to all players)*
 
+### plymeta:ClearQueuedMessage(id)
+Removes queued messages with the given ID from the queue and clears any currently displayed messages with the given ID.\
+*Realm:* Client and Server\
+*Added in:* 2.2.1\
+*Parameters:*
+- *id* - The identifier of the message(s) you want to clear
+
 ### plymeta:DrunkJoinLosingTeam()
 Attempts to find the losing team and calls `self:SoberDrunk(team)` using the losing team as the *team* parameter.\
 *Realm:* Server\
@@ -332,14 +339,15 @@ Begins printing messages from the message queue if it's not already. Automatical
 *Realm:* Server\
 *Added in:* 1.9.4
 
-### plymeta:QueueMessage(message_type, message, time, predicate)
+### plymeta:QueueMessage(message_type, message, time, id, predicate)
 Queues a message to be shown to the player. Useful in situations where multiple center-screen messages could be shown at the same time and overlapped. This ensures each message is shown in order without overlap.\
-*Realm:* Server and Client\
+*Realm:* Client and Server\
 *Added in:* 1.9.4\
 *Parameters:*
 - *message_type* - The [MSG_PRINT*](GLOBAL_ENUMERATIONS.md#msg_print) value representing the display target for this message
 - *message* - The message being shown
-- *time* - The amount of time to display the message in the center of the screen. Only used when *message_type* is *MSG_PRINTBOTH* or *MSG_PRINTCENTER*
+- *time* - The amount of time to display the message in the center of the screen. Only used when *message_type* is *MSG_PRINTBOTH* or *MSG_PRINTCENTER* (Optional. Defaults to 5 seconds if not provided)
+- *id* - An identifier string that can be used to clear the message or remove it from the queue (Optional) *(Added in 2.2.1)*
 - *predicate* - Predicate function called with the player as the sole parameter before the message is sent. Return *true* to allow the message or *false* to prevent it (Optional) *(Added in 2.0.5)* *(Only available on the server realm)*
 
 ### plymeta:RemoveEquipmentItem(item_id)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,8 @@
 ### Fixes
 - Fixed plaguemaster's dart gun being droppable
 - Fixed plaguemaster's infection warning message from being queued many times in a row if the plaguemaster repeatedly crosses the boundary of an infected player's spread radius
+- Fixed shadow's buff/punishment warning messages from being queued many times in a row if the shadow repeatedly crosses the boundary of their target's radius
+- Fixed assassin's new target messages from sometimes being outdated by the time they appear
 
 ### Developer
 - Added `plymeta:ClearQueuedMessage` method which can remove queued messages of a given ID from the message queue

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,11 @@
 
 ### Fixes
 - Fixed plaguemaster's dart gun being droppable
+- Fixed plaguemaster's infection warning message from being queued many times in a row if the plaguemaster repeatedly crosses the boundary of an infected player's spread radius
+
+### Developer
+- Added `plymeta:ClearQueuedMessage` method which can remove queued messages of a given ID from the message queue
+  - Added optional `id` parameter to `plymeta:QueueMessage` to provide queued messages with an ID
 
 ## 2.2.0
 **Released: August 12th, 2024**\

--- a/docs/api/methods_player_object.html
+++ b/docs/api/methods_player_object.html
@@ -91,6 +91,17 @@
             <li><em>targets</em> - The targets that should have this value cleared on their clients. <em>(Defaults to sending to all players)</em></li>
         </ul>
 
+        <h3><a id="plymetaclearqueuedmessageid" href="#plymetaclearqueuedmessageid">plymeta:ClearQueuedMessage(id)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <p>
+            Removes queued messages with the given ID from the queue and clears any currently displayed messages with the given ID.<br>
+            <em>Realm:</em> Client and Server<br>
+            <em>Added in:</em> 2.2.1<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>id</em> - The identifier of the message(s) you want to clear</li>
+        </ul>
+
         <h3><a id="plymetadrunkjoinlosingteam" href="#plymetadrunkjoinlosingteam">plymeta:DrunkJoinLosingTeam()</a></h3>
         <p>
             Attempts to find the losing team and calls <code>self:SoberDrunk(team)</code> using the losing team as the <em>team</em> parameter.<br>
@@ -499,7 +510,7 @@
             <em>Added in:</em> 1.9.4<br>
         </p>
         
-        <h3><a id="plymetaqueuemessagemessage_type-message-time-predicate" href="#plymetaqueuemessagemessage_type-message-time-predicate">plymeta:QueueMessage(message_type, message, time, predicate)</a></h3>
+        <h3><a id="plymetaqueuemessagemessage_type-message-time-id-predicate" href="#plymetaqueuemessagemessage_type-message-time-id-predicate">plymeta:QueueMessage(message_type, message, time, id, predicate)</a></h3>
         <p>
             Queues a message to be shown to the player. Useful in situations where multiple center-screen messages could be shown at the same time and overlapped. This ensures each message is shown in order without overlap.<br>
             <em>Realm:</em> Server and Client<br>
@@ -509,7 +520,8 @@
         <ul>
             <li><em>message_type</em> - The <a href="global_enumerations.html#msg_print" target="_blank">MSG_PRINT*</a> value representing the display target for this message</li>
             <li><em>message</em> - The message being shown</li>
-            <li><em>time</em> - The amount of time to display the message in the center of the screen. Only used when <code>message_type</code> is <code>MSG_PRINTBOTH</code> or <code>MSG_PRINTCENTER</code></li>
+            <li><em>time</em> - The amount of time to display the message in the center of the screen. Only used when <code>message_type</code> is <code>MSG_PRINTBOTH</code> or <code>MSG_PRINTCENTER</code> (Optional. Defaults to 5 seconds if not provided)</li>
+            <li><em>id</em> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> - An identifier string that can be used to clear the message or remove it from the queue (Optional) <em>(Added in 2.2.1)</em></li>
             <li><em>predicate</em> - Predicate function called with the player as the sole parameter before the message is sent. Return <code>true</code> to allow the message or <code>false</code> to prevent it (Optional) <em>(Added in 2.0.5)</em> <em>(Only available on the server realm)</em></li>
         </ul>
 

--- a/docs/teams/innocent.html
+++ b/docs/teams/innocent.html
@@ -308,7 +308,7 @@
             </div>
         </div>
         <div id="good-twin" class="collapsible">
-            <button class="header" style="background-color:var(--special-innocent);"><i class="icon-good-twin"></i>Good Twin<span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></button>
+            <button class="header" style="background-color:var(--special-innocent);"><i class="icon-good-twin"></i>Good Twin</button>
             <div class="content">
                 <div class="moreless">[more]</div>
                 <p>The <span class="inline-icon" style="color:var(--special-innocent);"><i class="icon-good-twin"></i><a href="#good-twin">Good Twin</a></span> spawns with an <span class="inline-icon" style="color:var(--special-traitor);"><i class="icon-evil-twin"></i><a href="../teams/traitor.html#evil-twin">Evil Twin</a></span> and they must convince everyone else who the real Good Twin is.</p>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -290,7 +290,7 @@
             </div>
         </div>
         <div id="evil-twin" class="collapsible">
-            <button class="header" style="background-color:var(--special-traitor);"><i class="icon-evil-twin"></i>Evil Twin<span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></button>
+            <button class="header" style="background-color:var(--special-traitor);"><i class="icon-evil-twin"></i>Evil Twin</button>
             <div class="content">
                 <div class="moreless">[more]</div>
                 <p>The <span class="inline-icon" style="color:var(--special-traitor);"><i class="icon-evil-twin"></i><a href="#evil-twin">Evil Twin</a></span> spawns with an <span class="inline-icon" style="color:var(--special-innocent);"><i class="icon-good-twin"></i><a href="../teams/innocent.html#good-twin">Good Twin</a></span> and they must trick everyone else into thinking that they are the Good Twin.</p>

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -293,6 +293,7 @@ util.AddNetworkString("TTT_LoadMonsterEquipment")
 util.AddNetworkString("TTT_UpdateRoleNames")
 util.AddNetworkString("TTT_ScoreboardUpdate")
 util.AddNetworkString("TTT_QueueMessage")
+util.AddNetworkString("TTT_ClearQueuedMessage")
 
 local function ClearAllFootsteps()
     net.Start("TTT_ClearPlayerFootsteps")

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -628,8 +628,13 @@ function plymeta:ResetMessageQueue()
     self:PrintMessage(HUD_PRINTCENTER, "")
 end
 
-function plymeta:QueueMessage(message_type, message, time, predicate, id)
+function plymeta:QueueMessage(message_type, message, time, id, predicate)
     time = time or 5
+    if type(id) == "function" and predicate == nil then
+        predicate = id
+        id = nil
+    end
+
     local sid = self:SteamID64()
     if not messageQueue[sid] then
         messageQueue[sid] = {}

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -605,7 +605,7 @@ if CLIENT then
         emitter:Finish()
     end
 
-    function plymeta:QueueMessage(message_type, message, time)
+    function plymeta:QueueMessage(message_type, message, time, id)
         if LocalPlayer() ~= self then
             ErrorNoHalt("`plymeta:QueueMessage` cannot be used to send messages to other players when called clientside.\n")
             return
@@ -615,6 +615,17 @@ if CLIENT then
         net.WriteUInt(message_type, 3)
         net.WriteString(message)
         net.WriteFloat(time)
+        net.WriteString(id or "")
+        net.SendToServer()
+    end
+
+    function plymeta:ClearQueuedMessage(id)
+        if LocalPlayer() ~= self then
+            ErrorNoHalt("`plymeta:QueueMessage` cannot be used to send messages to other players when called clientside.\n")
+            return
+        end
+        net.Start("TTT_ClearQueuedMessage")
+        net.WriteString(id)
         net.SendToServer()
     end
 else

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -106,7 +106,8 @@ local function AssignAssassinTarget(ply, start, delay)
 
     if ply:Alive() and not ply:IsSpec() then
         if not delay and not start then targetMessage = "Target eliminated. " .. targetMessage end
-        ply:QueueMessage(MSG_PRINTBOTH, targetMessage)
+        ply:ClearQueuedMessage("asnTarget")
+        ply:QueueMessage(MSG_PRINTBOTH, targetMessage, 5, "asnTarget")
     end
 end
 
@@ -123,7 +124,8 @@ local function UpdateAssassinTargets(ply)
                 -- Delay giving the next target if we're configured to do so
                 if delay > 0 then
                     if v:IsActive() then
-                        v:QueueMessage(MSG_PRINTBOTH, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.")
+                        v:ClearQueuedMessage("asnTarget")
+                        v:QueueMessage(MSG_PRINTBOTH, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.", math.min(delay, 5))
                     end
                     timer.Create(v:Nick() .. "AssassinTarget", delay, 1, function()
                         AssignAssassinTarget(v, false, true)
@@ -132,6 +134,7 @@ local function UpdateAssassinTargets(ply)
                     AssignAssassinTarget(v, false, false)
                 end
             else
+                v:ClearQueuedMessage("asnTarget")
                 v:QueueMessage(MSG_PRINTBOTH, "Final target eliminated.")
             end
         end
@@ -208,6 +211,7 @@ hook.Add("DoPlayerDeath", "Assassin_DoPlayerDeath", function(ply, attacker, dmgi
         local skipPenalty = cvars.Bool(convar, false) and ply:IsRoleActive()
         if wasNotTarget and not skipPenalty then
             timer.Remove(attacker:Nick() .. "AssassinTarget")
+            attacker:ClearQueuedMessage("asnTarget")
             attacker:QueueMessage(MSG_PRINTBOTH, "Contract failed. You killed the wrong player.")
             attacker:SetNWBool("AssassinFailed", true)
             attacker:SetNWString("AssassinTarget", "")

--- a/gamemodes/terrortown/gamemode/roles/plaguemaster/plaguemaster.lua
+++ b/gamemodes/terrortown/gamemode/roles/plaguemaster/plaguemaster.lua
@@ -125,7 +125,8 @@ AddHook("TTTPlayerAliveThink", "Plaguemaster_Plague_TTTPlayerAliveThink", functi
             -- If this is a plaguemaster that hasn't been warned, warn them
             if v:IsPlaguemaster() and not v.TTTPlaguemasterWarned then
                 v.TTTPlaguemasterWarned = true
-                v:QueueMessage(MSG_PRINTBOTH, "You are in range of someone with the plague!")
+                v:ClearQueuedMessage("plmInfectionWarning")
+                v:QueueMessage(MSG_PRINTBOTH, "You are in range of someone with the plague!", 5, nil, "plmInfectionWarning")
             end
         -- If we've been spreading the plague to this target for long enough, give them the plague
         elseif (CurTime() - v.TTTPlaguemasterSpreadStartTimes[sid64]) >= spread_time then

--- a/gamemodes/terrortown/gamemode/roles/plaguemaster/plaguemaster.lua
+++ b/gamemodes/terrortown/gamemode/roles/plaguemaster/plaguemaster.lua
@@ -126,7 +126,7 @@ AddHook("TTTPlayerAliveThink", "Plaguemaster_Plague_TTTPlayerAliveThink", functi
             if v:IsPlaguemaster() and not v.TTTPlaguemasterWarned then
                 v.TTTPlaguemasterWarned = true
                 v:ClearQueuedMessage("plmInfectionWarning")
-                v:QueueMessage(MSG_PRINTBOTH, "You are in range of someone with the plague!", 5, nil, "plmInfectionWarning")
+                v:QueueMessage(MSG_PRINTBOTH, "You are in range of someone with the plague!", 5, "plmInfectionWarning")
             end
         -- If we've been spreading the plague to this target for long enough, give them the plague
         elseif (CurTime() - v.TTTPlaguemasterSpreadStartTimes[sid64]) >= spread_time then

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -173,7 +173,8 @@ local function ClearBuffTimer(shadow, target, sendMessage)
             else
                 message = message .. "stopped buffing them!"
             end
-            shadow:QueueMessage(MSG_PRINTBOTH, message)
+            shadow:ClearQueuedMessage("shaBuffInfo")
+            shadow:QueueMessage(MSG_PRINTBOTH, message, 5, "shaBuffInfo")
         end
 
         target:SetNWBool("ShadowBuffActive", false)
@@ -211,7 +212,8 @@ local function SendBuffInfoMessage(shadow, time)
     else
         message = message .. "give them a buff!"
     end
-    shadow:QueueMessage(MSG_PRINTBOTH, message)
+    shadow:ClearQueuedMessage("shaBuffInfo")
+    shadow:QueueMessage(MSG_PRINTBOTH, message, 5, "shaBuffInfo")
 end
 
 local function CreateBuffTimer(shadow, target)
@@ -256,6 +258,7 @@ local function CreateBuffTimer(shadow, target)
                 role = ROLE_TRAITOR
             end
 
+            shadow:ClearQueuedMessage("shaBuffInfo")
             shadow:QueueMessage(MSG_PRINTBOTH, "You've stayed with your target long enough to join their team! You are now " .. ROLE_STRINGS_EXT[role])
 
             if shadow_target_buff_notify:GetBool() then
@@ -274,6 +277,7 @@ local function CreateBuffTimer(shadow, target)
             return
         elseif buff == SHADOW_BUFF_STEAL_ROLE then
             local role = target:GetRole()
+            shadow:ClearQueuedMessage("shaBuffInfo")
             shadow:QueueMessage(MSG_PRINTBOTH, "You've stayed with your target long enough to steal their role! You are now " .. ROLE_STRINGS_EXT[role])
 
             if shadow_target_buff_notify:GetBool() then
@@ -306,7 +310,8 @@ local function CreateBuffTimer(shadow, target)
             return
         end
 
-        shadow:QueueMessage(MSG_PRINTBOTH, "A buff is now active on your target. Stay with them to keep it up!")
+        shadow:ClearQueuedMessage("shaBuffInfo")
+        shadow:QueueMessage(MSG_PRINTBOTH, "A buff is now active on your target. Stay with them to keep it up!", 5, "shaBuffInfo")
 
         if shadow_target_buff_notify:GetBool() then
             target:QueueMessage(MSG_PRINTBOTH, "Your " .. ROLE_STRINGS[ROLE_SHADOW] .. " is buffing you. Stay with them to keep it up!")
@@ -350,6 +355,7 @@ hook.Add("DoPlayerDeath", "Shadow_SoulLink_DoPlayerDeath", function(ply, attacke
                 local target = player.GetBySteamID64(p:GetNWString("ShadowTarget", ""))
                 if IsPlayer(target) and target == ply then
                     p:Kill()
+                    p:ClearQueuedMessage("shaBuffInfo")
                     p:QueueMessage(MSG_PRINTBOTH, "Your target died!")
                 end
             end
@@ -396,6 +402,7 @@ hook.Add("PostPlayerDeath", "Shadow_Buff_PostPlayerDeath", function(ply)
             SafeRemoveEntity(corpse)
 
             if IsValid(shadow) then
+                shadow:ClearQueuedMessage("shaBuffInfo")
                 shadow:QueueMessage(MSG_PRINTBOTH, "Your target has respawned!")
             end
         end)
@@ -532,7 +539,8 @@ hook.Add("TTTBeginRound", "Shadow_TTTBeginRound", function()
                     v:SetNWBool("ShadowActive", false)
                     v:SetNWFloat("ShadowTimer", -1)
                 end
-                v:QueueMessage(MSG_PRINTBOTH, message)
+                v:ClearQueuedMessage("shaBuffInfo")
+                v:QueueMessage(MSG_PRINTBOTH, message, 5, "shaBuffInfo")
                 v:SetNWFloat("ShadowBuffTimer", -1)
                 ClearBuffTimer(v, target)
             else
@@ -596,6 +604,7 @@ hook.Add("PlayerDeath", "Shadow_KillCheck_PlayerDeath", function(victim, infl, a
 
     if victim:SteamID64() == attacker:GetNWString("ShadowTarget", "") then
         attacker:Kill()
+        attacker:ClearQueuedMessage("shaBuffInfo")
         attacker:QueueMessage(MSG_PRINTBOTH, "You killed your target!")
         attacker.TTTShadowKilledTarget = true
         ClearBuffTimer(attacker, victim)


### PR DESCRIPTION
## Changelog
### Fixes
- Fixed plaguemaster's infection warning message from being queued many times in a row if the plaguemaster repeatedly crosses the boundary of an infected player's spread radius

### Developer
- Added `plymeta:ClearQueuedMessage` method which can remove queued messages of a given ID from the message queue
  - Added optional `id` parameter to `plymeta:QueueMessage` to provide queued messages with an ID

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)