### PR TITLE
Misc. changes and fixes

### DIFF
--- a/CONVARS.md
+++ b/CONVARS.md
@@ -238,8 +238,6 @@ ttt_impersonator_use_detective_icon            1       // Whether a promoted Imp
 ttt_impersonator_without_detective             0       // Whether an Impersonator can spawn without a detective in the round. Will automatically promote the Impersonator when they spawn
 ttt_impersonator_activation_credits            0       // The number of credits to give the Impersonator when they are activated
 ttt_impersonator_detective_chance              0       // The chance that a detective will spawn as a promoted Impersonator instead (e.g. 0.5 = 50% chance)
-ttt_single_deputy_impersonator                 0       // Whether only a single Deputy or Impersonator should spawn in a round
-ttt_single_deputy_impersonator_chance          0.5     // The chance that a Deputy should have an opportunity to spawn instead of an Impersonator (e.g. 0.7 = 70% chance for Deputy, 30% chance for Impersonator. Only applies if ttt_single_deputy_impersonator is enabled)
 ttt_deputy_impersonator_promote_any_death      0       // Whether Deputy/Impersonator should be promoted when any detective dies rather than only after all detectives have died
 ttt_deputy_impersonator_start_promoted         0       // Whether Deputy/Impersonator should start the round promoted
 
@@ -252,8 +250,6 @@ ttt_hypnotist_convert_detectives               0       // Whether to convert det
 ttt_hypnotist_device_time                      8       // The amount of time (in seconds) the Hypnotist's device takes to use
 ttt_hypnotist_brainwash_muted                  0       // Whether players brainwashed by the Hypnotist should be muted
 ttt_hypnotist_brainwash_credits                0       // How many credits a hypnotized player should get
-ttt_single_paramedic_hypnotist                 0       // Whether only a single Paramedic or Hypnotist should spawn in a round
-ttt_single_paramedic_hypnotist_chance          0.5     // The chance that a Paramedic should have an opportunity to spawn instead of a Hypnotist (e.g. 0.7 = 70% chance for Paramedic, 30% chance for Hypnotist. Only applies if ttt_single_paramedic_hypnotist is enabled)
 
 // Assassin
 ttt_assassin_show_target_icon                  0       // Whether Assassins have an icon over their target's heads showing who to kill. Server or round must be restarted for changes to take effect
@@ -269,25 +265,26 @@ ttt_assassin_credits_starting                  1       // The number of credits 
 ttt_assassin_allow_jesters_kill                1       // Whether the Assassin can kill a member of the jester team without damage penalty, even if it is not their target
 ttt_assassin_allow_independents_kill           1       // Whether the Assassin can kill an independent role without damage penalty, even if it is not their target
 ttt_assassin_allow_monsters_kill               1       // Whether the Assassin can kill a member of the monster team without damage penalty, even if it is not their target
-ttt_assassin_allow_jester_kill                 1       // Whether the Assassin can kill a Jester without damage penalty, even if it is not their target
-ttt_assassin_allow_swapper_kill                1       // Whether the Assassin can kill a Swapper without damage penalty, even if it is not their target
+ttt_assassin_allow_jester_kill                 0       // Whether the Assassin can kill a Jester without damage penalty, even if it is not their target
+ttt_assassin_allow_swapper_kill                0       // Whether the Assassin can kill a Swapper without damage penalty, even if it is not their target
 ttt_assassin_allow_clown_kill                  1       // Whether the Assassin can kill a Clown without damage penalty, even if it is not their target
-ttt_assassin_allow_beggar_kill                 1       // Whether the Assassin can kill a Beggar without damage penalty, even if it is not their target
-ttt_assassin_allow_bodysnatcher_kill           1       // Whether the Assassin can kill a Bodysnatcher without damage penalty, even if it is not their target
+ttt_assassin_allow_beggar_kill                 0       // Whether the Assassin can kill a Beggar without damage penalty, even if it is not their target
+ttt_assassin_allow_bodysnatcher_kill           0       // Whether the Assassin can kill a Bodysnatcher without damage penalty, even if it is not their target
 ttt_assassin_allow_lootgoblin_kill             1       // Whether the Assassin can kill a Loot Goblin without damage penalty, even if it is not their target
