### PR TITLE
2.5.2 Hotfix

### DIFF
--- a/gamemodes/terrortown/gamemode/roles/cannibal/cl_cannibal.lua
+++ b/gamemodes/terrortown/gamemode/roles/cannibal/cl_cannibal.lua
@@ -164,7 +164,7 @@ end
 -- HUD --
 ---------
 
-local function Cannibal_HUDDrawScoreBoard()
+local function Cannibal_TTTHUDInfoPaint(cli, label_left, label_top, active_labels, x, y)
     if not IsPlayer(client) then
         client = LocalPlayer()
     end
@@ -177,8 +177,10 @@ local function Cannibal_HUDDrawScoreBoard()
         fill = ROLE_COLORS[ROLE_CANNIBAL]
     }
 
-    CRHUD:PaintBar(8, 20, ScrH() - 59, 230, 25, bar_colors, 1)
-    draw.SimpleText(LANG.GetTranslation("cannibal_swallowed"), "HealthAmmo", 135, ScrH() - 59, Color(255, 255, 255, 200), TEXT_ALIGN_CENTER)
+    local barX = x + 10
+    local barY = y + 75
+    CRHUD:PaintBar(8, barX, barY, 230, 25, bar_colors, 1)
+    draw.SimpleText(LANG.GetTranslation("cannibal_swallowed"), "HealthAmmo", x + 125, barY, Color(255, 255, 255, 200), TEXT_ALIGN_CENTER)
 end
 
 --------------
@@ -228,9 +230,9 @@ end)
 ------------------
 
 ROLE_REGISTERED_HOOKS[ROLE_CANNIBAL] = {
-    ["HUDDrawScoreBoard"] = Cannibal_HUDDrawScoreBoard,
     ["TTTEventFinishIconText"] = Cannibal_TTTEventFinishIconText,
     ["TTTEventFinishText"] = Cannibal_TTTEventFinishText,
+    ["TTTHUDInfoPaint"] = Cannibal_TTTHUDInfoPaint,
     ["TTTScoreGroup"] = Cannibal_TTTScoreGroup,
     ["TTTScoreboardPlayerName"] = Cannibal_TTTScoreboardPlayerName,
     ["TTTScoreboardPlayerRole"] = Cannibal_TTTScoreboardPlayerRole,


### PR DESCRIPTION
## Changelog
- Fixed Cannibal's "Swallowed" label not staying with the info panel when it is moved

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
