### PR TITLE
2.3.2 Hotfixes

### DIFF
--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -931,6 +931,16 @@ Called when a player buys a random item from the shop.\
 - *client* - The player who is buying a random item
 - *item* - The random item that was selected
 
+### TTTShouldHideFromHighlight(ply, client)
+Called when a player is about to be highlighted, allowing you to block that from happening.\
+*Realm*: Client\
+*Added in*: 2.3.3\
+*Parameters:*
+- *ply* - The target player being highlighted
+- *client* - The local player
+
+*Return*: `true` to stop this player from being highlighted 
+
 ### TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)
 Called when during a player's `Think`, allowing a player to emit smoke with different visual effects.\
 *Realm:* Client\

--- a/API/HOOKS.md
+++ b/API/HOOKS.md
@@ -934,7 +934,7 @@ Called when a player buys a random item from the shop.\
 ### TTTShouldHideFromHighlight(ply, client)
 Called when a player is about to be highlighted, allowing you to block that from happening.\
 *Realm*: Client\
-*Added in*: 2.3.3\
+*Added in*: 2.3.2\
 *Parameters:*
 - *ply* - The target player being highlighted
 - *client* - The local player

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,5 @@
 # Release Notes
 
-## 2.3.3 (Beta)
-**Released:**
-
-### Fixes
-- Fixed cannibal being revealed to anyone who can see jesters
-
-### Developer
-- Added `TTTShouldHideFromHighlight` hook to allow blocking a player from being highlighted
-
 ## 2.3.2 (Beta)
 **Released: June 14th, 2025**
 
@@ -28,6 +19,7 @@
 - Fixed role cheat sheet revealing your role when `ttt_hide_role` was enabled
 - Fixed potential errors when vampire fangs and zombie claws are used on fake ragdolls
 - Fixed arsonist's delayed notifications not being cancelled if their role is changed after a target is doused but before they are notified
+- Fixed cannibal being revealed to anyone who can see jesters
 
 ### Developer
 - Fixed `TTTUpdateRoleState` being called every time role weapons were updated
@@ -39,6 +31,7 @@
 - Added `ROLE.usesspectator` external role property and `ROLE_USES_SPECTATOR` global table to enable creating a following entity on dead players
 - Added `TTTSpectatorSpiritCreated` hook for when a following entity is created on a dead player
 - Added `SYNC:SetEntityProperty`, `SYNC:ClearEntityProperty`, `entmeta:SetProperty`, and `entmeta:ClearProperty` to allow doing an on-demand sync of property values for entities
+- Added `TTTShouldHideFromHighlight` hook to allow blocking a player from being highlighted
 
 ## 2.3.1
 **Released: April 20th, 2025**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.3.3 (Beta)
+**Released:**
+
+### Fixes
+- Fixed cannibal being revealed to anyone who can see jesters
+
+### Developer
+- Added `TTTShouldHideFromHighlight` hook to allow blocking a player from being highlighted
+
 ## 2.3.2 (Beta)
 **Released: June 14th, 2025**
 

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -1403,11 +1403,11 @@
             <li><em>item</em> - The random item that was selected</li>
         </ul>
 
-        <h3><a id="tttshouldhidefromhighlightply-client" href="#tttshouldhidefromhighlightply-client">TTTShouldHideFromHighlight(ply, client)</a></h3>
+        <h3><a id="tttshouldhidefromhighlightply-client" href="#tttshouldhidefromhighlightply-client">TTTShouldHideFromHighlight(ply, client)</a> <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></h3>
         <p>
             Called when a player is about to be highlighted, allowing you to block that from happening.<br>
             <em>Realm:</em> Client<br>
-            <em>Added in:</em> 2.3.3<br>
+            <em>Added in:</em> 2.3.2<br>
             <em>Parameters:</em>
         </p>
         <ul>

--- a/docs/api/hooks.html
+++ b/docs/api/hooks.html
@@ -1403,6 +1403,21 @@
             <li><em>item</em> - The random item that was selected</li>
         </ul>
 
+        <h3><a id="tttshouldhidefromhighlightply-client" href="#tttshouldhidefromhighlightply-client">TTTShouldHideFromHighlight(ply, client)</a></h3>
+        <p>
+            Called when a player is about to be highlighted, allowing you to block that from happening.<br>
+            <em>Realm:</em> Client<br>
+            <em>Added in:</em> 2.3.3<br>
+            <em>Parameters:</em>
+        </p>
+        <ul>
+            <li><em>ply</em> - The target player being highlighted</li>
+            <li><em>client</em> - The local player</li>
+        </ul>
+        <p>
+            <em>Return:</em> <code>true</code> to stop this player from being highlighted
+        </p>
+
         <h3><a id="tttshouldplayersmokeply-client-shouldsmoke-smokecolor-smokeparticle-smokeoffset" href="#tttshouldplayersmokeply-client-shouldsmoke-smokecolor-smokeparticle-smokeoffset">TTTShouldPlayerSmoke(ply, client, shouldSmoke, smokeColor, smokeParticle, smokeOffset)</a></h3>
         <p>
             Called when during a player's `Think`, allowing a player to emit smoke with different visual effects.<br>

--- a/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/cl_init.lua
@@ -572,7 +572,7 @@ end
 -- Player highlights
 
 local function ShouldHideFromHighlight(ply, client)