-ttt_assassin_allow_cupid_kill                  1       // Whether the Assassin can kill a Cupid without damage penalty, even if it is not their target
-ttt_assassin_allow_sponge_kill                 1       // Whether the Assassin can kill a Sponge without damage penalty, even if it is not their target
-ttt_assassin_allow_guesser_kill                1       // Whether the Assassin can kill a Guesser without damage penalty, even if it is not their target
-ttt_assassin_allow_oldman_kill                 1       // Whether the Assassin can kill an Old Man without damage penalty, even if it is not their target
-ttt_assassin_allow_killer_kill                 1       // Whether the Assassin can kill a Killer without damage penalty, even if it is not their target
-ttt_assassin_allow_zombie_kill                 1       // Whether the Assassin can kill a Zombie without damage penalty, even if it is not their target
-ttt_assassin_allow_madscientist_kill           1       // Whether the Assassin can kill a Mad Scientist without damage penalty, even if it is not their target
-ttt_assassin_allow_shadow_kill                 1       // Whether the Assassin can kill a Shadow without damage penalty, even if it is not their target
-ttt_assassin_allow_arsonist_kill               1       // Whether the Assassin can kill an Arsonist without damage penalty, even if it is not their target
-ttt_assassin_allow_hivemind_kill               1       // Whether the Assassin can kill a member of the Hive Mind without damage penalty, even if it is not their target
-ttt_assassin_allow_plaguemaster_kill           1       // Whether the Assassin can kill a Plaguemaster without damage penalty, even if it is not their target
-ttt_assassin_allow_cannibal_kill               1       // Whether the Assassin can kill a Cannibal without damage penalty, even if it is not their target
+ttt_assassin_allow_cupid_kill                  0       // Whether the Assassin can kill a Cupid without damage penalty, even if it is not their target
+ttt_assassin_allow_sponge_kill                 0       // Whether the Assassin can kill a Sponge without damage penalty, even if it is not their target
+ttt_assassin_allow_guesser_kill                0       // Whether the Assassin can kill a Guesser without damage penalty, even if it is not their target
+ttt_assassin_allow_oldman_kill                 0       // Whether the Assassin can kill an Old Man without damage penalty, even if it is not their target
+ttt_assassin_allow_killer_kill                 0       // Whether the Assassin can kill a Killer without damage penalty, even if it is not their target
+ttt_assassin_allow_zombie_kill                 1       // Whether the Assassin can kill a Zombie without damage penalty, even if it is not their target (only created and used when "ttt_zombie_is_monster" is enabled or "ttt_zombie_is_traitor" is disabled)
+ttt_assassin_allow_madscientist_kill           0       // Whether the Assassin can kill a Mad Scientist without damage penalty, even if it is not their target
+ttt_assassin_allow_shadow_kill                 0       // Whether the Assassin can kill a Shadow without damage penalty, even if it is not their target
+ttt_assassin_allow_arsonist_kill               0       // Whether the Assassin can kill an Arsonist without damage penalty, even if it is not their target
+ttt_assassin_allow_hivemind_kill               0       // Whether the Assassin can kill a member of the Hive Mind without damage penalty, even if it is not their target
+ttt_assassin_allow_plaguemaster_kill           0       // Whether the Assassin can kill a Plaguemaster without damage penalty, even if it is not their target
+ttt_assassin_allow_cannibal_kill               0       // Whether the Assassin can kill a Cannibal without damage penalty, even if it is not their target
 ttt_assassin_allow_vindicator_kill             1       // Whether the Assassin can kill a Vindicator without damage penalty, even if it is not their target
+ttt_assassin_allow_vampire_kill                1       // Whether the Assassin can kill a Vampire without damage penalty, even if it is not their target (only created and used when "ttt_vampire_is_monster" or "ttt_vampire_is_independent" is enabled)
 
 // Vampire
 ttt_vampire_is_monster                         0       // Whether Vampires should be treated as members of the monster team (rather than the traitor team)
@@ -327,8 +324,6 @@ ttt_quack_fake_cure_rebuyable                  0       // Whether the fake cure 
 ttt_quack_phantom_cure                         0       // Whether to allow the Quack to buy the Phantom exorcism device which can remove a haunting Phantom. Server must be restarted for changes to take effect
 ttt_quack_station_bomb                         0       // Whether the Quack should be able to buy a device which converts a health station to a bomb station
 ttt_quack_station_bomb_time                    4       // The amount of time (in seconds) the station bomb takes to plant
-ttt_single_doctor_quack                        0       // Whether only a single Doctor or Quack should spawn in a round
-ttt_single_doctor_quack_chance                 0.5     // The chance that a Doctor should have an opportunity to spawn instead of a Quack (e.g. 0.7 = 70% chance for Doctor, 30% chance for Quack. Only applies if ttt_single_doctor_quack is enabled)
 
 // Parasite
 ttt_parasite_is_monster                        0       // Whether the Parasite should be treated as a member of the monster team (rather than the traitor team)
@@ -345,8 +340,6 @@ ttt_parasite_infection_saves_lover             1       // Whether the Parasite's
 ttt_parasite_killer_smoke                      0       // Whether to show smoke on the player who killed the Parasite
 ttt_parasite_killer_footstep_time              0       // The amount of time a Parasite's killer's footsteps should show before fading. Set to 0 to disable
 ttt_parasite_credits_starting                  1       // The number of credits a Parasite should start with
-ttt_single_phantom_parasite                    0       // Whether only a single Phantom or Parasite should spawn in a round
-ttt_single_phantom_parasite_chance             0.5     // The chance that a Phantom should have an opportunity to spawn instead of a Parasite (e.g. 0.7 = 70% chance for Phantom, 30% chance for Parasite. Only applies if ttt_single_phantom_parasite is enabled)
 
 // Informant
 ttt_informant_share_scans                      1       // Whether the Informant should automatically share their information with fellow traitors or not
@@ -589,8 +582,6 @@ ttt_jester_notify_sound                        0       // Whether to play a chee
 ttt_jester_notify_confetti                     0       // Whether to throw confetti when a Jester is a killed
 ttt_jester_credits_starting                    0       // The number of credits a Jester should start with
 ttt_jester_healthstation_reduce_max            1       // Whether the Jester's max health should be reduced to match their current health when using a health station, instead of being healed
-ttt_single_jester_swapper                      0       // Whether only a single Jester or Swapper should spawn in a round (Only applies if ttt_multiple_jesters_independents is enabled)
-ttt_single_jester_swapper_chance               0.5     // The chance that a Jester should have an opportunity to spawn instead of a Swapper (e.g. 0.7 = 70% chance for Jester, 30% chance for Swapper. Only applies if ttt_single_jester_swapper is enabled)
 
 // Swapper
 ttt_swapper_respawn_health                     100     // What amount of health to give the Swapper when they are killed and respawned
@@ -620,8 +611,6 @@ ttt_clown_shop_delay                           0       // Whether the Clown's pu
 ttt_clown_credits_starting                     0       // The number of credits a Clown should start with
 ttt_clown_can_see_jesters                      1       // Whether jesters are revealed (via head icons, color/icon on the scoreboard, etc.) to the Clown after they activate
 ttt_clown_update_scoreboard                    1       // Whether the Clown shows dead players as missing in action after they activate
