### PR TITLE
2.5.2 Hotfix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 ### Fixes
 - Fixed players swallowed by the Cannibal still being able to trigger traitor traps
 - Fixed various roles erroring about unsupported hook 'TTTUpdateRoleState'
+- Fixed error causing rounds to not end when the Cannibal should have won
 
 ### Developer
 - Added `TTTHUDInfoPositionOverride` hook to override the position of the player information HUD (role, health, ammo etc.)

--- a/gamemodes/terrortown/gamemode/roles/cannibal/cannibal.lua
+++ b/gamemodes/terrortown/gamemode/roles/cannibal/cannibal.lua
@@ -28,6 +28,8 @@ CreateConVar("ttt_cannibal_notify_confetti", "0", FCVAR_NONE, "Whether to throw 
 --------------------
 
 local function ReleaseEatenPlayers(ply, message)
+    if GetRoundState() ~= ROUND_ACTIVE then return end
+
     local cannibalSID64 = ply:SteamID64()
     for _, v in PlayerIterator() do
         if v.TTTCannibalEaten and v.TTTCannibalEaten == cannibalSID64 then


### PR DESCRIPTION
## Changelog
- Fixed error causing rounds to not end when the Cannibal should have won

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
