### PR TITLE
2.2.4 Hotfix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,7 @@
 - Fixed error loading guesser tutorial
 - Fixed plaguemaster not being able to see Missing in Action players by default due to a typo
 - Fixed corpse role being shown on all player's scoreboards when `ttt_detectives_search_only_role` and `ttt_corpse_search_not_shared` are both enabled
+- Fixed error clearing shadow buff state on round prep
 - Reverted jester and sponge round win logic compatibility change from 2.1.6 that didn't actually added compatibility and did cause jester and sponge wins to not work when certain independent roles (e.g. Arsonist) were in the round
 
 ### Developer

--- a/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
+++ b/gamemodes/terrortown/gamemode/roles/shadow/shadow.lua
@@ -154,7 +154,7 @@ local function ClearShadowState(ply)
     timer.Remove("TTTShadowRegenTimer_" .. ply:SteamID64())
 
     -- Remove all buff timers that involve this player
-    for _, timerId in pairs(buffTimers) do
+    for timerId, _ in pairs(buffTimers) do
         if string.find(timerId, "_" .. ply:SteamID64()) then
             timer.Remove(timerId)
             buffTimers[timerId] = false


### PR DESCRIPTION
## Changelog
- Fixed error clearing shadow buff state on round prep

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
