### PR TITLE
Bug fix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 - Fixed plaguemaster's dart gun being droppable
+- Fixed player view being stuck zoomed in if their weapon was removed by swapper or zombie role logic while they were using the scope
 
 ## 2.2.0
 **Released: August 12th, 2024**\

--- a/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
+++ b/gamemodes/terrortown/gamemode/roles/swapper/swapper.lua
@@ -204,6 +204,7 @@ hook.Add("PlayerDeath", "Swapper_KillCheck_PlayerDeath", function(victim, infl, 
                         StripPlayerWeaponAndAmmo(attacker, w)
                     end
                 end
+                attacker:SetFOV(0, 0)
 
                 -- Give the opposite player's weapons back
                 for _, w in ipairs(attacker_weapons) do
@@ -225,6 +226,7 @@ hook.Add("PlayerDeath", "Swapper_KillCheck_PlayerDeath", function(victim, infl, 
                             GivePlayerWeaponAndAmmo(victim, w)
                         end
                     end
+                    attacker:SetFOV(0, 0)
 
                     -- Give the attacker all of the victim's role weapons
                     for _, w in ipairs(victim_weapons) do

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -253,6 +253,7 @@ hook.Add("TTTPlayerAliveThink", "Zombie_TTTPlayerAliveThink", function(ply)
                     ply:StripWeapon(weapclass)
                 end
             end
+            ply:SetFOV(0, 0)
         end
 
         -- If this zombie doesn't have claws, give them claws


### PR DESCRIPTION
## Changelog
- Fixed player view being stuck zoomed in if their weapon was removed by swapper or zombie role logic while they were using the scope

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
