### PR TITLE
Misc. bug fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,8 @@
 
 ### Changes
 - Changed the vindicator to reset back to the innocent team if their target becomes an unkillable role (like the guesser)
-- Change zombie rounds (`ttt_zombie_round_chance`) to obey `ttt_zombie_min_players`
+- Changed zombie rounds (`ttt_zombie_round_chance`) to obey `ttt_zombie_min_players`
+- Changed how zombie and vampire prime are assigned to hopefully work around a rare issue where they weren't set on round start
 
 ### Fixes
 - Ported "TTT: fix ragdoll not being created if ttt_dyingshot is on"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,6 +24,7 @@
 - Fixed detective hat not being wearable by special detectives or detective-like roles
 - Fixed error loading guesser tutorial
 - Fixed plaguemaster not being able to see Missing in Action players by default due to a typo
+- Fixed corpse role being shown on all player's scoreboards when `ttt_detectives_search_only_role` and `ttt_corpse_search_not_shared` are both enabled
 - Reverted jester and sponge round win logic compatibility change from 2.1.6 that didn't actually added compatibility and did cause jester and sponge wins to not work when certain independent roles (e.g. Arsonist) were in the round
 
 ### Developer

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -1,7 +1,9 @@
 ---- Corpse functions
 
+CreateConVar("ttt_corpse_search_not_shared", "0", FCVAR_NONE, "Whether corpse searches are not shared with other players (only affects non-detective-like searchers)", 0, 1)
+
 -- namespaced because we have no ragdoll metatable
-CORPSE = {}
+CORPSE = CORPSE or {}
 
 include("corpse_shd.lua")
 
@@ -188,9 +190,15 @@ local function IdentifyBody(ply, rag)
             -- Otherwise the scoreboard gets updated which reveals their name anyway
             if announceName then
                 deadply:SetNWBool("body_found", true)
+                local search_not_shared = GetConVar("ttt_corpse_search_not_shared"):GetBool()
                 -- Don't set "searched" if we're not sharing this information
-                if ply:IsDetectiveLike() or not GetConVar("ttt_corpse_search_not_shared"):GetBool() then
+                if ply:IsDetectiveLike() or not search_not_shared then
                     deadply:SetNWBool("body_searched", true)
+                end
+
+                -- If this information isn't shared, tell just the searching player that the body's role should be known
+                if search_not_shared then
+                    deadply:SetProperty("body_found_role", true, ply)
                 end
             end
 

--- a/gamemodes/terrortown/gamemode/corpse_shd.lua
+++ b/gamemodes/terrortown/gamemode/corpse_shd.lua
@@ -1,7 +1,6 @@
 ---- Shared corpsey stuff
 
 CreateConVar("ttt_spectator_corpse_search", "1", FCVAR_REPLICATED, "Whether spectators can search bodies (not shared with other players)", 0, 1)
-CreateConVar("ttt_corpse_search_not_shared", "0", FCVAR_REPLICATED, "Whether corpse searches are not shared with other players (only affects non-detective-like searchers)", 0, 1)
 CreateConVar("ttt_corpse_search_team_text_traitor", "0", FCVAR_REPLICATED, "Whether corpse searches of traitors should include flavor text hinting at the team of their killer", 0, 1)
 CreateConVar("ttt_corpse_search_team_text_innocent", "0", FCVAR_REPLICATED, "Whether corpse searches of innocents should include flavor text hinting at the team of their killer", 0, 1)
 CreateConVar("ttt_corpse_search_team_text_monster", "0", FCVAR_REPLICATED, "Whether corpse searches of monsters should include flavor text hinting at the team of their killer", 0, 1)

--- a/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/gamemodes/terrortown/gamemode/player_ext.lua
@@ -211,6 +211,7 @@ function plymeta:ResetRoundFlags()
     self:SetNWBool("det_called", false)
     self:SetNWBool("body_found", false)
     self:SetNWBool("body_searched", false)
+    self:ClearProperty("body_found_role")
     self:SetNWBool("body_searched_det", false)
 
     self.kills = {}
@@ -382,6 +383,7 @@ function plymeta:SpawnForRound(dead_only)
         -- Clear all search information for this resurrected player
         self:SetNWBool("det_called", false)
         self:SetNWBool("body_found", false)
+        self:ClearProperty("body_found_role")
         self:SetNWBool("body_searched", false)
         self:SetNWBool("body_searched_det", false)
 