-ttt_single_drunk_clown                         0       // Whether only a single Drunk or Clown should spawn in a round (Only applies if ttt_single_jester_independent is disabled)
-ttt_single_drunk_clown_chance                  0.5     // The chance that a Drunk should have an opportunity to spawn instead of a Clown (e.g. 0.7 = 70% chance for Drunk, 30% chance for Clown. Only applies if ttt_single_drunk_clown is enabled)
 
 // Beggar
 ttt_beggar_is_independent                      0       // Whether Beggars should be treated as members of the independent team (rather than the jester team)
@@ -734,8 +723,8 @@ ttt_sponge_device_for_jester                   0       // Whether the Jester sho
 ttt_sponge_device_for_jester_heal              0       // Whether the Jester should be fully healed when using the spongifier
 ttt_sponge_device_for_lootgoblin               0       // Whether the lootgoblin should get the spongifier
 ttt_sponge_device_for_lootgoblin_heal          0       // Whether the lootgoblin should be fully healed when using the spongifier
-ttt_sponge_device_for_shadow                   0       // Whether the Shadow should get the spongifier
-ttt_sponge_device_for_shadow_heal              0       // Whether the Shadow should be fully healed when using the spongifier
+ttt_sponge_device_for_shadow                   0       // Whether the Shadow should get the spongifier (only created and used when "ttt_shadow_is_jester" is enabled)
+ttt_sponge_device_for_shadow_heal              0       // Whether the Shadow should be fully healed when using the spongifier (only created and used when "ttt_shadow_is_jester" is enabled)
 ttt_sponge_device_for_swapper                  0       // Whether the Swapper should get the spongifier
 ttt_sponge_device_for_swapper_heal             0       // Whether the Swapper should be fully healed when using the spongifier
 
