### PR TITLE
Added TTTBeggarConvert hook and chat message

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -7,6 +7,16 @@ For example, if there is a hook that returns three parameters: `first`, `second`
 
 ***NOTE:*** Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the *remaining hook instances to be completely skipped*. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.
 
+### TTTBeggarConvert(beggar, wep)
+Called when a beggar is about to have their team changed from receiving an item.\
+*Realm:* Server\
+*Added in:* 2.2.3\
+*Parameters:*
+- *beggar* - The beggar who is about to be converted
+- *wep* - The weapon the beggar received
+
+*Return:* Whether or not the beggar should be converted (Defaults to `true`).
+
 ### TTTBodyCreditsLooted(ply, deadPly, rag, credits)
 Called when a player loots credits off of a dead player's body.\
 *Realm:* Server\

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -619,6 +619,7 @@ ttt_beggar_update_scoreboard                   0       // Whether the beggar sho
 ttt_beggar_announce_delay                      0       // How long the delay between role change and announcement should be
 ttt_beggar_keep_begging                        0       // Whether the beggar should be able to keep begging after joining a team and switch teams multiple times
 ttt_beggar_ignore_empty_weapons                1       // Whether the beggar should not change teams if they are given a weapon with no ammo
+ttt_beggar_ignore_empty_weapons_warning        1       // Whether the beggar should receive a chat message warning on receiving an empty weapon
 
 // Bodysnatcher
 ttt_bodysnatcher_is_independent                0       // Whether bodysnatchers should be treated as members of the independent team (rather than the jester team)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.2.3 (Beta)
+**Released:**
+
+### Additions
+- Added a chat message for the beggar when receiving an empty weapon and `ttt_beggar_ignore_empty_weapons` is enabled
+
+### Developer
+- Added `TTTBeggarConvert` hook to allow blocking a beggar from having their team changed after receiving an item
+
 ## 2.2.2 (Beta)
 **Released: September 21st, 2024**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,8 +4,7 @@
 **Released:**
 
 ### Additions
-- Added a chat message for the beggar when receiving an empty weapon and `ttt_beggar_ignore_empty_weapons` is enabled
-- Added `ttt_beggar_ignore_empty_weapons_warning` (enabled by default) to control displaying this chat message
+- Added a chat message for the beggar when receiving an empty weapon and `ttt_beggar_ignore_empty_weapons` is enabled (can be disabled by setting `ttt_beggar_ignore_empty_weapons_warning 0`)
 
 ### Developer
 - Added `TTTBeggarConvert` hook to allow blocking a beggar from having their team changed after receiving an item

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Additions
 - Added a chat message for the beggar when receiving an empty weapon and `ttt_beggar_ignore_empty_weapons` is enabled
