### PR TITLE
2.3.0 Release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## 2.3.0
 **Released: April 6th, 2025**\
-Includes beta updates [2.2.1](#221-beta) and [2.2.10](#2210-beta).
+Includes beta updates [2.2.1](#221-beta) to [2.2.10](#2210-beta).
 
 ### Fixes
 - Fixed player searching body originally searched by a detective-team member with their ability disabled still being able to see the dead player's role when `ttt_detectives_search_only` or `ttt_detectives_search_only_role` was enabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## 2.3.0
 **Released: April 6th, 2025**\
-Includes beta updates [2.2.7](#221-beta) and [2.2.10](#2210-beta).
+Includes beta updates [2.2.1](#221-beta) and [2.2.10](#2210-beta).
 
 ### Fixes
 - Fixed player searching body originally searched by a detective-team member with their ability disabled still being able to see the dead player's role when `ttt_detectives_search_only` or `ttt_detectives_search_only_role` was enabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@ Includes beta updates [2.2.1](#221-beta) to [2.2.10](#2210-beta).
 
 ### Fixes
 - Fixed player searching body originally searched by a detective-team member with their ability disabled still being able to see the dead player's role when `ttt_detectives_search_only` or `ttt_detectives_search_only_role` was enabled
+- Fixed sending role pack weapon messages more often then needed in a specific circumstance
 
 ## 2.2.10 (Beta)
 **Released: April 5th, 2025**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.3.0
+**Released: April 6th, 2025**\
+Includes beta updates [2.2.7](#221-beta) and [2.2.10](#2210-beta).
+
+### Fixes
+- Fixed player searching body originally searched by a detective-team member with their ability disabled still being able to see the dead player's role when `ttt_detectives_search_only` or `ttt_detectives_search_only_role` was enabled
+
 ## 2.2.10 (Beta)
 **Released: April 5th, 2025**
 

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -20,7 +20,7 @@
         <p><em><strong>NOTE:</strong></em> Be careful that you only return from a hook when you absolutely want to change something. Due to the way GMod hooks work, whichever hook instance returns first causes the <em>remaining hook instances to be completely skipped</em>. This is useful for certain hooks when you want to stop a behavior from happening, but it can also accidentally cause functionality to break because its code is completely ignored.</p>
     </div>
     <div class="contentbody panel">
-        <h3><a id="tttbeggarconvertbeggar-wep" href="#tttbeggarconvertbeggar-wep">TTTBeggarConvert(beggar, wep)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttbeggarconvertbeggar-wep" href="#tttbeggarconvertbeggar-wep">TTTBeggarConvert(beggar, wep)</a></h3>
         <p>
             Called when a beggar is about to have their team changed from receiving an item.<br>
             <em>Realm:</em> Server<br>
@@ -500,7 +500,7 @@
             <em>Return:</em> <code>true</code> if the player is currently respawning, <code>false</code> if they are not. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
         </p>
 
-        <h3><a id="tttisroleabilitydisabled" href="#tttisroleabilitydisabled">TTTIsRoleAbilityDisabled(ply, ...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttisroleabilitydisabled" href="#tttisroleabilitydisabled">TTTIsRoleAbilityDisabled(ply, ...)</a></h3>
         <p>
             Called to check whether a player's role ability is disabled.<br>
             <em>NOTE</em>: This will be called every time something queries for whether a player's role ability is disabled as long as is remains enabled.<br>
@@ -516,7 +516,7 @@
             <em>Return:</em> <code>true</code> if the player's role ability is currently disabled. If you have no opinion (e.g. let other logic determine this) then don't return anything at all.
         </p>
 
-        <h3><a id="tttisshoppurchasedisabled" href="#tttisshoppurchasedisabled">TTTIsShopPurchaseDisabled(ply, ...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttisshoppurchasedisabled" href="#tttisshoppurchasedisabled">TTTIsShopPurchaseDisabled(ply, ...)</a></h3>
         <p>
             Called to check whether a player's shop purchases are disabled.<br>
             <em>NOTE</em>: This will be called every time something queries for whether a player's shop purchases is disabled as long as they remain enabled.<br>
@@ -576,7 +576,7 @@
             <li><em>tgt</em> - The target being zombified</li>
         </ul>
 
-        <h3><a id="tttonroleabilityblocked" href="#tttonroleabilityblocked">TTTOnRoleAbilityBlocked(ply, ...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttonroleabilityblocked" href="#tttonroleabilityblocked">TTTOnRoleAbilityBlocked(ply, ...)</a></h3>
         <p>
             Called when a player tries to use their role ability but it's disabled.<br>
             <em>Realm:</em> Client and Server<br>
@@ -588,7 +588,7 @@
             <li><em>...</em> - Any other parameters that are passed to <code>plymeta:IsRoleAbilityDisabled</code></li>
         </ul>
 
-        <h3><a id="tttonroleabilitydisabled" href="#tttonroleabilitydisabled">TTTOnRoleAbilityDisabled(ply, ...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttonroleabilitydisabled" href="#tttonroleabilitydisabled">TTTOnRoleAbilityDisabled(ply, ...)</a></h3>
         <p>
             Called when a player's role ability is disabled.<br>
             <em>Realm:</em> Client and Server<br>
@@ -600,7 +600,7 @@
             <li><em>...</em> - Any other parameters that are passed to <code>plymeta:DisableRoleAbility</code> or <code>plymeta:IsRoleAbilityDisabled</code></li>
         </ul>
 
-        <h3><a id="tttonroleabilityenabled" href="#tttonroleabilityenabled">TTTOnRoleAbilityEnabled(ply)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttonroleabilityenabled" href="#tttonroleabilityenabled">TTTOnRoleAbilityEnabled(ply)</a></h3>
         <p>
             Called when a player's role ability is re-enabled.<br>
             <em>Realm:</em> Client and Server<br>
@@ -611,7 +611,7 @@
             <li><em>ply</em> - The player whose role ability is being enabled</li>
         </ul>
 
-        <h3><a id="tttonshoppurchaseblocked" href="#tttonshoppurchaseblocked">TTTOnShopPurchaseBlocked(ply, ...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttonshoppurchaseblocked" href="#tttonshoppurchaseblocked">TTTOnShopPurchaseBlocked(ply, ...)</a></h3>
         <p>
             Called when a player tries to use the shop but their purchases are disabled.<br>
             <em>Realm:</em> Server<br>
@@ -623,7 +623,7 @@
             <li><em>...</em> - Any other parameters that are passed to <code>plymeta:IsShopPurchaseDisabled</code></li>
         </ul>
 
-        <h3><a id="tttonshoppurchasedisabled" href="#tttonshoppurchasedisabled">TTTOnShopPurchaseDisabled(ply, ...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttonshoppurchasedisabled" href="#tttonshoppurchasedisabled">TTTOnShopPurchaseDisabled(ply, ...)</a></h3>
         <p>
             Called when a player's shop purchases are disabled.<br>
             <em>Realm:</em> Server<br>
@@ -635,7 +635,7 @@
             <li><em>...</em> - Any other parameters that are passed to <code>plymeta:DisableShopPurchases</code> or <code>plymeta:IsShopPurchaseDisabled</code></li>
         </ul>
 
-        <h3><a id="tttonshoppurchaseenabled" href="#tttonshoppurchaseenabled">TTTOnShopPurchaseEnabled(ply)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttonshoppurchaseenabled" href="#tttonshoppurchaseenabled">TTTOnShopPurchaseEnabled(ply)</a></h3>
         <p>
             Called when a player's shop purchases are enabled.<br>
             <em>Realm:</em> Server<br>
@@ -1998,7 +1998,7 @@
             <li><em>win</em> - The win type that the round is about to end with</li>
         </ul>
 
-        <h3><a id="tttzombiebodyeatenply-ent-healed" href="#tttzombiebodyeatenply-ent-healed">TTTZombieBodyEaten(ply, ent, healed)</a>  <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="tttzombiebodyeatenply-ent-healed" href="#tttzombiebodyeatenply-ent-healed">TTTZombieBodyEaten(ply, ent, healed)</a> </h3>
         <p>
             Called after a Zombie eats a body.<br>
             <em>Realm:</em> Server<br>

--- a/docs/api/methods_hud.html
+++ b/docs/api/methods_hud.html
@@ -44,7 +44,7 @@
             Paints a HUD for showing available powers and their associated costs. Used for roles such as the Phantom.<br>
             <em>Realm:</em> Client<br>
             <em>Added in:</em> 1.3.1<br>
-            <em>Parameters:</em> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span>
+            <em>Parameters:</em>
         </p>
         <ul>
             <li><em>client</em> - The client player</li>

--- a/docs/api/methods_player_object.html
+++ b/docs/api/methods_player_object.html
@@ -91,7 +91,7 @@
             <li><em>targets</em> - The targets that should have this value cleared on their clients. <em>(Defaults to sending to all players)</em></li>
         </ul>
 
-        <h3><a id="plymetaclearqueuedmessageid" href="#plymetaclearqueuedmessageid">plymeta:ClearQueuedMessage(id)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="plymetaclearqueuedmessageid" href="#plymetaclearqueuedmessageid">plymeta:ClearQueuedMessage(id)</a></h3>
         <p>
             Removes queued messages with the given ID from the queue and clears any currently displayed messages with the given ID.<br>
             <em>Realm:</em> Client and Server<br>
@@ -102,7 +102,7 @@
             <li><em>id</em> - The identifier of the message(s) you want to clear</li>
         </ul>
 
-        <h3><a id="plymetadisableroleability" href="#plymetadisableroleability">plymeta:DisableRoleAbility()</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="plymetadisableroleability" href="#plymetadisableroleability">plymeta:DisableRoleAbility()</a></h3>
         <p>
             Disables this player's role ability, if it isn't already.<br>
             <em>NOTE</em>: If the player's role ability was not already disabled, this will also call the <code>TTTOnRoleAbilityDisabled</code> hook<br>
@@ -110,7 +110,7 @@
             <em>Added in:</em> 2.2.9
         </p>
 
-        <h3><a id="plymetadisableshoppurchases" href="#plymetadisableshoppurchases">plymeta:DisableShopPurchases()</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="plymetadisableshoppurchases" href="#plymetadisableshoppurchases">plymeta:DisableShopPurchases()</a></h3>
         <p>
             Blocks player's purchases from the equipment shop, if they weren't already.<br>
             <em>NOTE</em>: If the player's purchases were not already blocked, this will also call the <code>TTTOnShopPurchaseDisabled</code> hook<br>
@@ -136,7 +136,7 @@
             <li><em>role</em> - Which role to set the Drunk to (see ROLE_* global enumeration)</li>
         </ul>
 
-        <h3><a id="plymetaenableroleability" href="#plymetaenableroleability">plymeta:EnableRoleAbility()</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="plymetaenableroleability" href="#plymetaenableroleability">plymeta:EnableRoleAbility()</a></h3>
         <p>
             Enables this player's role ability, if it was previously disabled.<br>
             <em>NOTE</em>: If the player's role ability was previously disabled, this will also call the <code>TTTOnRoleAbilityEnabled</code> hook<br>
@@ -410,7 +410,7 @@
             <em>Added in:</em> 2.1.12
         </p>
 
-        <h3><a id="plymetaisroleabilitydisabled" href="#plymetaisroleabilitydisabled">plymeta:IsRoleAbilityDisabled(...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="plymetaisroleabilitydisabled" href="#plymetaisroleabilitydisabled">plymeta:IsRoleAbilityDisabled(...)</a></h3>
         <p>
             Called to check whether a player's role ability is disabled.<br>
             <em>NOTE</em>: Calls <code>TTTIsRoleAbilityDisabled</code> hook to determine status if <code>plymeta:DisableRoleAbility</code> has not previously been called.<br>
@@ -462,7 +462,7 @@
             <li><em>isRoleOverridden</em> - Whether the role color or icon is currently overridden</li>
         </ul>
 
-        <h3><a id="plymetaisshoppurchasedisabled" href="#plymetaisshoppurchasedisabled">plymeta:IsShopPurchaseDisabled(...)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
+        <h3><a id="plymetaisshoppurchasedisabled" href="#plymetaisshoppurchasedisabled">plymeta:IsShopPurchaseDisabled(...)</a></h3>
         <p>
             Called to check whether a player's shop purchases are disabled.<br>
             <em>NOTE</em>: Calls <code>TTTIsShopPurchaseDisabled</code> hook to determine status if <code>plymeta:DisableShopPurchases</code> has not previously been called.<br>
@@ -599,7 +599,7 @@
             <li><em>message_type</em> - The <a href="global_enumerations.html#msg_print" target="_blank">MSG_PRINT*</a> value representing the display target for this message</li>
             <li><em>message</em> - The message being shown</li>
             <li><em>time</em> - The amount of time to display the message in the center of the screen. Only used when <code>message_type</code> is <code>MSG_PRINTBOTH</code> or <code>MSG_PRINTCENTER</code> (Optional. Defaults to 5 seconds if not provided)</li>
-            <li><em>id</em> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> - An identifier string that can be used to clear the message or remove it from the queue (Optional) <em>(Added in 2.2.1)</em></li>
+            <li><em>id</em> - An identifier string that can be used to clear the message or remove it from the queue (Optional) <em>(Added in 2.2.1)</em></li>
             <li><em>predicate</em> - Predicate function called with the player as the sole parameter before the message is sent. Return <code>true</code> to allow the message or <code>false</code> to prevent it (Optional) <em>(Added in 2.0.5)</em> <em>(Only available on the server realm)</em></li>
         </ul>
 

--- a/docs/teams/detective.html
+++ b/docs/teams/detective.html
@@ -319,7 +319,7 @@
                             <td>Whether the Illusionist should prevent monsters from knowing who their team mates are.</td>
                         </tr>
                         <tr>
-                            <td>ttt_illusionist_traitor_credits <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_illusionist_traitor_credits</td>
                             <td>0</td>
                             <td>Integer</td>
                             <td>How many extra credits traitors <i>(and monsters if <code>ttt_illusionist_hides_monsters</code> is enabled)</i> should receive at the start of the round if there is an Illusionist.</td>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -820,7 +820,7 @@
                             <td>Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the Plaguemaster.</td>
                         </tr>
                         <tr>
-                            <td>ttt_plaguemaster_dart_replace_timer <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_plaguemaster_dart_replace_timer</td>
                             <td>0</td>
                             <td>Integer</td>
                             <td>How long (in seconds) after the plaguemaster's infection dies out before they should receive another dart gun. Set to 0 to disable.</td>
@@ -1168,31 +1168,31 @@
                             <td>The fraction an attacker's bullet damage will be reduced by when they are shooting a Zombie. <i>(e.g. 0.5 = 50% less damage.)</i></td>
                         </tr>
                         <tr>
-                            <td>ttt_zombie_eat_enabled <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_zombie_eat_enabled</td>
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether Zombies have the ability to eat a player's corpse.</td>
                         </tr>
                         <tr>
-                            <td>ttt_zombie_eat_drop_bones <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_zombie_eat_drop_bones</td>
                             <td>1</td>
                             <td>Boolean</td>
                             <td>Whether Zombies should drop bones when eating a player's corpse.</td>
                         </tr>
                         <tr>
-                            <td>ttt_zombie_eat_timer <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_zombie_eat_timer</td>
                             <td>5</td>
                             <td>Integer</td>
                             <td>The amount of time it takes to consume a player's corpse.</td>
                         </tr>
                         <tr>
-                            <td>ttt_zombie_eat_heal <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_zombie_eat_heal</td>
                             <td>50</td>
                             <td>Integer</td>
                             <td>The amount of health a Zombie will heal by when they consume a player's corpse.</td>
                         </tr>
                         <tr>
-                            <td>ttt_zombie_eat_overheal <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_zombie_eat_overheal</td>
                             <td>25</td>
                             <td>Integer</td>
                             <td>The amount over the Zombie's normal maximum health (e.g. 100 + this ConVar) that the Zombie can heal to by consuming a player's corpse.</td>

--- a/docs/teams/innocent.html
+++ b/docs/teams/innocent.html
@@ -1053,13 +1053,13 @@
                             <td>Whether the Vindicator should be killed if they are revived after having died due to failing or succeeding in killing their target.</td>
                         </tr>
                         <tr>
-                            <td>ttt_vindicator_reset_on_success <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_vindicator_reset_on_success</td>
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether the Vindicator should be reset to the innocent team after they kill their target.</td>
                         </tr>
                         <tr>
-                            <td>ttt_vindicator_reset_win_on_success <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_vindicator_reset_win_on_success</td>
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether the Vindicator, when they are reset to the innocent team after killing their target, should only win with the innocent team. When disabled, the Vindicator will also have a solo secondary win. <em>(Requires <code>ttt_vindicator_reset_on_success</code> to be enabled).</em></td>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -230,13 +230,13 @@
                             <td>Whether jesters are revealed (via overhead icons, color/icon on the scoreboard, etc.) to the Beggar <i>(Requires <code>ttt_beggar_is_independent</code> to be enabled.)</i></td>
                         </tr>
                         <tr>
-                            <td>ttt_beggar_ignore_empty_weapons <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_beggar_ignore_empty_weapons</td>
                             <td>1</td>
                             <td>Boolean</td>
                             <td>Whether the Beggar should not change teams if they are given a weapon with no ammo.</td>
                         </tr>
                         <tr>
-                            <td>ttt_beggar_ignore_empty_weapons_warning <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>ttt_beggar_ignore_empty_weapons_warning</td>
                             <td>1</td>
                             <td>Boolean</td>
                             <td>Whether the Beggar should receive a chat message warning on receiving an empty weapon.</td>

--- a/gamemodes/terrortown/gamemode/corpse.lua
+++ b/gamemodes/terrortown/gamemode/corpse.lua
@@ -448,7 +448,25 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
     end
 
     local round_state = GetRoundState()
+
+    -- Specifically skip the check for the detective search here
+    -- since the role information is hidden for a role-disabled detective
+    -- and we need to know the difference in a couple cases
+    local nonDetectiveKnowsRole = not ply:IsDetectiveLike() and AnnounceBodyRole(ply, round_state, nil)
+
+    -- Keep track who searched this ragdoll
+    if not IsPlayer(rag.searched_by) then
+        rag.searched_by = ply
+    -- If role information is known by everyone or the searcher is a detective-like player (who can see everything)
+    -- and this was previously searched by a role-disabled detective then use the NEW searcher for the record going forward
+    -- since the previous searcher couldn't know their role and the new one can
+    elseif (nonDetectiveKnowsRole or ply:IsDetectiveLike()) and rag.searched_by ~= ply and IsPlayer(rag.searched_by) and rag.searched_by:IsDetectiveTeam() and rag.searched_by:IsRoleAbilityDisabled() then
+        rag.searched_by = ply
+    end
+
     local sendName = AnnounceBodyName(ply, round_state, ownerEnt)
+    -- If any player should be able to see this role information or it was searched by a person who isn't a detective with their role ability disabled, then show the role
+    local sendRole = nonDetectiveKnowsRole or (IsPlayer(rag.searched_by) and (not rag.searched_by:IsDetectiveTeam() or not rag.searched_by:IsRoleAbilityDisabled()))
 
     -- Send a message with basic info
     net.Start("TTT_RagdollSearch")
@@ -461,10 +479,10 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
     for _, v in ipairs(eq) do
         net.WriteUInt(v, eq_bits)
     end
-    if ply:IsDetectiveTeam() and ply:IsRoleAbilityDisabled() then
-        net.WriteInt(-1, 8) -- ( 8 bits )
-    else
+    if sendRole then
         net.WriteInt(role, 8) -- ( 8 bits )
+    else
+        net.WriteInt(-1, 8) -- ( 8 bits )
     end
     net.WriteUInt(c4, bitsRequired(C4_WIRE_COUNT)) -- 0 -> 2^bits ( default c4: 3 bits )
     net.WriteUInt(dmg, 30) -- DMG_BUCKSHOT is the highest. ( 30 bits )

--- a/gamemodes/terrortown/gamemode/rolepacks.lua
+++ b/gamemodes/terrortown/gamemode/rolepacks.lua
@@ -393,9 +393,11 @@ function ROLEPACKS.SendRolePackWeapons(ply)
 
     for id, _ in pairs(ROLE_STRINGS_RAW) do
         -- If this rolepack table doesn't exist that implies we never loaded
-        -- the tables. Do that now before we try to use it
+        -- the tables. Do that now and then stop processing since that method
+        -- already sends the lists to everyone
         if not WEPS.RolePackBuyableWeapons[id] then
             ROLEPACKS.FillRolePackWeaponTables()
+            return
         end
 
         local roleBuyables = WEPS.RolePackBuyableWeapons[id]

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,8 +24,8 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.2.10"
-CR_BETA = true
+CR_VERSION = "2.3.0"
+CR_BETA = false
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 
 function CRVersion(version)


### PR DESCRIPTION
## Changelog
- Fixed player searching body originally searched by a detective-team member with their ability disabled still being able to see the dead player's role when `ttt_detectives_search_only` or `ttt_detectives_search_only_role` was enabled
- Prepare for release

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] CONVARS.md updated, if applicable
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