@@ -1493,7 +1482,7 @@ Role blocks are configured using the UI, accessible by admins using the `ttt_rol
 
 ![Blank Role Blocks Window](docs/tutorials/img/RoleBlocks_Blank.png)
 
-By default, your role blocks window should be mostly empty. (If you were previously using ConVars such as `ttt_single_paramedic_hypnotist`, you will see those options have already copied over.)
+By default, your role blocks window should be mostly empty. (If you were previously using ConVars such as `ttt_single_paramedic_hypnotist` prior to Beta 2.1.4 or Release 2.3.0, you will see those options have already copied over.)
 
 Here you will be able to create "blocking groups" which determine which roles cannot spawn together. Roles that are in the same blocking group will be unable to spawn together at the start of a round, but will still have the ability to appear later in the round through other means. (e.g. Marshal deputizing, Drunk sobering, etc.) Each role within a blocking group can have a weight assigned to it, making it more likely to block other roles in the same blocking group from spawning.
 

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -251,6 +251,7 @@ ttt_hypnotist_device_shop_rebuyable            0       // Whether the Hypnotist'
 ttt_hypnotist_convert_detectives               0       // Whether to convert detectives and Deputies (only if ttt_deputy_use_detective_icon is enabled) to Impersonator instead of just a regular Traitor. Target will be automatically promoted to appear as a detective if appropriate
 ttt_hypnotist_device_time                      8       // The amount of time (in seconds) the Hypnotist's device takes to use
 ttt_hypnotist_brainwash_muted                  0       // Whether players brainwashed by the Hypnotist should be muted
+ttt_hypnotist_brainwash_credits                0       // How many credits a hypnotized player should get
 ttt_single_paramedic_hypnotist                 0       // Whether only a single Paramedic or Hypnotist should spawn in a round
 ttt_single_paramedic_hypnotist_chance          0.5     // The chance that a Paramedic should have an opportunity to spawn instead of a Hypnotist (e.g. 0.7 = 70% chance for Paramedic, 30% chance for Hypnotist. Only applies if ttt_single_paramedic_hypnotist is enabled)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 - Fixed bodysnatcher forced duck/unduck logic not working
 - Fixed transfer window label using role name instead of team name
 - Fixed `ttt_hypnotist_brainwash_muted` not showing in ULX menu
+- Fixed players who were swallowed and released by a Cannibal getting their role weapons back even if they used them already
 
 ## 2.3.0
 **Released: April 6th, 2025**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 ### Additions
 - Added option to reduce any damage dealt by the Cannibal (disabled by default)
 
+### Changes
+- Changed Veteran activation message to not say there's one one innocent remaining when multiple Veterans are activated at the same time
+
 ### Fixes
 - Fixed entities that were being spectated by living players showing role/target icons and other in-world visual elements as if they were the player spectating them
 - Fixed error opening the F1 menu too quickly after loading in to the game

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 2.3.1 (Beta)
-**Released:**
+**Released: April 19th, 2025**
 
 ### Additions
 - Added option to reduce any damage dealt by the Cannibal (disabled by default)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 - Fixed entities that were being spectated by living players showing role/target icons and other in-world visual elements as if they were the player spectating them
 - Fixed error opening the F1 menu too quickly after loading in to the game
 - Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled
+- Fixed bodysnatcher forced duck/unduck logic not working
 
 ## 2.3.0
 **Released: April 6th, 2025**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 ### Fixes
 - Fixed entities that were being spectated by living players showing role/target icons and other in-world visual elements as if they were the player spectating them
 - Fixed error opening the F1 menu too quickly after loading in to the game
+- Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled
 
 ## 2.3.0
 **Released: April 6th, 2025**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Additions
 - Added option to reduce any damage dealt by the Cannibal (disabled by default)
+- Added ability for a player brainwashed by a Hypnotist to be given credits (disabled by default)
 
 ### Changes
 - Changed Veteran activation message to not say there's one one innocent remaining when multiple Veterans are activated at the same time
@@ -15,6 +16,7 @@
 - Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled
 - Fixed bodysnatcher forced duck/unduck logic not working
 - Fixed transfer window label using role name instead of team name
+- Fixed `ttt_hypnotist_brainwash_muted` not showing in ULX menu
 
 ## 2.3.0
 **Released: April 6th, 2025**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 - Changed Veteran activation message to not say there's one one innocent remaining when multiple Veterans are activated at the same time
 
 ### Fixes
+- Ported "[TTT] fix players sometimes being revealed as dead when they chat/voicechat right as they die (again)"
 - Fixed entities that were being spectated by living players showing role/target icons and other in-world visual elements as if they were the player spectating them
 - Fixed error opening the F1 menu too quickly after loading in to the game
 - Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@
 - Fixed error opening the F1 menu too quickly after loading in to the game
 - Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled
 - Fixed bodysnatcher forced duck/unduck logic not working
-- Fixed transfer window label using role name instead of team name
+- Fixed credit transfer window label using role name instead of team name
 - Fixed `ttt_hypnotist_brainwash_muted` not showing in ULX menu
 - Fixed players who were swallowed and released by a Cannibal getting their role weapons back even if they used them already
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 - Added ability for a player brainwashed by a Hypnotist to be given credits (disabled by default)
 
 ### Changes
-- Changed Veteran activation message to not say there's one one innocent remaining when multiple Veterans are activated at the same time
+- Changed Veteran activation message to not say there's one innocent remaining when multiple Veterans are activated at the same time
 
 ### Fixes
 - Ported "[TTT] fix players sometimes being revealed as dead when they chat/voicechat right as they die (again)"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
 - Fixed error opening the F1 menu too quickly after loading in to the game
 - Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled
 - Fixed bodysnatcher forced duck/unduck logic not working
+- Fixed transfer window label using role name instead of team name
 
 ## 2.3.0
 **Released: April 6th, 2025**\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - Fixed entities that were being spectated by living players showing role/target icons and other in-world visual elements as if they were the player spectating them
+- Fixed error opening the F1 menu too quickly after loading in to the game
 
 ## 2.3.0
 **Released: April 6th, 2025**\

--- a/docs/api/methods_hud.html
+++ b/docs/api/methods_hud.html
@@ -102,7 +102,7 @@
             <li><em>m</em> - The margin between each segment (Defaults to 10)</li>
         </ul>
 
-        <h3><span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span> <a id="curhudpaintspectatorprogressbarmax_value-current_value-colors-title-subtitle" href="#curhudpaintspectatorprogressbarmax_value-current_value-colors-title-subtitle">CRHUD:PaintSpectatorProgressBar(max_value, current_value, colors, title, subtitle)</a></h3>
+        <h3><a id="curhudpaintspectatorprogressbarmax_value-current_value-colors-title-subtitle" href="#curhudpaintspectatorprogressbarmax_value-current_value-colors-title-subtitle">CRHUD:PaintSpectatorProgressBar(max_value, current_value, colors, title, subtitle)</a></h3>
         <p>
             Paints a HUD for showing a progress bar to spectators, similar to that shown when possessing a prop<br>
             <em>Realm:</em> Client<br>

--- a/docs/teams/independent.html
+++ b/docs/teams/independent.html
@@ -348,18 +348,6 @@
                             <td>Boolean</td>
                             <td>Whether the Drunk shows dead players as missing in action.</td>
                         </tr>
-                        <tr>
-                            <td>ttt_single_drunk_clown</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Drunk or Clown should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_drunk_clown_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Drunk should have an opportunity to spawn instead of a Clown. <i>(e.g. 0.7 = 70% chance forDrunk, 30% chance for Clown. Requires <code>ttt_single_drunk_clown</code> to be enabled.)</i></td>
-                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>

--- a/docs/teams/innocent.html
+++ b/docs/teams/innocent.html
@@ -165,18 +165,6 @@
                             <td>Boolean</td>
                             <td>Whether Deputy/Impersonator should start the round promoted.</td>
                         </tr>
-                        <tr>
-                            <td>ttt_single_deputy_impersonator</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Deputy or Impersonator should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_deputy_impersonator_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Deputy should have an opportunity to spawn instead of an Impersonator. <i>(e.g. 0.7 = 70% chance for Deputy, 30% chance for Impersonator. Requires <code>ttt_single_deputy_impersonator</code> to be enabled.)</i></td>
-                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>
@@ -230,18 +218,6 @@
                             <td>3</td>
                             <td>Integer</td>
                             <td>The amount of time in seconds the cure takes to use.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_doctor_quack</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Doctor or Quack should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_doctor_quack_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Doctor should have an opportunity to spawn instead of a Quack. <i>(e.g. 0.7 = 70% chance for Doctor, 30% chance for Quack. Requires <code>ttt_single_doctor_quack</code> to be enabled.)</i></td>
                         </tr>
                         </tbody>
                     </table>
@@ -544,18 +520,6 @@
                             <td>Boolean</td>
                             <td>Whether players revived by the paramedic should be muted.</td>
                         </tr>
-                        <tr>
-                            <td>ttt_single_paramedic_hypnotist</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Paramedic or Hypnotist should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_paramedic_hypnotist_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Paramedic should have an opportunity to spawn instead of a Hypnotist. <i>(e.g. 0.7 = 70% chance for Paramedic, 30% chance for Hypnotist. Requires <code>ttt_single_paramedic_hypnotist</code> to be enabled.)</i></td>
-                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>
@@ -713,18 +677,6 @@
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether to allow the traitor to buy the phantom exorcism device which can remove a haunting Phantom. <i>(Server must be restarted for changes to take effect.)</i></td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_phantom_parasite</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Phantom or Parasite should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_phantom_parasite_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Phantom should have an opportunity to spawn instead of a Parasite. <i>(e.g. 0.7 = 70% chance for Phantom, 30% chance for Parasite. Requires <code>ttt_single_phantom_parasite</code> to be enabled.)</i></td>
                         </tr>
                         </tbody>
                     </table>

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -684,18 +684,6 @@
                             <td>Boolean</td>
                             <td>Whether the Clown can see and use traitor traps when they are activated.</td>
                         </tr>
-                        <tr>
-                            <td>ttt_single_drunk_clown</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Drunk or Clown should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_drunk_clown_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Drunk should have an opportunity to spawn instead of a Clown. <i>(e.g. 0.7 = 70% chance forDrunk, 30% chance for Clown. Requires <code>ttt_single_drunk_clown</code> to be enabled.)</i></td>
-                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>
@@ -902,18 +890,6 @@
                             <td>1</td>
                             <td>Boolean</td>
                             <td>Whether the jester winning causes the round to end.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_jester_swapper</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single jester or Swapper should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_jester_swapper_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a jester should have an opportunity to spawn instead of a Swapper. <i>(e.g. 0.7 = 70% chance for jester, 30% chance for Swapper. Requires <code>ttt_single_jester_swapper</code> to be enabled.)</i></td>
                         </tr>
                         </tbody>
                     </table>
@@ -1238,18 +1214,6 @@
                                     <li>Swap all weapons.</li>
                                 </ol>
                             </td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_jester_swapper</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single jester or Swapper should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_jester_swapper_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a jester should have an opportunity to spawn instead of a Swapper. <i>(e.g. 0.7 = 70% chance for jester, 30% chance for Swapper. Requires <code>ttt_single_jester_swapper</code> to be enabled.)</i></td>
                         </tr>
                         </tbody>
                     </table>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -354,6 +354,12 @@
                         </thead>
                         <tbody>
                         <tr>
+                            <td>ttt_hypnotist_brainwash_credits <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Integer</td>
+                            <td>How many credits a hypnotized player should get.</td>
+                        </tr>
+                        <tr>
                             <td>ttt_hypnotist_brainwash_muted</td>
                             <td>0</td>
                             <td>Boolean</td>

--- a/docs/teams/traitor.html
+++ b/docs/teams/traitor.html
@@ -233,7 +233,7 @@
                             <td>ttt_assassin_allow_*_kill</td>
                             <td>0 <i>(Clown, Loot Goblin, Vampire, Zombie, Vindicator: 1)</i></td>
                             <td>Boolean</td>
-                            <td>Whether the assassin can kill a specific role without damage penalty, even if it is not their target. Replace * with the name of the role you want to configure without spaces or capital letters.</td>
+                            <td>Whether the assassin can kill a specific role without damage penalty, even if it is not their target. Replace * with the name of the role you want to configure without spaces or capital letters. Note that roles that can switch teams will only have this convar created and used when that role is a Jester, Monster, or Independent.</td>
                         </tr>
                         <tr>
                             <td>ttt_assassin_credits_starting</td>
@@ -401,18 +401,6 @@
                             <td>Integer</td>
                             <td>The amount of time in seconds the Hypnotist's device takes to use.</td>
                         </tr>
-                        <tr>
-                            <td>ttt_single_paramedic_hypnotist</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Paramedic or Hypnotist should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_paramedic_hypnotist_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Paramedic should have an opportunity to spawn instead of a Hypnotist. <i>(e.g. 0.7 = 70% chance for Paramedic, 30% chance for Hypnotist. Requires <code>ttt_single_paramedic_hypnotist</code> to be enabled.)</i></td>
-                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>
@@ -488,18 +476,6 @@
                             <td>0</td>
                             <td>Boolean</td>
                             <td>Whether Deputy/Impersonator should start the round promoted.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_deputy_impersonator</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Deputy or Impersonator should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_deputy_impersonator_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Deputy should have an opportunity to spawn instead of an Impersonator. <i>(e.g. 0.7 = 70% chance for Deputy, 30% chance for Impersonator. Requires <code>ttt_single_deputy_impersonator</code> to be enabled.)</i></td>
                         </tr>
                         </tbody>
                     </table>
@@ -731,18 +707,6 @@
                                 </ol>
                             </td>
                         </tr>
-                        <tr>
-                            <td>ttt_single_phantom_parasite</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Phantom or Parasite should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_phantom_parasite_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Phantom should have an opportunity to spawn instead of a Parasite. <i>(e.g. 0.7 = 70% chance for Phantom, 30% chance for Parasite. Requires <code>ttt_single_phantom_parasite</code> to be enabled.)</i></td>
-                        </tr>
                         </tbody>
                     </table>
                     <p>A list of ConVars shared by every role and instructions for using ConVars can be found on the <a href="../tutorials/configuring_convars.html">Configuring ConVars</a> tutorial page.</p>
@@ -816,18 +780,6 @@
                             <td>4</td>
                             <td>Integer</td>
                             <td>The amount of time in seconds the station bomb takes to plant.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_doctor_quack</td>
-                            <td>0</td>
-                            <td>Boolean</td>
-                            <td>Whether only a single Doctor or Quack should spawn in a round.</td>
-                        </tr>
-                        <tr>
-                            <td>ttt_single_doctor_quack_chance</td>
-                            <td>0.5</td>
-                            <td>Float (0-1)</td>
-                            <td>The chance that a Doctor should have an opportunity to spawn instead of a Quack. <i>(e.g. 0.7 = 70% chance for Doctor, 30% chance for Quack. Requires <code>ttt_single_doctor_quack</code> to be enabled.)</i></td>
                         </tr>
                         </tbody>
                     </table>

--- a/docs/tutorials/configuring_role_blocks.html
+++ b/docs/tutorials/configuring_role_blocks.html
@@ -20,7 +20,7 @@
         <h2><a id="configuration-by-ui" href="#configuration-by-ui">Configuration by UI</a></h2>
         <p>Role blocks are configured using the UI, accessible by admins using the <code>ttt_roleblocks</code> command. Role blocks are saved in the <em>data/rolepacks.json</em> file so that they can then be backed up or copied from server-to-server just by transferring that file.</p>
         <p><img src="img/RoleBlocks_Blank.png" alt="Blank Role Blocks Window" style="max-width: 100%;"></p>
-        <p>By default, your role blocks window should be mostly empty. (If you were previously using ConVars such as <code>ttt_single_paramedic_hypnotist</code>, you will see those options have already copied over.)</p>
+        <p>By default, your role blocks window should be mostly empty. (If you were previously using ConVars such as <code>ttt_single_paramedic_hypnotist</code> prior to Beta 2.1.4 or Release 2.3.0, you will see those options have already copied over.)</p>
         <p>Here you will be able to create "blocking groups" which determine which roles cannot spawn together. Roles that are in the same blocking group will be unable to spawn together at the start of a round, but will still have the ability to appear later in the round through other means. (e.g. Marshal deputizing, Drunk sobering, etc.) Each role within a blocking group can have a weight assigned to it, making it more likely to block other roles in the same blocking group from spawning.</p>
 
         <h3><a id="adding-a-new-blocking-group" href="#adding-a-new-blocking-group"><strong>Adding a new Blocking Group</strong></a></h3>

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -152,10 +152,10 @@ if SERVER then
                     if owner:Crouching() then
                         ply:SetProperty("TTTBodysnatcherForceDuck", true, ply)
                         net.Start("TTT_BodysnatcherForceDuck")
-                        net.ReadBool(true)
+                        net.WriteBool(true)
                         net.Send(ply)
                         net.Start("TTT_BodysnatcherForceDuck")
-                        net.ReadBool(false)
+                        net.WriteBool(false)
                         net.Send(owner)
                     end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -156,6 +156,7 @@ if SERVER then
                         net.WriteBool(true)
                         net.Send(ply)
 
+                        owner:SetProperty("TTTBodysnatcherForceDuck", true, owner)
                         owner:ConCommand("-duck")
                         net.Start("TTT_BodysnatcherForceDuck")
                         net.WriteBool(false)
@@ -290,10 +291,13 @@ if CLIENT then
         return disguiseName
     end)
 
+    local forceDuckTime = nil
     -- If the server tells us this player should be ducking, do it
     net.Receive("TTT_BodysnatcherForceDuck", function()
         local ply = LocalPlayer()
         if not IsPlayer(ply) then return end
+
+        forceDuckTime = CurTime()
 
         local state = net.ReadBool()
         ply:ConCommand((state and "+" or "-") .. "duck")
@@ -304,9 +308,18 @@ if CLIENT then
         if not IsPlayer(ply) then return end
         if not ply:Alive() or ply:IsSpec() then return end
         if not ply.TTTBodysnatcherForceDuck then return end
+        -- Force them to stay ducked (or standing) for a bit
+        if forceDuckTime and (forceDuckTime + 0.5) < CurTime() then
+            forceDuckTime = nil
+            return
+        end
 
         local key = input.LookupKeyBinding(button)
         if key == "+duck" then
+            -- Set this on the client right now so we don't run this hook more than we need
+            -- The net call will set it on the server as well
+            ply.TTTBodysnatcherForceDuck = false
+
             ply:ConCommand("-duck")
 
             net.Start("TTT_BodysnatcherUnforceDuck")

--- a/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_bod_bodysnatch.lua
@@ -151,9 +151,12 @@ if SERVER then
                     -- Include whether the player is crouching
                     if owner:Crouching() then
                         ply:SetProperty("TTTBodysnatcherForceDuck", true, ply)
+                        ply:ConCommand("+duck")
                         net.Start("TTT_BodysnatcherForceDuck")
                         net.WriteBool(true)
                         net.Send(ply)
+
+                        owner:ConCommand("-duck")
                         net.Start("TTT_BodysnatcherForceDuck")
                         net.WriteBool(false)
                         net.Send(owner)
@@ -221,6 +224,7 @@ if SERVER then
         if not ply:Alive() or ply:IsSpec() then return end
         if not ply.TTTBodysnatcherForceDuck then return end
 
+        ply:ConCommand("-duck")
         ply:ClearProperty("TTTBodysnatcherForceDuck", ply)
     end)
 end
@@ -290,7 +294,6 @@ if CLIENT then
     net.Receive("TTT_BodysnatcherForceDuck", function()
         local ply = LocalPlayer()
         if not IsPlayer(ply) then return end
-        if not ply:Alive() or ply:IsSpec() then return end
 
         local state = net.ReadBool()
         ply:ConCommand((state and "+" or "-") .. "duck")

--- a/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_hyp_brainwash.lua
@@ -91,7 +91,7 @@ if SERVER then
         net.Broadcast()
 
         ply:SpawnForRound(true)
-        ply:SetCredits(credits)
+        ply:SetCredits(credits + GetConVar("ttt_hypnotist_brainwash_credits"):GetInt())
         ply:SetPos(self.Location or body:GetPos())
         ply:SetEyeAngles(Angle(0, body:GetAngles().y, 0))
         ply:SetNWBool("WasHypnotised", true)

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -264,18 +264,18 @@ function SWEP:DoAttack(pickup)
     self:SetNextSecondaryFire( CurTime() + self.Secondary.Delay )
 
     if IsValid(self.EntHolding) then
-            self:SendWeaponAnim( ACT_VM_MISSCENTER )
+        self:SendWeaponAnim( ACT_VM_MISSCENTER )
 
-            if (not pickup) and self.EntHolding:GetClass() == "prop_ragdoll" then
-                -- see if we can pin this ragdoll to a wall in front of us
-                self:PinRagdoll()
-            end
+        if (not pickup) and self.EntHolding:GetClass() == "prop_ragdoll" then
+            -- see if we can pin this ragdoll to a wall in front of us
+            self:PinRagdoll()
+        end
 
-            -- else just drop it as usual
-            self:Drop()
+        -- else just drop it as usual
+        self:Drop()
 
-            self:SetNextSecondaryFire(CurTime() + 0.3)
-            return
+        self:SetNextSecondaryFire(CurTime() + 0.3)
+        return
     end
 
     local ply = self:GetOwner()

--- a/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/cl_help.lua
@@ -102,6 +102,7 @@ function HELPSCRN:Show()
     dbut:SetPos(w - bw - margin, h - bh - margin / 2)
     dbut:SetText(GetTranslation("close"))
     dbut.DoClick = function()
+        if not IsValid(dframe) then return end
         dframe:Close()
         dframe = nil
     end

--- a/gamemodes/terrortown/gamemode/cl_transfer.lua
+++ b/gamemodes/terrortown/gamemode/cl_transfer.lua
@@ -72,7 +72,8 @@ function CreateTransferMenu(parent)
     dform:AddItem(dpick)
     dform:AddItem(dsubmit)
 
-    dform:Help(LANG.GetParamTranslation("xfer_help", { role = LocalPlayer():GetRoleString() }))
+    local roleTeam = LocalPlayer():GetRoleTeam(true)
+    dform:Help(LANG.GetParamTranslation("xfer_help", { role = GetRoleTeamName(roleTeam) }))
 
     return dform
 end

--- a/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -75,7 +75,7 @@ net.Receive("TTT_RoleChat", RoleChatRecv)
 
 function GM:GetTeamColor(ent)
     -- don't reveal that a player has died when they happen to chat or voicechat at the moment of death
-    if not LocalPlayer():IsSpec() and ent:IsPlayer() and ent:IsSpec() and ScoreGroup(ent) == GROUP_NOTFOUND then
+    if LocalPlayer():IsTerror() and ent:IsPlayer() then
         return RunHook("GetTeamNumColor", TEAM_TERROR)
     end
 

--- a/gamemodes/terrortown/gamemode/roleblocks.lua
+++ b/gamemodes/terrortown/gamemode/roleblocks.lua
@@ -16,7 +16,7 @@ util.AddNetworkString("TTT_RequestRoleBlocks")
 util.AddNetworkString("TTT_ReadRoleBlocks")
 util.AddNetworkString("TTT_ReadRoleBlocks_Part")
 
--- 2^16 bytes - 4 (header) - 2 (UInt length) - 1 (Extra optional byte) - 1 (terminanting byte)
+-- 2^16 bytes - 4 (header) - 2 (UInt length) - 1 (Extra optional byte) - 1 (terminating byte)
 local maxStreamLength = 65528
 
 local function SendStreamToClient(ply, json, networkString, byte)

--- a/gamemodes/terrortown/gamemode/rolepacks.lua
+++ b/gamemodes/terrortown/gamemode/rolepacks.lua
@@ -47,7 +47,7 @@ util.AddNetworkString("TTT_ClearRolePack")
 util.AddNetworkString("TTT_SendRolePackRoleList")
 util.AddNetworkString("TTT_RolePackBuyableWeapons")
 
--- 2^16 bytes - 4 (header) - 2 (UInt length) - 1 (Extra optional byte) - 1 (terminanting byte)
+-- 2^16 bytes - 4 (header) - 2 (UInt length) - 1 (Extra optional byte) - 1 (terminating byte)
 local maxStreamLength = 65528
 
 local function SendStreamToClient(ply, json, networkString, byte)

--- a/gamemodes/terrortown/gamemode/roles/cannibal/cannibal.lua
+++ b/gamemodes/terrortown/gamemode/roles/cannibal/cannibal.lua
@@ -30,6 +30,8 @@ local function ReleaseEatenPlayers(ply, message)
     local cannibalSID64 = ply:SteamID64()
     for _, v in PlayerIterator() do
         if v.TTTCannibalEaten and v.TTTCannibalEaten == cannibalSID64 then
+            -- Set this to prevent the player from getting their loadout back
+            v.Resurrecting = true
             v:ClearProperty("TTTCannibalEaten")
             v:SetParent(nil)
             v:SpectateEntity(nil)

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/hypnotist.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/hypnotist.lua
@@ -6,6 +6,9 @@ local player = player
 
 local PlayerIterator = player.Iterator
 
+CreateConVar("ttt_hypnotist_brainwash_credits", 0, FCVAR_NONE, "How many credits a hypnotized player should get", 0, 5)
+local hypnotist_brainwash_muted = CreateConVar("ttt_hypnotist_brainwash_muted", 0, FCVAR_NONE, "Whether players brainwashed by the hypnotist should be muted", 0, 1)
+
 ------------------
 -- ROLE WEAPONS --
 ------------------
@@ -23,8 +26,6 @@ end)
 -------------------
 -- ROLE FEATURES --
 -------------------
-
-local hypnotist_brainwash_muted = CreateConVar("ttt_hypnotist_brainwash_muted", 0, FCVAR_NONE, "Whether players brainwashed by the hypnotist should be muted", 0, 1)
 
 hook.Add("PlayerCanHearPlayersVoice", "Hypnotist_PlayerCanHearPlayersVoice", function(listener, speaker)
     if GetRoundState() ~= ROUND_ACTIVE then return end

--- a/gamemodes/terrortown/gamemode/roles/hypnotist/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/hypnotist/shared.lua
@@ -51,25 +51,35 @@ CreateConVar("ttt_hypnotist_device_loadout", "1", FCVAR_REPLICATED)
 CreateConVar("ttt_hypnotist_device_shop", "0", FCVAR_REPLICATED)
 CreateConVar("ttt_hypnotist_device_shop_rebuyable", "0", FCVAR_REPLICATED)
 
-ROLE_CONVARS[ROLE_HYPNOTIST] = {}
-table.insert(ROLE_CONVARS[ROLE_HYPNOTIST], {
-    cvar = "ttt_hypnotist_device_loadout",
-    type = ROLE_CONVAR_TYPE_BOOL
-})
-table.insert(ROLE_CONVARS[ROLE_HYPNOTIST], {
-    cvar = "ttt_hypnotist_device_shop",
-    type = ROLE_CONVAR_TYPE_BOOL
-})
-table.insert(ROLE_CONVARS[ROLE_HYPNOTIST], {
-    cvar = "ttt_hypnotist_device_shop_rebuyable",
-    type = ROLE_CONVAR_TYPE_BOOL
-})
-table.insert(ROLE_CONVARS[ROLE_HYPNOTIST], {
-    cvar = "ttt_hypnotist_convert_detectives",
-    type = ROLE_CONVAR_TYPE_BOOL
-})
-table.insert(ROLE_CONVARS[ROLE_HYPNOTIST], {
-    cvar = "ttt_hypnotist_device_time",
-    type = ROLE_CONVAR_TYPE_NUM,
-    decimal = 0
-})
+ROLE_CONVARS[ROLE_HYPNOTIST] = {
+    {
+        cvar = "ttt_hypnotist_device_loadout",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
+    {
+        cvar = "ttt_hypnotist_device_shop",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
+    {
+        cvar = "ttt_hypnotist_device_shop_rebuyable",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
+    {
+        cvar = "ttt_hypnotist_convert_detectives",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
+    {
+        cvar = "ttt_hypnotist_device_time",
+        type = ROLE_CONVAR_TYPE_NUM,
+        decimal = 0
+    },
+    {
+        cvar = "ttt_hypnotist_brainwash_muted",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
+    {
+        cvar = "ttt_hypnotist_brainwash_credits",
+        type = ROLE_CONVAR_TYPE_NUM,
+        decimal = 0
+    }
+}

--- a/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
+++ b/gamemodes/terrortown/gamemode/roles/veteran/veteran.lua
@@ -36,7 +36,11 @@ hook.Add("PlayerDeath", "Veteran_RoleFeatures_PlayerDeath", function(victim, inf
                 v:SetNWBool("VeteranActive", true)
                 v:AddCredits(veteran_activation_credits:GetInt())
 
-                v:QueueMessage(MSG_PRINTBOTH, "You are the last " .. ROLE_STRINGS[ROLE_INNOCENT] .. " alive!")
+                if innocents_alive == 1 then
+                    v:QueueMessage(MSG_PRINTBOTH, "You are the last " .. ROLE_STRINGS[ROLE_INNOCENT] .. " alive!")
+                else
+                    v:QueueMessage(MSG_PRINTBOTH, "Only " .. ROLE_STRINGS_PLURAL[ROLE_VETERAN] .. " remain alive from the " .. ROLE_STRINGS[ROLE_INNOCENT] .. " team!")
+                end
                 if veteran_announce:GetBool() then
                     for _, p in PlayerIterator() do
                         if p ~= v and p:IsActive() then

--- a/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
+++ b/gamemodes/terrortown/gamemode/roles/vindicator/vindicator.lua
@@ -91,7 +91,8 @@ local function ActivateVindicator(vindicator, target)
 end
 
 local function OnVindicatorSuccess(vindicator, target, msg)
-    if vindicator_reset_on_success:GetBool() and not vindicator_reset_win_on_success:GetBool() then
+    -- Mark the vindicator as winning if they aren't resetting or they are resetting but they aren't resetting their win state
+    if not vindicator_reset_on_success:GetBool() or not vindicator_reset_win_on_success:GetBool() then
         vindicator:SetNWBool("VindicatorSuccess", true)
     end
     vindicator:QueueMessage(MSG_PRINTBOTH, msg)


### PR DESCRIPTION
## Changelog
### Additions
- Added ability for a player brainwashed by a Hypnotist to be given credits (disabled by default)

### Changes
- Changed Veteran activation message to not say there's one innocent remaining when multiple Veterans are activated at the same time

### Fixes
- Ported "[TTT] fix players sometimes being revealed as dead when they chat/voicechat right as they die (again)"
- Fixed error opening the F1 menu too quickly after loading in to the game
- Fixed vindicator not winning when `ttt_vindicator_reset_on_success` was disabled
- Fixed bodysnatcher forced duck/unduck logic not working
- Fixed credit transfer window label using role name instead of team name
- Fixed `ttt_hypnotist_brainwash_muted` not showing in ULX menu
- Fixed players who were swallowed and released by a Cannibal getting their role weapons back even if they used them already

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [x] CONVARS.md updated, if applicable
  - [x] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
