### PR TITLE
2.2.0 Drunk Error Hotfix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@ Includes beta updates [2.1.17](#2117-beta) and [2.1.20](#2120-beta).
 - Fixed external roles that belong to teams with default shop items (traitors, detectives) not having those default items in their shop if they set up their equipment items table manually
 - Fixed illusionist not blocking traitor team highlighting when that is enabled
 - Fixed the twins not spawning/despawning correctly when only one twin was assigned through a rolepack
+- Fixed error in the drunk role selection logic when a role doesn't have the `ttt_drunk_can_be_*` convar
 
 ## 2.1.20 (Beta)
 **Released: August 10th, 2024**

--- a/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
+++ b/gamemodes/terrortown/gamemode/roles/drunk/drunk.lua
@@ -362,7 +362,7 @@ function plymeta:SoberDrunk(team)
             -- Remove any roles that are not enabled or allowed
             for _, r in ipairs(role_options) do
                 local rolestring = ROLE_STRINGS_RAW[r]
-                if GetConVar("ttt_drunk_can_be_" .. rolestring):GetBool() and (DEFAULT_ROLES[r] or drunk_any_role_include_disabled:GetBool() or util.CanRoleSpawnNaturally(r)) then
+                if cvars.Bool("ttt_drunk_can_be_" .. rolestring, false) and (DEFAULT_ROLES[r] or drunk_any_role_include_disabled:GetBool() or util.CanRoleSpawnNaturally(r)) then
                     table.insert(allowed_options, r)
                 end
             end


### PR DESCRIPTION
## Changelog
- Fixed error in the drunk role selection logic when a role doesn't have the `ttt_drunk_can_be_*` convar

## Affected Issues

## Checklist
- [ ] Tested in-game
- [x] Release Notes updated
- [ ] CONVARS.md updated (if applicable)
- [ ] Docs website updated and changes marked with "beta only" notation (if applicable)
- [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Be sure to add a link to the PR\])