@@ -733,8 +735,11 @@ hook.Add("TTTPrepareRound", "PostLoadOverride", function()
         local oldDRuncloak = plymeta.DRuncloak
         -- Handle clearing search and corpse data when a Dead Ringer'd player uncloaks
         function plymeta:DRuncloak()
-            self:SetNWBool("body_searched", false)
             self:SetNWBool("det_called", false)
+            self:SetNWBool("body_found", false)
+            self:SetNWBool("body_searched", false)
+            self:ClearProperty("body_found_role")
+            self:SetNWBool("body_searched_det", false)
             oldDRuncloak(self)
 
             net.Start("TTT_RemoveCorpseCall")

--- a/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
+++ b/gamemodes/terrortown/gamemode/roles/vampire/vampire.lua
@@ -182,6 +182,7 @@ hook.Add("PlayerDisconnected", "Vampire_Prime_PlayerDisconnected", function(ply)
     new_prime:QueueMessage(MSG_PRINTBOTH, "The prime " .. ROLE_STRINGS[ROLE_VAMPIRE] .. " has faded away and you've seized power in their absence!")
 end)
 
+-- Keep previous naming scheme for backwards compatibility
 function plymeta:SetVampirePrime(p) self:SetNWBool("vampire_prime", p) end
 function plymeta:SetVampirePreviousRole(r) self:SetNWInt("vampire_previous_role", r) end
 
@@ -189,20 +190,18 @@ function plymeta:SetVampirePreviousRole(r) self:SetNWInt("vampire_previous_role"
 -- ROLE STATUS --
 -----------------
 
-hook.Add("TTTBeginRound", "Vampire_RoleFeatures_PrepareRound", function()
-    for _, v in PlayerIterator() do
-        if v:IsVampire() then
-            v:SetVampirePrime(true)
-        end
-    end
+hook.Add("TTTPlayerRoleChanged", "Vampire_RoleFeatures_TTTPlayerRoleChanged", function(ply, oldRole, role)
+    if role ~= ROLE_VAMPIRE then return end
+    if oldRole ~= ROLE_NONE then return end
+
+    ply:SetVampirePrime(true)
 end)
 
 hook.Add("TTTPrepareRound", "Vampire_RoleFeatures_PrepareRound", function()
     for _, v in PlayerIterator() do
         v:SetNWInt("VampireFreezeCount", 0)
-        -- Keep previous naming scheme for backwards compatibility
-        v:SetNWBool("vampire_prime", false)
-        v:SetNWInt("vampire_previous_role", ROLE_NONE)
+        v:SetVampirePrime(false)
+        v:SetVampirePreviousRole(ROLE_NONE)
     end
 end)
 

--- a/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
+++ b/gamemodes/terrortown/gamemode/roles/zombie/zombie.lua
@@ -64,26 +64,25 @@ hook.Add("PlayerDisconnected", "Zombie_Prime_PlayerDisconnected", function(ply)
     new_prime:QueueMessage(MSG_PRINTBOTH, "The prime " .. ROLE_STRINGS[ROLE_ZOMBIE] .. " has been lost and you've seized power in their absence!")
 end)
 
+-- Keep previous naming scheme for backwards compatibility
 function plymeta:SetZombiePrime(p) self:SetNWBool("zombie_prime", p) end
 
 -----------------
 -- ROLE STATUS --
 -----------------
 
-hook.Add("TTTBeginRound", "Zombie_RoleFeatures_BeginRound", function()
-    for _, v in PlayerIterator() do
-        if v:IsZombie() then
-            v:SetZombiePrime(true)
-        end
-    end
+hook.Add("TTTPlayerRoleChanged", "Zombie_RoleFeatures_TTTPlayerRoleChanged", function(ply, oldRole, role)
+    if role ~= ROLE_ZOMBIE then return end
+    if oldRole ~= ROLE_NONE then return end
+
+    ply:SetZombiePrime(true)
 end)
 
 hook.Add("TTTPrepareRound", "Zombie_RoleFeatures_PrepareRound", function()
     for _, v in PlayerIterator() do
         v.WasZombieColored = false
         v:SetNWBool("IsZombifying", false)
-        -- Keep previous naming scheme for backwards compatibility
-        v:SetNWBool("zombie_prime", false)
+        v:SetZombiePrime(false)
         timer.Remove("Zombify_" .. v:SteamID64())
     end
 end)

--- a/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -156,7 +156,7 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
     if not IsValid(ply) or GetRoundState() == ROUND_WAIT or GetRoundState() == ROUND_PREP then return defaultcolor end
 
     local client = LocalPlayer()
-    if ShouldSpectatorSeeRoles(client) then
+    if client == ply or ShouldSpectatorSeeRoles(client) then
         return ply:GetRole()
     end
 
@@ -166,8 +166,8 @@ function GM:TTTScoreboardRowColorForPlayer(ply)
         return ply.search_result.role
     end
 
-    if ply == client or
-        (ply:GetNWBool("body_found", false) and GetConVar("ttt_corpse_search_not_shared"):GetBool()) then
+    -- If this client should know the player's role, show it
+    if ply.body_found_role then
         return ply:GetRole()
     end
 


### PR DESCRIPTION
## Changelog

### Changes
- Changed how zombie and vampire prime are assigned to hopefully work around a rare issue where they weren't set on round start

### Fixes
- Fixed corpse role being shown on all player's scoreboards when `ttt_detectives_search_only_role` and `ttt_corpse_search_not_shared` are both enabled

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
