### PR TITLE
Misc. fixes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -118,6 +118,23 @@ Called before a player is killed because their lover (as set by Cupid's arrows) 
 
 *Return:* If `ply` should not be killed, return `true`. Otherwise do not return anything.
 
+### TTTCupidLoverChosen(cupid, lover)
+Called after a player has been chosen as a cupid's lover.\
+*Realm:* Server\
+*Added in:* 2.2.2\
+*Parameters:*
+- *cupid* - The cupid who has chosen a lover
+- *lover* - The lover that was chosen
+
+### TTTCupidLoversChosen(cupid, lover1, lover2)
+Called after both players have been chosen as a cupid's lovers.\
+*Realm:* Server\
+*Added in:* 2.2.2\
+*Parameters:*
+- *cupid* - The cupid who has chosen both lovers
+- *lover1* - The first lover that was chosen
+- *lover2* - The second lover that was chosen
+
 ### TTTCurePlayer(ply)
 Called when someone uses a cure on a player.\
 *Realm:* Server\

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -485,7 +485,7 @@ ttt_detectives_glow_enabled                    0       // Whether members of the
 ttt_special_detectives_armor_loadout           1       // Whether special detectives (all detective roles other than the original detective itself) get armor automatically for free
 ttt_all_search_postround                       1       // Whether non-detectives can search bodies post-round or not
 ttt_all_search_binoc                           0       // Whether non-detectives can search bodies if they are using binoculars
-ttt_all_search_dnascanner                      0       // Whether non-detectives can search bodies if they are hold the DNA scanner
+ttt_all_search_dnascanner                      0       // Whether non-detectives can search bodies if they are holding the DNA scanner
 ttt_detectives_credits_timer                   0       // How often in seconds to give members of the detective team a credit. Set to 0 to disable.
 ttt_detectives_search_credits                  0       // How many credits a detective should get for searching a corpse. Set to 0 to disable.
 ttt_detectives_search_credits_friendly         0       // Whether detectives should get credits for searching friendly corpses

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,9 @@
 - Fixed assassin whose target is made their lover by a cupid not being assigned a new lover
 - Fixed illusionist not blocking the radar color for traitors revealing other traitors
 - Fixed error when calling `plymeta:ClearMessageQueue` or `plymeta:PrintMessageQueue` when the player didn't have a message queue created first
+- Fixed player whose role is changed into a beggar with scanning ability being told they need to have their role rescanned
+- Fixed player whose role is changed into an informant being told they need to have their role rescanned
+- Fixed player whose role is changed to a member of the traitor team being told they need to have their role rescanned by the informant
 
 ### Developer
 - Added `TTTCupidLoverChosen` hook to allow detecting when a lover is hit by cupid's arrow

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 - Fixed player whose role is changed into a beggar with scanning ability being told they need to have their role rescanned
 - Fixed player whose role is changed into an informant being told they need to have their role rescanned
 - Fixed player whose role is changed to a member of the traitor team being told they need to have their role rescanned by the informant
+- Fixed killers seeing eachother via vision even though they normally wouldn't know eachothers roles
 - Ported "TTT: fix and optimize traitor button rendering" from base TTT
 
 ### Developer

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed assassin whose target is made their lover by a cupid not being assigned a new lover
+- Fixed illusionist not blocking the radar color for traitors revealing other traitors
 
 ### Developer
 - Added `TTTCupidLoverChosen` hook to allow detecting when a lover is hit by cupid's arrow

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.2.2 (Beta)
+**Released:**
+
+### Fixes
+- Fixed assassin whose target is made their lover by a cupid not being assigned a new lover
+
+### Developer
+- Added `TTTCupidLoverChosen` hook to allow detecting when a lover is hit by cupid's arrow
+- Added `TTTCupidLoversChosen` hook to allow detecting when both of cupid's lovers have been chosen
+
 ## 2.2.1 (Beta)
 **Released: August 24th, 2024**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ### Fixes
 - Fixed assassin whose target is made their lover by a cupid not being assigned a new lover
 - Fixed illusionist not blocking the radar color for traitors revealing other traitors
+- Fixed error when calling `plymeta:ClearMessageQueue` or `plymeta:PrintMessageQueue` when the player didn't have a message queue created first
 
 ### Developer
 - Added `TTTCupidLoverChosen` hook to allow detecting when a lover is hit by cupid's arrow

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 - Fixed player whose role is changed into a beggar with scanning ability being told they need to have their role rescanned
 - Fixed player whose role is changed into an informant being told they need to have their role rescanned
 - Fixed player whose role is changed to a member of the traitor team being told they need to have their role rescanned by the informant
+- Ported "TTT: fix and optimize traitor button rendering" from base TTT
 
 ### Developer
 - Added `TTTCupidLoverChosen` hook to allow detecting when a lover is hit by cupid's arrow

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -186,6 +186,31 @@
             <em>Return:</em> If <code>ply</code> should not be killed, return <code>true</code>. Otherwise do not return anything.
         </p>
 
+        <h3><a id="tttcupidloverchosencupid-lover" href="#tttcupidloverchosencupid-lover">TTTCupidLoverChosen(cupid, lover)</a></h3>
+        <p>
+            Called after a player has been chosen as a cupid's lover.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 2.2.2<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>cupid</em> - The cupid who has chosen a lover</li>
+            <li><em>lover</em> - The lover that was chosen</li>
+        </ul>
+
+        <h3><a id="tttcupidloverschosencupid-lover1-lover2" href="#tttcupidloverschosencupid-lover1-lover2">TTTCupidLoversChosen(cupid, lover1, lover2)</a></h3>
+        <p>
+            Called after both players have been chosen as a cupid's lovers.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 2.2.2<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>cupid</em> - The cupid who has chosen both lovers</li>
+            <li><em>lover1</em> - The first lover that was chosen</li>
+            <li><em>lover2</em> - The second lover that was chosen</li>
+        </ul>
+
         <h3><a id="tttcureplayerply" href="#tttcureplayerply">TTTCurePlayer(ply)</a></h3>
         <p>
             Called when someone uses a cure on a player.<br>

--- a/gamemodes/terrortown/entities/entities/ttt_cup_arrow.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cup_arrow.lua
@@ -1,7 +1,9 @@
 AddCSLuaFile()
 
+local hook = hook
 local player = player
 
+local HookCall = hook.Call
 local PlayerIterator = player.Iterator
 
 ENT.Type      = "anim"
@@ -119,6 +121,7 @@ function ENT:Touch(ent)
                     owner:SetNWString("TTTCupidTarget1", ent:SteamID64())
                     owner:QueueMessage(MSG_PRINTBOTH, ent:Nick() .. " has been hit with your first arrow.")
                     ent:QueueMessage(MSG_PRINTBOTH, "You have been hit by cupid's arrow!")
+                    HookCall("TTTCupidLoverChosen", nil, owner, ent)
                 elseif #target2 == 0 then
                     if ent:SteamID64() == target1 then
                         owner:QueueMessage(MSG_PRINTCENTER, "You cannot make someone fall in love with themselves.")
@@ -133,6 +136,8 @@ function ENT:Touch(ent)
                         owner:QueueMessage(MSG_PRINTBOTH, ent:Nick() .. " has fallen in love with " .. ent2:Nick() .. ".")
                         ent2:QueueMessage(MSG_PRINTBOTH, "You have fallen in love with " .. ent:Nick() .. "!")
                         ent:QueueMessage(MSG_PRINTBOTH, "You have fallen in love with " .. ent2:Nick() .. "!")
+                        HookCall("TTTCupidLoverChosen", nil, owner, ent2)
+                        HookCall("TTTCupidLoversChosen", nil, owner, ent, ent2)
 
                         if ent:IsSameTeam(ent2) then
                             ent:QueueMessage(MSG_PRINTBOTH, "The " .. ROLE_STRINGS[ROLE_CUPID] .. " will now win with your team!")

--- a/gamemodes/terrortown/gamemode/cl_tbuttons.lua
+++ b/gamemodes/terrortown/gamemode/cl_tbuttons.lua
@@ -1,11 +1,7 @@
 --- Display of and interaction with ttt_traitor_button
-local ents = ents
-local ipairs = ipairs
-local math = math
-local net = net
-local pairs = pairs
 local surface = surface
-local table = table
+local pairs = pairs
+local math = math
 local abs = math.abs
 
 TBHUD = {}
@@ -24,15 +20,14 @@ function TBHUD:Clear()
 end
 
 function TBHUD:CacheEnts()
+    self.buttons = {}
+
     if IsValid(LocalPlayer()) and LocalPlayer():CanUseTraitorButton(true) then
-        self.buttons = {}
         for _, ent in ipairs(ents.FindByClass("ttt_traitor_button")) do
             if IsValid(ent) then
                 self.buttons[ent:EntIndex()] = ent
             end
         end
-    else
-        self.buttons = {}
     end
 
     self.buttons_count = table.Count(self.buttons)
@@ -66,64 +61,56 @@ local tbut_focus = surface.GetTextureID("vgui/ttt/tbut_hand_filled")
 local size = 32
 local mid = size / 2
 local focus_range = 25
+local focus_d = 0
+local sz = 16
 
 local use_key = Key("+use", "USE")
 
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 function TBHUD:Draw(client)
-    if self.buttons_count ~= 0 then
-        surface.SetTexture(tbut_normal)
+    if self.buttons_count == 0 then return end
 
-        -- we're doing slowish distance computation here, so lots of probably
-        -- ineffective micro-optimization
-        local plypos = client:GetPos()
-        local midscreen_x = ScrW() / 2
-        local midscreen_y = ScrH() / 2
-        local pos, scrpos, d
-        local focus_ent = nil
-        local focus_d, focus_scrpos_x, focus_scrpos_y = 0, midscreen_x, midscreen_y
+    surface.SetTexture(tbut_normal)
 
-        -- draw icon on HUD for every button within range
-        for k, but in pairs(self.buttons) do
-            if IsValid(but) and but.IsUsable then
-                pos = but:GetPos()
-                scrpos = pos:ToScreen()
+    -- we're doing slowish distance computation here, so lots of probably
+    -- ineffective micro-optimization
+    local plypos = client:GetPos()
+    local midscreen_x = ScrW() / 2
+    local midscreen_y = ScrH() / 2
+    local pos, scrpos, d
+    local focus_ent = nil
+    local focus_scrpos_x, focus_scrpos_y = midscreen_x, midscreen_y
 
-                if (not IsOffScreen(scrpos)) and but:IsUsable() then
-                    d = pos - plypos
-                    d = d:Dot(d) / (but:GetUsableRange() ^ 2)
-                    -- draw if this button is within range, with alpha based on distance
-                    if d < 1 then
-                        surface.SetDrawColor(255, 255, 255, 200 * (1 - d))
-                        surface.DrawTexturedRect(scrpos.x - mid, scrpos.y - mid, size, size)
+    -- draw icon on HUD for every button within range
+    for k, but in pairs(self.buttons) do
+        if not IsValid(but) or not but.IsUsable or not but:IsUsable() then continue end
 
-                        if d > focus_d then
-                            local x = abs(scrpos.x - midscreen_x)
-                            local y = abs(scrpos.y - midscreen_y)
-                            if (x < focus_range and y < focus_range and
-                                    x < focus_scrpos_x and y < focus_scrpos_y) then
+        pos = but:GetPos()
+        scrpos = pos:ToScreen()
 
-                                -- avoid constantly switching focus every frame causing
-                                -- 2+ buttons to appear in focus, instead "stick" to one
-                                -- ent for a very short time to ensure consistency
-                                if self.focus_stick < CurTime() or but == self.focus_ent then
-                                    focus_ent = but
-                                end
-                            end
-                        end
-                    end
-                end
-            end
+        if IsOffScreen(scrpos) then continue end
 
-            -- draw extra graphics and information for button when it's in-focus
-            if IsValid(focus_ent) then
+        d = pos - plypos
+        d = d:Dot(d) / (but:GetUsableRange() ^ 2)
+
+        -- draw if this button is within range, with alpha based on distance
+        if d >= 1 then continue end
+
+        if not IsValid(focus_ent) and d > focus_d and (self.focus_stick < CurTime() or but == self.focus_ent) then
+            local x = abs(scrpos.x - midscreen_x)
+            local y = abs(scrpos.y - midscreen_y)
+            if (x < focus_range and y < focus_range and
+                x < focus_scrpos_x and y < focus_scrpos_y) then
+
+                -- draw extra graphics and information for button when it's in-focus
+                focus_ent = but
+
+                -- avoid constantly switching focus every frame causing
+                -- 2+ buttons to appear in focus, instead "stick" to one
+                -- ent for a very short time to ensure consistency
                 self.focus_ent = focus_ent
                 self.focus_stick = CurTime() + 0.1
-
-                scrpos = focus_ent:GetPos():ToScreen()
-
-                local sz = 16
 
                 -- redraw in-focus version of icon
                 surface.SetTexture(tbut_focus)
@@ -134,25 +121,37 @@ function TBHUD:Draw(client)
                 surface.SetTextColor(255, 50, 50, 255)
                 surface.SetFont("TabLarge")
 
-                local x = scrpos.x + sz + 10
-                local y = scrpos.y - sz - 3
+                x = scrpos.x + sz + 10
+                y = scrpos.y - sz - 3
                 surface.SetTextPos(x, y)
                 surface.DrawText(focus_ent:GetDescription())
 
                 y = y + 12
                 surface.SetTextPos(x, y)
-                if focus_ent:GetDelay() < 0 then
+
+                local delay = focus_ent:GetDelay()
+                if delay < 0 then
                     surface.DrawText(GetTranslation("tbut_single"))
-                elseif focus_ent:GetDelay() == 0 then
+                elseif delay == 0 then
                     surface.DrawText(GetTranslation("tbut_reuse"))
                 else
-                    surface.DrawText(GetPTranslation("tbut_retime", { num = focus_ent:GetDelay() }))
+                    local txt = GetPTranslation("tbut_retime", {num = delay})
+                    surface.DrawText(txt)
                 end
 
                 y = y + 12
                 surface.SetTextPos(x, y)
-                surface.DrawText(GetPTranslation("tbut_help", { key = use_key }))
+
+                local txt = GetPTranslation("tbut_help", {key = use_key})
+                surface.DrawText(txt)
+
+                surface.SetTexture(tbut_normal)
+
+                continue
             end
         end
+
+        surface.SetDrawColor(255, 255, 255, 200 * (1 - d))
+        surface.DrawTexturedRect(scrpos.x - mid, scrpos.y - mid, size, size)
     end
 end

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -594,7 +594,7 @@ local messageQueue = {}
 function plymeta:PrintMessageQueue()
     local sid = self:SteamID64()
 
-    if #messageQueue[sid] == 0 then
+    if not messageQueue[sid] or #messageQueue[sid] == 0 then
         self:PrintMessage(HUD_PRINTCENTER, "")
         return
     end
@@ -666,16 +666,18 @@ function plymeta:ClearQueuedMessage(id)
     local sid = self:SteamID64()
 
     local skipCurrent = false
-    if messageQueue[sid] and messageQueue[sid][1] and messageQueue[sid][1].id == id then
-        skipCurrent = true
-    end
+    if messageQueue[sid] then
+        if messageQueue[sid][1] and messageQueue[sid][1].id == id then
+            skipCurrent = true
+        end
 
-    local i = 1
-    while i <= #messageQueue[sid] do
-        if messageQueue[sid][i].id == id then
-            table.remove(messageQueue[sid], i)
-        else
-            i = i + 1
+        local i = 1
+        while i <= #messageQueue[sid] do
+            if messageQueue[sid][i].id == id then
+                table.remove(messageQueue[sid], i)
+            else
+                i = i + 1
+            end
         end
     end
 

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -208,7 +208,6 @@ end)
 
 -- Handle an assassin becoming the lover of their target
 hook.Add("TTTCupidLoversChosen", "Assassin_TTTCupidLoversChosen", function(cupid, lover1, lover2)
-    print("TTTCupidLoversChosen", lover1, lover2)
     if not IsPlayer(lover1) then return end
     if not IsPlayer(lover2) then return end
 

--- a/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
+++ b/gamemodes/terrortown/gamemode/roles/assassin/assassin.lua
@@ -59,11 +59,16 @@ local function AssignAssassinTarget(ply, start, delay)
         end
     end
 
+    local assassinLover = ply:GetNWString("TTTCupidLover", "")
     for _, p in PlayerIterator() do
         if p:Alive() and not p:IsSpec() then
+            local pSid64 = p:SteamID64()
+            -- Don't add the assassin's lover as a target, if they have one
+            if #assassinLover > 0 and pSid64 == assassinLover then continue end
+
             -- Include all non-traitor detective-like players
             if p:IsDetectiveLike() and not p:IsTraitorTeam() then
-                table.insert(detectives, p:SteamID64())
+                table.insert(detectives, pSid64)
             -- Exclude Glitch from this list so they don't get discovered immediately
             elseif p:IsInnocentTeam() and not p:IsGlitch() then
                 AddEnemy(p)
@@ -111,7 +116,7 @@ local function AssignAssassinTarget(ply, start, delay)
     end
 end
 
-local function UpdateAssassinTargets(ply)
+local function UpdateAssassinTargets(ply, msgOverride, finalMsgOverride)
     for _, v in PlayerIterator() do
         local assassintarget = v:GetNWString("AssassinTarget", "")
         if v:IsAssassin() and ply:SteamID64() == assassintarget then
@@ -125,7 +130,7 @@ local function UpdateAssassinTargets(ply)
                 if delay > 0 then
                     if v:IsActive() then
                         v:ClearQueuedMessage("asnTarget")
-                        v:QueueMessage(MSG_PRINTBOTH, "Target eliminated. You will receive your next assignment in " .. tostring(delay) .. " seconds.", math.min(delay, 5))
+                        v:QueueMessage(MSG_PRINTBOTH, (msgOverride or "Target eliminated.") .. " You will receive your next assignment in " .. tostring(delay) .. " seconds.", math.min(delay, 5))
                     end
                     timer.Create(v:Nick() .. "AssassinTarget", delay, 1, function()
                         AssignAssassinTarget(v, false, true)
@@ -135,7 +140,7 @@ local function UpdateAssassinTargets(ply)
                 end
             else
                 v:ClearQueuedMessage("asnTarget")
-                v:QueueMessage(MSG_PRINTBOTH, "Final target eliminated.")
+                v:QueueMessage(MSG_PRINTBOTH, finalMsgOverride or "Final target eliminated.")
             end
         end
     end
@@ -199,6 +204,21 @@ hook.Add("TTTTurncoatTeamChanged", "Assassin_TTTTurncoatTeamChanged", function(p
 
     -- Update any assassin targets since this player isn't a threat anymore
     UpdateAssassinTargets(ply)
+end)
+
+-- Handle an assassin becoming the lover of their target
+hook.Add("TTTCupidLoversChosen", "Assassin_TTTCupidLoversChosen", function(cupid, lover1, lover2)
+    print("TTTCupidLoversChosen", lover1, lover2)
+    if not IsPlayer(lover1) then return end
+    if not IsPlayer(lover2) then return end
+
+    -- If one of the lovers is an assassin and their target is the other lover, reassign
+    if lover1:IsAssassin() and lover1:GetNWString("AssassinTarget", "") == lover2:SteamID64() then
+        UpdateAssassinTargets(lover2, "You fell in love with your target.", "Final target seduced.")
+    end
+    if lover2:IsAssassin() and lover2:GetNWString("AssassinTarget", "") == lover1:SteamID64() then
+        UpdateAssassinTargets(lover1, "You fell in love with your target.", "Final target seduced.")
+    end
 end)
 
 hook.Add("DoPlayerDeath", "Assassin_DoPlayerDeath", function(ply, attacker, dmginfo)

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -295,7 +295,7 @@ hook.Add("TTTPlayerRoleChanged", "Beggar_Informant_TTTPlayerRoleChanged", functi
         -- Only notify if there is an beggar and the player had some info being reset
         if scanStage > BEGGAR_UNSCANNED then
             for _, v in PlayerIterator() do
-                if v:IsActiveBeggar() then
+                if ply ~= v and v:IsActiveBeggar() then
                     v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")
                 end
             end

--- a/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
+++ b/gamemodes/terrortown/gamemode/roles/bodysnatcher/bodysnatcher.lua
@@ -55,7 +55,7 @@ end)
 -- Only allow the bodysnatcher to pick up bodysnatcher-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Bodysnatcher_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
 
     if wep:GetClass() == "weapon_bod_bodysnatch" then
         return ply:IsBodysnatcher()

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/hypnotist.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/hypnotist.lua
@@ -13,7 +13,7 @@ local PlayerIterator = player.Iterator
 -- Only allow the hypnotist to pick up hypnotist-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Hypnotist_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
 
     if wep:GetClass() == "weapon_hyp_brainwash" then
         return ply:IsHypnotist()

--- a/gamemodes/terrortown/gamemode/roles/illusionist/cl_illusionist.lua
+++ b/gamemodes/terrortown/gamemode/roles/illusionist/cl_illusionist.lua
@@ -75,6 +75,21 @@ AddHook("TTTScoreboardPlayerRole", "Illusionist_TTTScoreboardPlayerRole", functi
     end
 end)
 
+-----------
+-- RADAR --
+-----------
+
+AddHook("TTTRadarPlayerRender", "Illusionist_TTTRadarPlayerRender", function(cli, tgt, color, hidden)
+    if hidden then return end
+    if cli == tgt then return end
+    if not GetGlobalBool("ttt_illusionist_alive", false) then return end
+
+    if (cli:IsActiveTraitorTeam() and (TRAITOR_ROLES[tgt.role] or tgt.role == ROLE_GLITCH)) or
+        (cli:IsActiveMonsterTeam() and MONSTER_ROLES[tgt.role] and illusionist_hides_monsters:GetBool()) then
+        return ColorAlpha(ROLE_COLORS_RADAR[ROLE_INNOCENT], color.a)
+    end
+end)
+
 --------------
 -- TUTORIAL --
 --------------

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -145,6 +145,8 @@ hook.Add("TTTPlayerRoleChanged", "Informant_TTTPlayerRoleChanged", function(ply,
             for _, v in PlayerIterator() do
                 -- Don't tell people about this role change if we're not revealing them
                 if hideRole then continue end
+                -- We don't need to tell the player who changed roles
+                if ply == v then continue end
 
                 if v:IsActiveInformant() then
                     v:PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has changed roles. You will need to rescan them.")

--- a/gamemodes/terrortown/gamemode/roles/informant/informant.lua
+++ b/gamemodes/terrortown/gamemode/roles/informant/informant.lua
@@ -33,7 +33,7 @@ local informant_scanner_monster_mult = GetConVar("ttt_informant_scanner_monster_
 -- Only allow the informant to pick up informant-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Informant_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
 
     if wep:GetClass() == "weapon_inf_scanner" then
         return ply:IsInformant()

--- a/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/cl_killer.lua
@@ -70,7 +70,7 @@ local client = nil
 
 local function EnableKillerHighlights()
     hook.Add("PreDrawHalos", "Killer_Highlight_PreDrawHalos", function()
-        OnPlayerHighlightEnabled(client, {ROLE_KILLER}, can_see_jesters, false, false)
+        OnPlayerHighlightEnabled(client, {}, can_see_jesters, false, false)
     end)
 end
 

--- a/gamemodes/terrortown/gamemode/roles/killer/killer.lua
+++ b/gamemodes/terrortown/gamemode/roles/killer/killer.lua
@@ -267,7 +267,7 @@ end)
 -- Only allow the killer to pick up killer-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Killer_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
 
     if (wep:GetClass() == "weapon_kil_knife" or wep:GetClass() == "weapon_kil_crowbar") then
         return ply:IsKiller()

--- a/gamemodes/terrortown/gamemode/roles/spy/spy.lua
+++ b/gamemodes/terrortown/gamemode/roles/spy/spy.lua
@@ -26,7 +26,7 @@ local spy_steal_name = GetConVar("ttt_spy_steal_name")
 -- Only allow the spy to pick up spy-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Spy_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
     if wep:GetClass() == "weapon_spy_flaregun" then return ply:IsSpy() end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -341,7 +341,7 @@ end)
 -- Only allow the vampire to pick up vampire-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Vampire_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
 
     if wep:GetClass() == "weapon_vam_fangs" then
         return ply:IsVampire()

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -278,7 +278,7 @@ end)
 -- Only allow the zombie to pick up zombie-specific weapons
 hook.Add("PlayerCanPickupWeapon", "Zombie_Weapons_PlayerCanPickupWeapon", function(ply, wep)
     if not IsValid(wep) or not IsValid(ply) then return end
-    if ply:IsSpec() then return false end
+    if ply:IsSpec() then return end
 
     if wep:GetClass() == "weapon_zom_claws" then
         return ply:IsZombie()


### PR DESCRIPTION
## Changelog
### Fixes
- Fixed assassin whose target is made their lover by a cupid not being assigned a new lover
- Fixed illusionist not blocking the radar color for traitors revealing other traitors
- Fixed error when calling `plymeta:ClearMessageQueue` or `plymeta:PrintMessageQueue` when the player didn't have a message queue created first
- Fixed player whose role is changed into a beggar with scanning ability being told they need to have their role rescanned
- Fixed player whose role is changed into an informant being told they need to have their role rescanned
- Fixed player whose role is changed to a member of the traitor team being told they need to have their role rescanned by the informant
- Fixed killers seeing eachother via vision even though they normally wouldn't know eachothers roles
- Ported "TTT: fix and optimize traitor button rendering" from base TTT

### Developer
- Added `TTTCupidLoverChosen` hook to allow detecting when a lover is hit by cupid's arrow
- Added `TTTCupidLoversChosen` hook to allow detecting when both of cupid's lovers have been chosen

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
