### PR TITLE
Role registration system changes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1346,7 +1346,6 @@ globals = {
     "ShouldShowTraitorExtraInfo",
     "StartsWithVowel",
     "SyncShopConVars",
-    "UnregisterRoleHooks",
     "UpdateRoleColors",
     "UpdateRoleColours",
     "UpdateRoleState",

--- a/API/METHODS_GLOBAL.md
+++ b/API/METHODS_GLOBAL.md
@@ -225,11 +225,6 @@ Whether the given string starts with a vowel.\
 *Realm:* Client and Server\
 *Added in:* 1.0.8
 
-### UnregisterRoleHooks(role)
-Unregisters a role as active, causing its managed hooks to be removed if they are active.\
-*Realm:* Client and Server\
-*Added in:* 2.5.1 
-
 ### UpdateRoleColours()/UpdateRoleColors()
 Updates the role color tables based on the color convars and color type convar.\
 *Realm:* Client and Server\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,9 @@
 ### Developer
 - Added `TTTHUDInfoPositionOverride` hook to override the position of the player information HUD (role, health, ammo etc.)
 - Added new `x` and `y` parameters to `TTTHUDInfoPaint` hook which provide the raw position of the player information HUD (i.e. agnostic of any existing labels)
+- Changed role registration system so role hooks are only removed in the prep phase of the next round
+    - This fixes some issues with role logic ending early or experiencing odd bugs when a player's role is changed after their role ability is already active
+    - Also removes `UnregisterRoleHooks` global method
 
 ## 2.5.1
 **Released: July 25th, 2026**

--- a/docs/api/methods_global.html
+++ b/docs/api/methods_global.html
@@ -353,13 +353,6 @@
             <em>Added in:</em> 1.0.0
         </p>
 
-        <h3><a id="unregisterrolehooksrole" href="#nuregisterrolehooksrole">UnregisterRoleHooks(role)</a></h3>
-        <p>
-            Unregisters a role as active, causing its managed hooks to be removed if they are active.<br>
-            <em>Realm:</em> Client and Server<br>
-            <em>Added in:</em> 2.5.1
-        </p>
-
         <h3><a id="updaterolestrings" href="#updaterolestrings">UpdateRoleStrings()</a></h3>
         <p>
             Updates the role string tables based on the role name convars.<br>

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -1212,13 +1212,8 @@ function RegisterRole(tbl)
     CallHook("TTTRoleRegistered", nil, roleID)
 end
 
-local role_hooks_registered = {}
 local banned_hooks = {"Initialize", "PreRegisterSWEP", "TTTBeginRound", "TTTPlayerRoleChanged", "TTTPrepareRound", "TTTRoleSpawnsArtificially", "TTTSelectRoles", "TTTSyncEventIDs", "TTTSyncWinIDs", "TTTTutorialRoleText", "TTTUpdateRoleState"}
 local function RegisterHooks(role)
-    local key = ROLE_HOOK_REGISTRATION_KEY[role] or role
-    role_hooks_registered[key] = (role_hooks_registered[key] or 0) + 1
-    if role_hooks_registered[key] ~= 1 then return end
-
     for hookName, hookData in pairs(ROLE_REGISTERED_HOOKS[role]) do
         if not hookData then continue end
         if TableHasValue(banned_hooks, hookName) then
@@ -1238,10 +1233,6 @@ local function RegisterHooks(role)
 end
 
 local function UnregisterHooks(role)
-    local key = ROLE_HOOK_REGISTRATION_KEY[role] or role
-    role_hooks_registered[key] = (role_hooks_registered[key] or 0) - 1
-    if role_hooks_registered[key] ~= 0 then return end
-
     for hookName, hookData in pairs(ROLE_REGISTERED_HOOKS[role]) do
         if not hookData then continue end
 
@@ -1273,35 +1264,12 @@ function RegisterRoleHooks(role)
     end
 end
 
-function UnregisterRoleHooks(role)
-    local oldHooks = ROLE_REGISTERED_HOOKS[role]
-    local oldDepRoles = ROLE_HOOK_REGISTRATION_DEPENDENCIES[role]
-    if not oldHooks and not oldDepRoles then return end
-
-    if oldHooks then
-        UnregisterHooks(role)
-    end
-    if oldDepRoles then
-        for _, r in ipairs(oldDepRoles) do
-            if ROLE_REGISTERED_HOOKS[r] then
-                UnregisterHooks(r)
-            end
-        end
-    end
-end
-
 AddHook("TTTPlayerRoleChanged", "HookRegistration_TTTPlayerRoleChanged", function(ply, oldRole, newRole)
     if oldRole == newRole then return end
-    if not ROLE_REGISTERED_HOOKS[oldRole] and
-        not ROLE_HOOK_REGISTRATION_DEPENDENCIES[oldRole] and
-        not ROLE_REGISTERED_HOOKS[newRole] and
+    if not ROLE_REGISTERED_HOOKS[newRole] and
         not ROLE_HOOK_REGISTRATION_DEPENDENCIES[newRole] then return end
 
-    -- Delay this by a frame so cleanup can run first
-    timer.Simple(0, function()
-        UnregisterRoleHooks(oldRole)
-        RegisterRoleHooks(newRole)
-    end)
+    RegisterRoleHooks(newRole)
 end)
 AddHook("TTTPrepareRound", "HookRegistration_TTTPrepareRound", function()
     -- Delay this by a frame so cleanup can run first
@@ -1311,7 +1279,6 @@ AddHook("TTTPrepareRound", "HookRegistration_TTTPrepareRound", function()
                 UnregisterHooks(role)
             end
         end
-        role_hooks_registered = {}
     end)
 end)
 


### PR DESCRIPTION
## Changelog
- Changed role registration system so role hooks are only removed in the prep phase of the next round
    - This fixes some issues with role logic ending early or experiencing odd bugs when a player's role is changed after their role ability is already active
    - Also removes `UnregisterRoleHooks` global method

## Affected Issues

## Checklist
- [x] Tested in-game
- [x] Release Notes updated
- [x] API Docs updated
  - [x] Markdown
  - [x] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