+- Added `ttt_beggar_ignore_empty_weapons_warning` (enabled by default) to control displaying this chat message
 
 ### Developer
 - Added `TTTBeggarConvert` hook to allow blocking a beggar from having their team changed after receiving an item

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,7 +20,7 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
-        <h3><a id="tttconvertbeggarply-wep" href="#tttconvertbeggarply-wep">TTTBeggarConvert(beggar, wep)</a></h3>
+        <h3><a id="tttconvertbeggarply-wep" href="#tttconvertbeggarply-wep">TTTBeggarConvert(beggar, wep)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
         <p>
             Called when a beggar is about to have their team changed from receiving an item.<br>
             <em>Realm:</em> Server<br>

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,7 +20,7 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
-        <h3><a id="tttbeggarconvertply-wep" href="#tttbeggarconvertply-wep">TTTBeggarConvert(beggar, wep)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttbeggarconvertbeggar-wep" href="#tttbeggarconvertbeggar-wep">TTTBeggarConvert(beggar, wep)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
         <p>
             Called when a beggar is about to have their team changed from receiving an item.<br>
             <em>Realm:</em> Server<br>

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,7 +20,7 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
-        <h3><a id="tttconvertbeggarply-wep" href="#tttconvertbeggarply-wep">TTTBeggarConvert(beggar, wep)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttbeggarconvertply-wep" href="#tttbeggarconvertply-wep">TTTBeggarConvert(beggar, wep)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
         <p>
             Called when a beggar is about to have their team changed from receiving an item.<br>
             <em>Realm:</em> Server<br>

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,6 +20,21 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
+        <h3><a id="tttconvertbeggarply-wep" href="#tttconvertbeggarply-wep">TTTBeggarConvert(beggar, wep)</a></h3>
+        <p>
+            Called when a beggar is about to have their team changed from receiving an item.<br>
+            <em>Realm:</em> Server<br>
+            <em>Added in:</em> 2.2.3<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>beggar</em> - The beggar who is about to be converted</li>
+            <li><em>wep</em> - The weapon the beggar received</li>
+        </ul>
+        <p>
+            <em>Return:</em> Whether or not the beggar should be converted (Defaults to <code>true</code>).
+        </p>
+
         <h3><a id="tttbodycreditslootedply-deadPly-rag-credits" href="#tttbodycreditslootedply-deadPly-rag-credits">TTTBodyCreditsLooted(ply, deadPly, rag, credits)</a></h3>
         <p>
             Called when a player loots credits off of a dead player's body.<br>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -236,6 +236,12 @@
                             <td>Whether the Beggar should not change teams if they are given a weapon with no ammo.</td>
                         </tr>
                         <tr>
+                            <td>ttt_beggar_ignore_empty_weapons_warning <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>1</td>
+                            <td>Boolean</td>
+                            <td>Whether the Beggar should receive a chat message warning on receiving an empty weapon.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_beggar_is_independent</td>
                             <td>0</td>
                             <td>Boolean</td>

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -8,6 +8,7 @@ local timer = timer
 local util = util
 
 local PlayerIterator = player.Iterator
+local CallHook = hook.Call
 
 util.AddNetworkString("TTT_BeggarConverted")
 util.AddNetworkString("TTT_BeggarKilled")
