### PR TITLE
Misc. fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - Fixed rare error in Taskmaster's Kill 360 task when the HUD is rendered before the state has been synced
+- Ported "TTT: Fix prepare state hooks running before map cleanup" from base TTT
 
 ## 2.4.6 (Beta)
 **Released: June 13th, 2026**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.4.7 (Beta)
+**Released:**
+
+### Fixes
+- Fixed rare error in Taskmaster's Kill 360 task when the HUD is rendered before the state has been synced
+
 ## 2.4.6 (Beta)
 **Released: June 13th, 2026**
 
@@ -9,6 +15,7 @@
 
 ### Changes
 - Changed roles to register and unregister hooks automatically to reduce the performance impact of roles that aren't in the current round
+- Changed distance calculations to use more efficient methods when possible
 - Ported "TTT: Use replicated convars instead of global nwvars" from base TTT
 
 ### Fixes

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -429,12 +429,10 @@ end
 
 -- Used to be in Think/Tick, now in a timer
 function WaitingForPlayersChecker()
-    if GetRoundState() == ROUND_WAIT then
-        if EnoughPlayers() then
-            timer.Create("wait2prep", 1, 1, PrepareRound)
+    if GetRoundState() == ROUND_WAIT and EnoughPlayers() then
+        timer.Create("wait2prep", 1, 1, PrepareRound)
 
-            timer.Stop("waitingforply")
-        end
+        timer.Stop("waitingforply")
     end
 end
 
@@ -505,6 +503,28 @@ function StartNameChangeChecks()
     end
 end
 
+local function StopRoundTimers()
+    -- remove all timers
+    timer.Stop("wait2prep")
+    timer.Stop("prep2begin")
+    timer.Stop("end2prep")
+    timer.Stop("winchecker")
+end
+
+-- Make sure we have the players to do a round, people can leave during our
+-- preparations so we'll call this numerous times
+local function CheckForAbort()
+    if not EnoughPlayers() then
+        LANG.Msg("round_minplayers")
+        StopRoundTimers()
+
+        WaitForPlayers()
+        return true
+    end
+
+    return false
+end
+
 local function SpawnEntities()
     local et = ents.TTT
     -- Spawn weapons from script if there is one
@@ -543,6 +563,14 @@ local function CleanUp()
     game.CleanUpMap(false, nil, function()
         et.FixParentedPostCleanup()
         SpawnEntities()
+
+        if CheckForAbort() then return end
+
+        -- Tell hooks and map we started prep
+        hook.Call("TTTPrepareRound")
+
+        ClearAllFootsteps()
+        et.TriggerRoundStateOutputs(ROUND_PREP)
     end)
 
     -- Strip players now, so that their weapons are not seen by ReplaceEntities
@@ -554,28 +582,6 @@ local function CleanUp()
 
     -- a different kind of cleanup
     hook.Remove("PlayerSay", "ULXMeCheck")
-end
-
-local function StopRoundTimers()
-    -- remove all timers
-    timer.Stop("wait2prep")
-    timer.Stop("prep2begin")
-    timer.Stop("end2prep")
-    timer.Stop("winchecker")
-end
-
--- Make sure we have the players to do a round, people can leave during our
--- preparations so we'll call this numerous times
-local function CheckForAbort()
-    if not EnoughPlayers() then
-        LANG.Msg("round_minplayers")
-        StopRoundTimers()
-
-        WaitForPlayers()
-        return true
-    end
-
-    return false
 end
 
 function GM:TTTDelayRoundStartForVote()
@@ -672,12 +678,6 @@ function PrepareRound()
 
     -- In case client's cleanup fails, make client set all players to innocent role
     timer.Simple(1, SendRoleReset)
-
-    -- Tell hooks and map we started prep
-    RunHook("TTTPrepareRound")
-
-    ClearAllFootsteps()
-    ents.TTT.TriggerRoundStateOutputs(ROUND_PREP)
 end
 
 function SetRoundEnd(endtime)

--- a/gamemodes/terrortown/gamemode/roles/taskmaster/tasks/kill360.lua
+++ b/gamemodes/terrortown/gamemode/roles/taskmaster/tasks/kill360.lua
@@ -161,7 +161,7 @@ if CLIENT then
 
             local startTime = client.Task_Kill360Start
             if not startTime or CurTime() > startTime + time then
-                progress = client.Task_Kill360Progress / 320
+                progress = (client.Task_Kill360Progress or 0) / 320
                 message = "DO A 360"
                 color = Color(255, 0, 0, 155)
             else

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -30,7 +30,7 @@ local TableHasValue = table.HasValue
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.4.6"
+CR_VERSION = "2.4.7"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog
- Fixed rare error in Taskmaster's Kill 360 task when the HUD is rendered before the state has been synced
- Ported "TTT: Fix prepare state hooks running before map cleanup" from base TTT

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] CONVARS.md updated, if applicable
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
