### PR TITLE
2.5.2 Hotfixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.5.3 (Beta)
+**Released:**
+
+### Fixes
+- Fixed message stack message (top-right) on round start showing Traitors who their allies are even if there was an Illusionist in the round
+- Fixed (mostly unused) previous round role tracking
+
 ## 2.5.2
 **Released: August 8th, 2026**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,5 @@
 # Release Notes
 
-## 2.5.3 (Beta)
-**Released:**
-
-### Fixes
-- Fixed message stack message (top-right) on round start showing Traitors who their allies are even if there was an Illusionist in the round
-- Fixed (mostly unused) previous round role tracking
-
 ## 2.5.2
 **Released: August 8th, 2026**
 
@@ -23,6 +16,8 @@
 - Fixed players swallowed by the Cannibal still being able to trigger traitor traps
 - Fixed various roles erroring about unsupported hook 'TTTUpdateRoleState'
 - Fixed error causing rounds to not end when the Cannibal should have won
+- Fixed message stack message (top-right) on round start showing Traitors who their allies are even if there was an Illusionist in the round
+- Fixed (mostly unused) previous round role tracking
 
 ### Developer
 - Added `TTTHUDInfoPositionOverride` hook to override the position of the player information HUD (role, health, ammo etc.)

--- a/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -353,6 +353,7 @@ local styledmessages = {
     rolecolour = {
         "round_traitors_one",
         "round_traitors_more",
+        "round_traitors_illusionist",
 
         "body_found",
         "body_found_updated",

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -724,7 +724,10 @@ function TellTraitorsAboutTraitors()
                 v:QueueMessage(MSG_PRINTBOTH, "There is " .. ROLE_STRINGS_EXT[ROLE_GLITCH] .. ".")
             end
 
-            if #traitornicks < 2 then
+            if IsIllusionistBlocking() then
+                LANG.Msg(v, "round_traitors_illusionist", { role = ROLE_STRINGS[ROLE_TRAITOR], anillusionist = ROLE_STRINGS_EXT[ROLE_ILLUSIONIST] })
+                return
+            elseif #traitornicks < 2 then
                 LANG.Msg(v, "round_traitors_one", { role = ROLE_STRINGS[ROLE_TRAITOR] })
                 return
             else

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -590,8 +590,22 @@ function GM:TTTDelayRoundStartForVote()
     return false
 end
 
+local prev_roles = {}
 function PrepareRound()
+    table.Empty(prev_roles)
+
+    -- Initialize the table for every role
+    for wrole = ROLE_NONE, ROLE_MAX do
+        prev_roles[wrole] = {}
+    end
+
+    if not GAMEMODE.LastRole then GAMEMODE.LastRole = {} end
+
     for _, v in PlayerIterator() do
+        -- save previous role and sign up as a possible role
+        local r = GAMEMODE.LastRole[v:SteamID64()] or v:GetRole() or ROLE_NONE
+        table.insert(prev_roles[r], v)
+
         v:SetRole(ROLE_INNOCENT)
         v:SetInvulnerable(false, false)
         v:SetNWVector("PlayerColor", Vector(1, 1, 1))
@@ -1202,22 +1216,11 @@ end
 
 function SelectRoles()
     local choices = {}
-    local prev_roles = {}
-    -- Initialize the table for every role
-    for wrole = ROLE_NONE, ROLE_MAX do
-        prev_roles[wrole] = {}
-    end
-
-    if not GAMEMODE.LastRole then GAMEMODE.LastRole = {} end
 
     for _, v in PlayerIterator() do
         if IsValid(v) then
             -- everyone on the spec team is in specmode
             if not v:IsSpec() then
-                -- save previous role and sign up as a possible role
-                local r = GAMEMODE.LastRole[v:SteamID64()] or v:GetRole() or ROLE_NONE
-
-                table.insert(prev_roles[r], v)
                 table.insert(choices, v)
             end
 

--- a/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/lang/english.lua
@@ -34,6 +34,7 @@ L.round_restart = "The round has been forced to restart by an admin."
 
 L.round_traitors_one = "{role}, you stand alone."
 L.round_traitors_more = "{role}, these are your allies: {names}"
+L.round_traitors_illusionist = "{role}, {anillusionist} is blocking ally information"
 
 L.win_prevented = "Map was prevented from ending the round."
 L.win_showreport = "Let's look at the round report for {num} seconds."
@@ -705,7 +706,8 @@ L.info_popup_monster_alone = [[You have no allies this round.
 Kill all others to win!]]
 
 L.info_popup_monster_illusionist = [[Work with your allies to kill all others.
-BUT BEWARE! There is {anillusionist} that is preventing you from knowing who your comrades are.]]
+BUT BEWARE! There is {anillusionist} that is preventing you
+from knowing who your comrades are.]]
 
 L.info_popup_traitor_comrades = [[Work with fellow {traitors} to kill all others.
 But take care, or your treason may be discovered...
@@ -724,7 +726,8 @@ These may or may not be your comrades:
 {traitorlist}]]
 
 L.info_popup_traitor_illusionist = [[Work with fellow {traitors} to kill all others.
-BUT BEWARE! There is {anillusionist} that is preventing you from knowing who your comrades are.]]
+BUT BEWARE! There is {anillusionist} that is preventing you
+from knowing who your comrades are.]]
 
 --- Various other text
 L.name_kick = "A player was automatically kicked for changing their name during a round."

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -32,7 +32,7 @@ local TableInsert = table.insert
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.5.3"
+CR_VERSION = "2.5.2"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -32,7 +32,7 @@ local TableInsert = table.insert
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.5.2"
+CR_VERSION = "2.5.3"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 


### PR DESCRIPTION
## Changelog
### Fixes
- Fixed message stack message (top-right) on round start showing Traitors who their allies are even if there was an Illusionist in the round
- Fixed (mostly unused) previous round role tracking

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