-    return ply:IsLootGoblin() and ply:IsRoleActive()
+    return CallHook("TTTShouldHideFromHighlight", nil, ply, client) == true
 end
 
 function OnPlayerHighlightEnabled(client, alliedRoles, showJesters, hideEnemies, traitorAllies, onlyShowEnemies)

--- a/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -728,12 +728,12 @@ if SERVER then
         if rag.damage_resist and rag.damage_resist > 0 then
             damage = damage - (damage * rag.damage_resist)
         end
-        rag.player_health = rag.player_health - damage
+        ply.ragdoll_info.health = ply.ragdoll_info.health - damage
 
         StartBleeding(rag, damage, 5)
 
         -- Kill the player if they run out of health
-        if rag.player_health <= 0 then
+        if ply.ragdoll_info.health <= 0 then
             ply:UnRagdoll()
 
             local att = dmginfo:GetAttacker()
@@ -756,7 +756,7 @@ if SERVER then
             ply:SetHealth(1)
             ply:TakeDamageInfo(dmg)
         else
-            ply:SetHealth(rag.player_health)
+            ply:SetHealth(ply.ragdoll_info.health)
         end
     end
 
@@ -796,7 +796,6 @@ if SERVER then
             weps = weps,
             activeWeapon = WEPS.GetClass(ply:GetActiveWeapon()),
             health = ply:Health(),
-            maxhealth = ply:GetMaxHealth(),
             model = ply:GetModel(),
             credits = ply:GetCredits(),
             equipment = equipment,
@@ -1073,9 +1072,8 @@ if SERVER then
         -- Restore potentially-changed values
         ply:SetWalkSpeed(walkSpeed)
         ply:SetJumpPower(jumpPower)
-        ply:SetMaxHealth(maxHealth)
 
-        ply:SetMaxHealth(ragdoll_info.maxhealth)
+        ply:SetMaxHealth(maxHealth)
         ply:SetHealth(math.max(0, ragdoll_info.health))
         if ply:Health() <= 0 then
             ply:Kill()

--- a/gamemodes/terrortown/gamemode/roles/cannibal/cl_cannibal.lua
+++ b/gamemodes/terrortown/gamemode/roles/cannibal/cl_cannibal.lua
@@ -82,11 +82,41 @@ net.Receive("TTT_CannibalEaten", function(len)
     })
 end)
 
+------------------
+-- HIGHLIGHTING --
+------------------
+
+AddHook("TTTShouldHideFromHighlight", "Cannibal_TTTShouldHideFromHighlight", function(ply, cli)
+    if ply:IsCannibal() then
+        return true
+    end
+end)
+
+---------------
+-- TARGET ID --
+---------------
+
+AddHook("TTTTargetIDPlayerBlockIcon", "Cannibal_TTTTargetIDPlayerBlockIcon", function(ply, cli)
+    if ply:IsCannibal() then
+        return true
+    end
+end)
+
+AddHook("TTTTargetIDPlayerBlockInfo", "Cannibal_TTTTargetIDPlayerBlockInfo", function(ply, cli)
+    if ply:IsCannibal() then
+        return true
+    end
+end)
+
 ----------------
 -- SCOREBOARD --
 ----------------
 
-local client
+AddHook("TTTScoreboardPlayerRole", "Cannibal_TTTScoreboardPlayerRole", function(ply, cli, c, roleStr)
+    if ply:IsCannibal() then
+        return false, false
+    end
+end)
 
 AddHook("TTTScoreboardPlayerName", "Cannibal_TTTScoreboardPlayerName", function(ply, cli, text)
     if not IsPlayer(ply) then return end
@@ -105,6 +135,8 @@ ROLE_IS_SCOREBOARD_INFO_OVERRIDDEN[ROLE_CANNIBAL] = function(ply, target)
     ------ name, role
     return true, false
 end
+
+local client
 
 AddHook("TTTScoreGroup", "Cannibal_TTTScoreGroup", function(ply)
     if GetRoundState() < ROUND_ACTIVE then return end

--- a/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
+++ b/gamemodes/terrortown/gamemode/roles/lootgoblin/cl_lootgoblin.lua
@@ -66,6 +66,16 @@ hook.Add("TTTSettingsRolesTabSections", "LootGoblin_TTTSettingsRolesTabSections"
     return true
 end)
 
+------------------
+-- HIGHLIGHTING --
+------------------
+
+hook.Add("TTTShouldHideFromHighlight", "LootGoblin_TTTShouldHideFromHighlight", function(ply, cli)
+    if ply:IsLootGoblin() and ply:IsRoleActive() then
+        return true
+    end
+end)
+
 -----------
 -- RADAR --
 -----------

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.3.3"
+CR_VERSION = "2.3.2"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -24,7 +24,7 @@ local StringSub = string.sub
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.3.2"
+CR_VERSION = "2.3.3"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog

### Fixes
- Fixed cannibal being revealed to anyone who can see jesters
- Fixed changes in max health why ragdolled being overwritten when unragdolling
- Fixed damage transfer to ragdolled players not working correctly

### Developer
- Added `TTTShouldHideFromHighlight` hook to allow blocking a player from being highlighted

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] API Docs updated
  - [x] Markdown
  - [x] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] CONVARS.md updated, if applicable
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