@@ -57,7 +58,13 @@ hook.Add("WeaponEquip", "Beggar_WeaponEquip", function(wep, ply)
     if wep.BoughtBy and wep.BoughtBy:IsBeggar() then return end -- If a beggar is the owner of this weapon then it should no longer change ownership or convert beggars as it has already been 'used'
 
     if ply:IsBeggar() and wep.BoughtBy and IsPlayer(wep.BoughtBy) and (wep.BoughtBy:IsTraitorTeam() or wep.BoughtBy:IsInnocentTeam()) then
-        if beggar_ignore_empty_weapons:GetBool() and wep:GetMaxClip1() > 0 and wep:Clip1() == 0 then return end
+        if beggar_ignore_empty_weapons:GetBool() and wep:GetMaxClip1() > 0 and wep:Clip1() == 0 then 
+            ply:PrintMessage(HUD_PRINTTALK, "Empty weapons don't convert the " .. ROLE_STRINGS[ROLE_BEGGAR])
+            return
+        end
+
+        local result = CallHook("TTTBeggarConvert", nil, ply, wep)
+        if type(result) == "boolean" and not result then return end
 
         local role
         if wep.BoughtBy:IsTraitorTeam() and not TRAITOR_ROLES[ROLE_BEGGAR] then
@@ -394,7 +401,7 @@ local function Scan(ply, target)
             ply:SetNWString("TTTBeggarScannerMessage", "")
             ply:SetNWFloat("TTTBeggarScannerStartTime", -1)
             target:SetNWInt("TTTBeggarScanStage", stage)
-            hook.Call("TTTBeggarScanStageChanged", nil, ply, target, stage)
+            CallHook("TTTBeggarScanStageChanged", nil, ply, target, stage)
         end
     else
         TargetLost(ply)

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -29,6 +29,7 @@ local beggar_scan_cooldown = CreateConVar("ttt_beggar_scan_cooldown", "3", FCVAR
 local beggar_scan_distance = CreateConVar("ttt_beggar_scan_distance", "2500", FCVAR_NONE, "The maximum distance away the scanner target can be", 1000, 10000)
 local beggar_transfer_ownership = CreateConVar("ttt_beggar_transfer_ownership", "0", FCVAR_NONE, "Whether the ownership of a shop item should transfer each time its picked up by a non-beggar", 0, 1)
 local beggar_ignore_empty_weapons = CreateConVar("ttt_beggar_ignore_empty_weapons", "1", FCVAR_NONE, "Whether the beggar should not change teams if they are given a weapon with no ammo", 0, 1)
+local beggar_ignore_empty_weapons_warning = CreateConVar("ttt_beggar_ignore_empty_weapons_warning", "1", FCVAR_NONE, "Whether the beggar should receive a chat message warning on receiving an empty weapon", 0, 1)
 
 local beggar_respawn = GetConVar("ttt_beggar_respawn")
 local beggar_respawn_limit = GetConVar("ttt_beggar_respawn_limit")
@@ -59,7 +60,9 @@ hook.Add("WeaponEquip", "Beggar_WeaponEquip", function(wep, ply)
 
     if ply:IsBeggar() and wep.BoughtBy and IsPlayer(wep.BoughtBy) and (wep.BoughtBy:IsTraitorTeam() or wep.BoughtBy:IsInnocentTeam()) then
         if beggar_ignore_empty_weapons:GetBool() and wep:GetMaxClip1() > 0 and wep:Clip1() == 0 then
-            ply:PrintMessage(HUD_PRINTTALK, "Empty weapons don't convert the " .. ROLE_STRINGS[ROLE_BEGGAR])
+            if beggar_ignore_empty_weapons_warning:GetBool() then
+                ply:PrintMessage(HUD_PRINTTALK, "Empty weapons don't convert the " .. ROLE_STRINGS[ROLE_BEGGAR])
+            end
             return
         end
 

--- a/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/beggar.lua
@@ -58,7 +58,7 @@ hook.Add("WeaponEquip", "Beggar_WeaponEquip", function(wep, ply)
     if wep.BoughtBy and wep.BoughtBy:IsBeggar() then return end -- If a beggar is the owner of this weapon then it should no longer change ownership or convert beggars as it has already been 'used'
 
     if ply:IsBeggar() and wep.BoughtBy and IsPlayer(wep.BoughtBy) and (wep.BoughtBy:IsTraitorTeam() or wep.BoughtBy:IsInnocentTeam()) then
-        if beggar_ignore_empty_weapons:GetBool() and wep:GetMaxClip1() > 0 and wep:Clip1() == 0 then 
+        if beggar_ignore_empty_weapons:GetBool() and wep:GetMaxClip1() > 0 and wep:Clip1() == 0 then
             ply:PrintMessage(HUD_PRINTTALK, "Empty weapons don't convert the " .. ROLE_STRINGS[ROLE_BEGGAR])
             return
         end

--- a/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/beggar/shared.lua
@@ -172,6 +172,10 @@ table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
     cvar = "ttt_beggar_ignore_empty_weapons",
     type = ROLE_CONVAR_TYPE_BOOL
 })
+table.insert(ROLE_CONVARS[ROLE_BEGGAR], {
+    cvar = "ttt_beggar_ignore_empty_weapons_warning",
+    type = ROLE_CONVAR_TYPE_BOOL
+})
 
 -------------------
 -- ROLE FEATURES --


### PR DESCRIPTION
## Changelog
- Added a chat message for the beggar when receiving an empty weapon and `ttt_beggar_ignore_empty_weapons` is enabled
- Added `TTTBeggarConvert` hook to allow blocking a beggar from having their team changed after receiving an item

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] CONVARS.md updated (if applicable)
- [x] Docs website updated and changes marked with "beta only" notation (if applicable)
- [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
