### PR TITLE
2.5.3 Beta

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -254,6 +254,7 @@ globals = {
     "COLOR_ORANGE",
     "COLOR_PINK",
     "COLOR_RED",
+    "color_transparent",
     "COLOR_WHITE",
     "COLOR_YELLOW",
     "CONTENTS_AREAPORTAL",

--- a/CONVARS.md
+++ b/CONVARS.md
@@ -786,6 +786,7 @@ ttt_cannibal_gains_health                      0       // Whether the Cannibal g
 ttt_cannibal_gained_health_percentage          15      // What percentage of their victim's health the Cannibal gains. Set to 0 to always gain a flat 100HP (Only applies if ttt_cannibal_gains_health is enabled)
 ttt_cannibal_digestion                         0       // Whether the Cannibal digests and permanently kills their victims over time
 ttt_cannibal_digestion_time                    30      // How long in seconds a victim takes to be digested when eaten. Set to 0 for immediate digestion (Only applies if ttt_cannibal_digestion is enabled)
+ttt_cannibal_digestion_corpse                  0       // Whether the Cannibal drops the victim's corpse when they are digested (Only applies if ttt_cannibal_digestion is enabled)
 ttt_cannibal_digestion_poop                    1       // Whether the Cannibal drops poop when a victim is digested (Only applies if ttt_cannibal_digestion is enabled)
 ttt_cannibal_digestion_poop_sound              1       // Whether the Cannibal causes a sound when poop is dropped from a digested victim (Only applies if ttt_cannibal_digestion is enabled)
 ttt_cannibal_digestion_poop_sound_level        100     // The sound level (volume) to play the Cannibal's digestion poop sound (set to 0 to disable). (Only applies if ttt_cannibal_digestion is enabled)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.5.3 (Beta)
+**Released:**
+
+### Changes
+- Ported "TTT: restore original arctic playermodel colour if in 'serious mode'" from base TTT
+
 ## 2.5.2
 **Released: August 8th, 2026**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ### Changes
 - Ported "TTT: restore original arctic playermodel colour if in 'serious mode'" from base TTT
+- Ported "Rollback some changes to VoiceNotify pnl to fix regressions with addons" from base TTT
 
 ## 2.5.2
 **Released: August 8th, 2026**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,8 @@
 - Changed Cannibal's digestion to not drop the victim's corpse
   - Added a convar to re-enable the previous behavior
 - Ported "TTT: restore original arctic playermodel colour if in 'serious mode'" from base TTT
+
+### Fixes
 - Ported "Fix TTT erroring due to it using base gamemode panels" from base TTT
 
 ## 2.5.2

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@
 - Changed Cannibal's digestion to not drop the victim's corpse
   - Added a convar to re-enable the previous behavior
 - Ported "TTT: restore original arctic playermodel colour if in 'serious mode'" from base TTT
-- Ported "Rollback some changes to VoiceNotify pnl to fix regressions with addons" from base TTT
+- Ported "Fix TTT erroring due to it using base gamemode panels" from base TTT
 
 ## 2.5.2
 **Released: August 8th, 2026**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 2.5.3 (Beta)
-**Released:**
+**Released: September 5th, 2026**
 
 ### Changes
 - Changed Cannibal's digestion to not drop the victim's corpse

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 **Released:**
 
 ### Changes
+- Changed Cannibal's digestion to not drop the victim's corpse
+  - Added a convar to re-enable the previous behavior
 - Ported "TTT: restore original arctic playermodel colour if in 'serious mode'" from base TTT
 - Ported "Rollback some changes to VoiceNotify pnl to fix regressions with addons" from base TTT
 

--- a/docs/teams/jester.html
+++ b/docs/teams/jester.html
@@ -589,6 +589,12 @@
                             <td>Whether the Cannibal digests and permanently kills their victims over time.</td>
                         </tr>
                         <tr>
+                            <td>ttt_cannibal_digestion_corpse <span data-text="Beta Only" class="betaonly betaicon tooltip">&nbsp;</span></td>
+                            <td>0</td>
+                            <td>Boolean</td>
+                            <td>Whether the Cannibal drops the victim's corpse when they are digested. <i>(Requires <code>ttt_cannibal_digestion</code> to be enabled.)</i></td>
+                        </tr>
+                        <tr>
                             <td>ttt_cannibal_digestion_poop</td>
                             <td>1</td>
                             <td>Boolean</td>

--- a/gamemodes/terrortown/entities/weapons/weapon_can_eater.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_can_eater.lua
@@ -44,6 +44,7 @@ SWEP.DigestionTimeConVar = CreateConVar("ttt_cannibal_digestion_time", "30", FCV
 
 if SERVER then
     SWEP.EatSoundLevelConVar = CreateConVar("ttt_cannibal_eat_sound_level", "100", FCVAR_NONE, "The sound level (volume) to play the Cannibal's eat sound (set to 0 to disable)", 0, 511)
+    SWEP.DigestionCorpseConVar = CreateConVar("ttt_cannibal_digestion_corpse", "0", FCVAR_NONE, "Whether the Cannibal drops the victim's corpse when they are digested", 0, 1)
     SWEP.DigestionPoopConVar = CreateConVar("ttt_cannibal_digestion_poop", "1", FCVAR_NONE, "Whether the Cannibal drops poop when a victim is digested", 0, 1)
     SWEP.DigestionPoopSoundConVar = CreateConVar("ttt_cannibal_digestion_poop_sound", "1", FCVAR_NONE, "Whether the Cannibal causes a sound when poop is dropped from a digested victim", 0, 1)
     SWEP.DigestionPoopSoundLevelConVar = CreateConVar("ttt_cannibal_digestion_poop_sound_level", "100", FCVAR_NONE, "The sound level (volume) to play the Cannibal's digestion poop sound (set to 0 to disable)", 0, 511)
@@ -201,6 +202,15 @@ function SWEP:PrimaryAttack()
 
                 hitEnt:QueueMessage(MSG_PRINTBOTH, "You have been fully digested!")
                 owner:QueueMessage(MSG_PRINTBOTH, "You have fully digested " .. hitEnt:Nick() .. "!")
+
+                if not self.DigestionCorpseConVar:GetBool() then
+                    timer.Simple(0, function()
+                        if not IsPlayer(hitEnt) then return end
+
+                        local rag = hitEnt.server_ragdoll or hitEnt:GetRagdollEntity()
+                        SafeRemoveEntity(rag)
+                    end)
+                end
 
                 -- Spawn poop at cannibal's position
                 if self.DigestionPoopConVar:GetBool() then

--- a/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -604,6 +604,7 @@ function GM:PlayerStartVoice(ply)
     local pnl = g_VoicePanelList:Add("VoiceNotify")
     pnl:Setup(ply)
     pnl:Dock(TOP)
+    pnl.Color = color_transparent
 
     local oldThink = pnl.Think
     pnl.Think = function(p)

--- a/gamemodes/terrortown/gamemode/roles/cannibal/shared.lua
+++ b/gamemodes/terrortown/gamemode/roles/cannibal/shared.lua
@@ -75,6 +75,10 @@ ROLE_CONVARS[ROLE_CANNIBAL] = {
         type = ROLE_CONVAR_TYPE_NUM
     },
     {
+        cvar = "ttt_cannibal_digestion_corpse",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
+    {
         cvar = "ttt_cannibal_digestion_poop",
         type = ROLE_CONVAR_TYPE_BOOL
     },

--- a/gamemodes/terrortown/gamemode/shared.lua
+++ b/gamemodes/terrortown/gamemode/shared.lua
@@ -32,7 +32,7 @@ local TableInsert = table.insert
 include("player_class/player_ttt.lua")
 
 -- Version string for display and function for version checks
-CR_VERSION = "2.5.2"
+CR_VERSION = "2.5.3"
 CR_BETA = true
 CR_WORKSHOP_ID = CR_BETA and "2404251054" or "2421039084"
 
@@ -1763,6 +1763,9 @@ local playercolor_mode = CreateConVar("ttt_playercolor_mode", "1")
 function GM:TTTPlayerColor(model)
     local mode = playercolor_mode:GetInt()
     if mode == 1 then
+        if model == "models/player/arctic.mdl" then
+            return COLOR_WHITE
+        end
         return table.Random(ttt_playercolors.serious)
     elseif mode == 2 then
         return table.Random(ttt_playercolors.all)


### PR DESCRIPTION
## Changelog
### Changes
- Changed Cannibal's digestion to not drop the victim's corpse
  - Added a convar to re-enable the previous behavior
- Ported "TTT: restore original arctic playermodel colour if in 'serious mode'" from base TTT

### Fixes
- Ported "Fix TTT erroring due to it using base gamemode panels" from base TTT

## Affected Issues

## Checklist
- [ ] Tested in-game
- [ ] Release Notes updated
- [ ] API Docs updated
  - [ ] Markdown
  - [ ] Website (changes marked with "beta only" notation if applicable)
- If this is for a new role:
  - [ ] Icons created
  - [ ] Tutorial created
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ConVars added to ULX list
  - [ ] `plymeta:IsRoleAbilityDisabled` used
- Otherwise:
  - [ ] Documentation
    - [ ] CONVARS.md
    - [ ] Website (changes marked with "beta only" notation if applicable)
  - [ ] ULX updated (either added to list of convars for a role, or PR created in [ULX](https://github.com/Custom-Roles-for-TTT/TTT-Custom-Roles-ULX) repo \[Add link below\])
