### PR TITLE
Fixed Cannibal's name, health, and karma information not showing when a player looked at them

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed Drunk not sobering up when another role (such as Taskmaster or Clown) blocked another team's win
+- Fixed Cannibal's name, health, and karma information not showing when a player looked at them
 
 ### Developer
 - Added `TTTCanRespawnAsRole` hook to allow other roles or addons to prevent players from respawning as a targeted role

--- a/gamemodes/terrortown/gamemode/roles/cannibal/cl_cannibal.lua
+++ b/gamemodes/terrortown/gamemode/roles/cannibal/cl_cannibal.lua
@@ -102,9 +102,15 @@ AddHook("TTTTargetIDPlayerBlockIcon", "Cannibal_TTTTargetIDPlayerBlockIcon", fun
     end
 end)
 
-AddHook("TTTTargetIDPlayerBlockInfo", "Cannibal_TTTTargetIDPlayerBlockInfo", function(ply, cli)
-    if ply:IsCannibal() then
-        return true
+AddHook("TTTTargetIDPlayerText", "Cannibal_TTTTargetIDPlayerText", function(ent, cli, text, col)
+    if IsPlayer(ent) and ent:IsCannibal() then
+        return false
+    end
+end)
+
+AddHook("TTTTargetIDPlayerRing", "Cannibal_TTTTargetIDPlayerRing", function(ent, cli, ring_visible)
+    if IsPlayer(ent) and ent:IsCannibal() then
+        return false
     end
 end)
 


### PR DESCRIPTION
## Changelog

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] CONVARS.md updated, if applicable
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
