### PR TITLE
Fix error in Cannibal's role weapon HUD when weapon was selected from last round

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_can_eater.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_can_eater.lua
@@ -152,7 +152,7 @@ if CLIENT then
 
         local cooldownLeft = self:GetDeviceCooldownEnd() - CurTime()
         local progress = 1 - (cooldownLeft / cooldown)
-        if cooldownLeft > -3 or self.DeployTime > CurTime() - 3 then
+        if cooldownLeft > -3 or (self.DeployTime and self.DeployTime > CurTime() - 3) then
             if progress > 1 then
                 CRHUD:PaintProgressBar(x, y, w, Color(0, 255, 0, 155), "READY TO EAT", 1)
             else


### PR DESCRIPTION
Turn off fast weapon switch, force yourself to a Cannibal. Select the Cannibal's role weapon and eat someone. Restart the round, and without selecting any weapons, force yourself to a Cannibal again, the error should occur.

## Changelog

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] CONVARS.md updated, if applicable
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
