### PR TITLE
Fixed `TTTUpdateRoleState` being called every time role weapons were updated

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.3.2
+**Released:**
+
+### Developer
+- Fixed `TTTUpdateRoleState` being called every time role weapons were updated
+
 ## 2.3.1
 **Released: April 20th, 2025**
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.3.1"
+CR_VERSION = "2.3.2"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 
@@ -1644,8 +1644,6 @@ function GM:Move(ply, mv)
 end
 
 function UpdateRoleWeaponState()
-    CallHook("TTTUpdateRoleState", nil)
-
     if SERVER then
         net.Start("TTT_ResetBuyableWeaponsCache")
         net.Broadcast()
@@ -1673,6 +1671,8 @@ function UpdateRoleState()
             end
         end
     end
+
+    CallHook("TTTUpdateRoleState", nil)
 
     -- Update which weapons are available based on role state
     UpdateRoleWeaponState()


### PR DESCRIPTION
## Changelog
- Fixed `TTTUpdateRoleState` being called every time role weapons were updated

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] CONVARS.md updated, if applicable
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
